### PR TITLE
Improve cover movement state updates

### DIFF
--- a/custom_components/nikobus/cover.py
+++ b/custom_components/nikobus/cover.py
@@ -512,6 +512,7 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
             self._state = new_state
             self._position_estimator.start(self._direction, self._position)
             self._movement_task = self.hass.async_create_task(self._update_position())
+            self.async_write_ha_state()
         elif new_state == STATE_STOPPED:
             if self._in_motion:
                 await self._finalize_movement()
@@ -533,6 +534,7 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
         self._direction = direction
         self._in_motion = True
         self._state = STATE_OPENING if direction == "opening" else STATE_CLOSING
+        self._previous_state = self._state
         self._position_estimator.start(self._direction, self._position)
         await self._start_position_estimation(target_position=target_position)
         self.async_write_ha_state()


### PR DESCRIPTION
## Summary
- track cover movement state immediately when starting a move so observers like HomeKit see opening/closing
- write state to Home Assistant as soon as coordinator signals movement

## Testing
- Not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69415f78c97c832cbf62ae90409bd2eb)