### PR TITLE
Fix module address example casing

### DIFF
--- a/custom_components/nikobus/services.yaml
+++ b/custom_components/nikobus/services.yaml
@@ -1,5 +1,11 @@
 query_module_inventory:
-  description: "Trigger a Nikobus module inventory."
+  name: Query module inventory
+  description: Trigger a Nikobus module inventory.
   fields:
     module_address:
-      description: "Module address"
+      name: Module address
+      description: "Module address to query. Leave empty to scan all modules."
+      example: "05FA"
+      required: false
+      selector:
+        text:


### PR DESCRIPTION
## Summary
- add a user-friendly name and expanded description for the `query_module_inventory` service
- document the `module_address` field with an example, optional status, and selector guidance for the UI
- correct the `module_address` example to use uppercase letters

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694170d9a524832c994cc6a25898bf75)