### PR TITLE
Refine exception definitions

### DIFF
--- a/custom_components/nikobus/exceptions.py
+++ b/custom_components/nikobus/exceptions.py
@@ -1,25 +1,46 @@
 """Custom exceptions for the Nikobus integration."""
 
+__all__ = [
+    "NikobusError",
+    "NikobusConnectionError",
+    "NikobusDataError",
+    "NikobusReadError",
+    "NikobusSendError",
+    "NikobusTimeoutError",
+]
+
 
 class NikobusError(Exception):
-    """Base exception class for Nikobus errors."""
+    """Base exception for all Nikobus integration errors."""
+
+    __slots__ = ()
 
 
 class NikobusConnectionError(NikobusError):
-    """Exception for connection-related errors."""
+    """Raised when the integration cannot connect to the Nikobus gateway."""
+
+    __slots__ = ()
 
 
 class NikobusSendError(NikobusError):
-    """Exception for errors when sending commands."""
+    """Raised when sending a command to the gateway fails."""
+
+    __slots__ = ()
 
 
 class NikobusTimeoutError(NikobusError):
-    """Exception for timeout errors."""
+    """Raised when an operation times out waiting for the gateway."""
+
+    __slots__ = ()
 
 
 class NikobusDataError(NikobusError):
-    """Exception for data-related errors."""
+    """Raised when invalid or unexpected data is encountered."""
+
+    __slots__ = ()
 
 
 class NikobusReadError(NikobusError):
-    """Exception for errors when reading data."""
+    """Raised when reading data from the gateway fails."""
+
+    __slots__ = ()


### PR DESCRIPTION
## Summary
- add module exports for nikobus exceptions and clarify documentation
- use slots on exception classes to reduce instance footprint

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69416a700eb4832c9ac134726c3c3104)