### PR TITLE
Optimize Nikobus diagnostics registry lookup

### DIFF
--- a/custom_components/nikobus/diagnostics.py
+++ b/custom_components/nikobus/diagnostics.py
@@ -35,17 +35,15 @@ async def async_get_config_entry_diagnostics(
         config_entry.entry_id,
     )
 
-    device_registry: DeviceRegistry = async_get_device_registry(hass)
+    device_registry: DeviceRegistry = await async_get_device_registry(hass)
 
     # Gather all Nikobus devices that belong to this config entry
     nikobus_devices: list[DeviceEntry] = [
         device
-        for device in device_registry.devices.values()
-        if config_entry.entry_id in device.config_entries
-        and any(
-            identifier[0] == DOMAIN
-            for identifier in device.identifiers
+        for device in device_registry.async_entries_for_config_entry(
+            config_entry.entry_id
         )
+        if any(identifier[0] == DOMAIN for identifier in device.identifiers)
     ]
 
     _LOGGER.debug(


### PR DESCRIPTION
## Summary
- await device registry retrieval in diagnostics
- use registry helper to gather devices for the config entry

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941695bd980832c8f95501fe76fd966)