### PR TITLE
Add pyserial-asyncio-fast to nikobus integration requirements

### DIFF
--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -7,7 +7,7 @@
   "codeowners": ["@fdebrus"],
   "config_flow": true,
   "integration_type": "hub",
-  "requirements": ["aiofiles>=23.2.0"],
+  "requirements": ["aiofiles>=23.2.0", "pyserial-asyncio-fast"],
   "iot_class": "local_polling",
   "loggers": ["custom_components.nikobus"]
 }


### PR DESCRIPTION
### Motivation
- `pyserial-asyncio` is deprecated and will be blocked in Home Assistant.
- The integration needs to use the replacement package to remain compatible with HA policies.
- Prepare the integration to be able to use the faster/maintained replacement package.

### Description
- Add `pyserial-asyncio-fast` to the integration requirements in `custom_components/nikobus/manifest.json`.
- File modified: `custom_components/nikobus/manifest.json` (updated `requirements` list).
- No runtime code imports were changed in this PR; the package addition ensures the replacement dependency is available.

### Testing
- No automated tests were run as part of this change.
- No CI/test failures reported (change is limited to manifest dependency).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69451eb71754832cbccfe7cc00955b7f)