### PR TITLE
Optimize manifest metadata

### DIFF
--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -6,9 +6,8 @@
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
   "config_flow": true,
-  "dependencies": [],
+  "integration_type": "hub",
   "requirements": ["aiofiles>=23.2.0"],
   "iot_class": "local_polling",
-  "loggers": ["custom_components.nikobus"],
-  "after_dependencies": ["device_registry"]
+  "loggers": ["custom_components.nikobus"]
 }


### PR DESCRIPTION
## Summary
- mark the integration as a hub in the manifest metadata
- remove unused manifest entries to streamline the configuration

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69416b870b78832c8fdde55b7c6da764)