### PR TITLE
Fix orphan entity cleanup compatibility

### DIFF
--- a/custom_components/nikobus/__init__.py
+++ b/custom_components/nikobus/__init__.py
@@ -97,8 +97,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         devices_with_entities: set[str] = {
             entity.device_id
-            for entity in ent_reg.async_entries_for_config_entry(entry.entry_id)
-            if entity.platform == DOMAIN and entity.device_id
+            for entity in _iter_relevant_entities()
+            if entity.device_id
         }
 
         for device in list(dev_reg.devices.values()):


### PR DESCRIPTION
## Summary
- use existing registry iterator to collect devices with entities during cleanup
- maintain orphan device removal without calling unavailable registry helper

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694176bf451c832c92c9ed0403267a1b)