### PR TITLE
Handle cover movement task cancellation

### DIFF
--- a/custom_components/nikobus/cover.py
+++ b/custom_components/nikobus/cover.py
@@ -567,14 +567,7 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
     async def _start_position_estimation(
         self, target_position: Optional[int] = None
     ) -> None:
-        if self._movement_task and not self._movement_task.done():
-            self._movement_task.cancel()
-            try:
-                await self._movement_task
-            except asyncio.CancelledError:
-                _LOGGER.debug(
-                    "Cancelled existing movement task for %s", self._attr_name
-                )
+        await self._cancel_movement_task()
         self._movement_task = self.hass.async_create_task(
             self._update_position(target_position)
         )
@@ -668,6 +661,8 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
     async def _finalize_movement(self) -> None:
         _LOGGER.debug("Finalizing movement for %s", self._attr_name)
 
+        await self._cancel_movement_task()
+
         final_pos = self._position_estimator.current_position
         if final_pos is not None:
             self._set_position(final_pos)
@@ -684,6 +679,17 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
             self._channel,
             STATE_STOPPED,
         )
+
+    async def _cancel_movement_task(self) -> None:
+        if self._movement_task and not self._movement_task.done():
+            self._movement_task.cancel()
+            try:
+                await self._movement_task
+            except asyncio.CancelledError:
+                _LOGGER.debug(
+                    "Cancelled existing movement task for %s", self._attr_name
+                )
+        self._movement_task = None
 
     async def _handle_nikobus_button_event(self, event: Any) -> None:
         if event.data.get("impacted_module_address") != self._address:


### PR DESCRIPTION
## Summary
- add a shared helper to cancel any in-flight cover movement tasks
- ensure movement finalization waits for cancellation for consistent state

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941618e439c832cb016c5d151978b82)