### PR TITLE
Optimize Nikobus button binary sensor handling

### DIFF
--- a/custom_components/nikobus/binary_sensor.py
+++ b/custom_components/nikobus/binary_sensor.py
@@ -1,20 +1,24 @@
-"""Sensor platform for the Nikobus integration."""
+"""Binary sensor platform for the Nikobus integration."""
 
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.event import async_call_later
 
-from .const import DOMAIN, BRAND
+from .const import DOMAIN
 from .coordinator import NikobusDataCoordinator
+from .entity import NikobusEntity
 
 _LOGGER = logging.getLogger(__name__)
+_BUTTON_REGISTRY_KEY = "button_sensor_registry"
+_BUTTON_LISTENER_KEY = "button_sensor_listener"
 
 
 async def async_setup_entry(
@@ -39,16 +43,23 @@ async def async_setup_entry(
             entities.append(entity)
 
     # Register a single global event listener for all sensors
-    register_global_listener(hass, entities)
+    register_global_listener(hass)
 
     async_add_entities(entities)
     _LOGGER.debug("Added %d Nikobus button sensor entities.", len(entities))
 
 
-def register_global_listener(
-    hass: HomeAssistant, sensors: list[NikobusButtonSensor]
-) -> None:
+def _get_button_registry(hass: HomeAssistant) -> dict[str, NikobusButtonSensor]:
+    """Return the shared button sensor registry."""
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    return domain_data.setdefault(_BUTTON_REGISTRY_KEY, {})
+
+
+def register_global_listener(hass: HomeAssistant) -> None:
     """Register a single global event listener for all Nikobus sensors."""
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    if domain_data.get(_BUTTON_LISTENER_KEY):
+        return
 
     @callback
     async def handle_event(event: Any) -> None:
@@ -58,18 +69,26 @@ def register_global_listener(
             if not address:
                 _LOGGER.warning("Received event without address: %s", event.data)
                 return
-            for sensor in sensors:
-                if sensor._address == address:
-                    await sensor._handle_button_event(event)
+            sensor = _get_button_registry(hass).get(address)
+            if sensor is None:
+                _LOGGER.debug(
+                    "No registered button sensor for address %s (event=%s)",
+                    address,
+                    event.data,
+                )
+                return
+            await sensor.async_handle_button_event(event)
         except Exception as e:
             _LOGGER.error(
                 "Error handling nikobus_button_pressed event: %s", e, exc_info=True
             )
 
-    hass.bus.async_listen("nikobus_button_pressed", handle_event)
+    domain_data[_BUTTON_LISTENER_KEY] = hass.bus.async_listen(
+        "nikobus_button_pressed", handle_event
+    )
 
 
-class NikobusButtonSensor(CoordinatorEntity, SensorEntity):
+class NikobusButtonSensor(NikobusEntity, BinarySensorEntity):
     """Represents a Nikobus button sensor entity within Home Assistant."""
 
     def __init__(
@@ -80,49 +99,59 @@ class NikobusButtonSensor(CoordinatorEntity, SensorEntity):
         address: str,
     ) -> None:
         """Initialize the button sensor entity with data from the Nikobus system configuration."""
-        super().__init__(coordinator)
+        super().__init__(
+            coordinator=coordinator,
+            address=address,
+            name=description,
+            model="Button Sensor",
+        )
         self._hass = hass
-        self._coordinator = coordinator
-        self._description = description
-        self._address = address
 
         self._attr_name = f"Nikobus Button Sensor {address}"
         self._attr_unique_id = f"{DOMAIN}_button_sensor_{address}"
-        self._state: str | None = "idle"
+        self._attr_is_on = False
+        self._reset_cancel: Any | None = None
 
-    @property
-    def device_info(self) -> dict[str, Any]:
-        """Return device information about this sensor."""
-        return {
-            "identifiers": {(DOMAIN, self._address)},
-            "name": self._description,
-            "manufacturer": BRAND,
-            "model": "Button Sensor",
-        }
+    async def async_added_to_hass(self) -> None:
+        """Register the sensor in the shared registry."""
+        await super().async_added_to_hass()
+        _get_button_registry(self.hass)[self._address] = self
 
-    @property
-    def state(self) -> str | None:
-        """Return the state of the sensor."""
-        return self._state
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove the sensor from the shared registry."""
+        _get_button_registry(self.hass).pop(self._address, None)
+        self._cancel_reset()
+        await super().async_will_remove_from_hass()
 
     @callback
-    async def _handle_button_event(self, event: Any) -> None:
+    async def async_handle_button_event(self, event: Any) -> None:
         """Handle Nikobus button press events."""
         if event.data.get("address") == self._address:
             _LOGGER.debug("Button sensor %s detected a press event.", self._address)
-            self._state = "Pressed"
+            self._attr_is_on = True
             self.async_write_ha_state()
 
-            # Optionally reset the state after a short delay
-            self._hass.loop.call_later(1, self._reset_state)
+            # Reset the state after a short delay
+            self._cancel_reset()
+            self._reset_cancel = async_call_later(
+                self._hass, 1, self._async_reset_state
+            )
 
     @callback
-    def _reset_state(self) -> None:
+    def _async_reset_state(self, _: datetime) -> None:
         """Reset the sensor state to idle after a short delay."""
-        self._state = "idle"
+        self._reset_cancel = None
+        self._attr_is_on = False
         self.async_write_ha_state()
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updates from the coordinator if needed."""
         pass  # Since the state is event-driven, no coordinator updates are required.
+
+    @callback
+    def _cancel_reset(self) -> None:
+        """Cancel any pending reset callback."""
+        if self._reset_cancel:
+            self._reset_cancel()
+            self._reset_cancel = None

--- a/custom_components/nikobus/entity.py
+++ b/custom_components/nikobus/entity.py
@@ -1,0 +1,36 @@
+"""Shared entity helpers for the Nikobus integration."""
+
+from __future__ import annotations
+
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import BRAND, DOMAIN
+from .coordinator import NikobusDataCoordinator
+
+
+class NikobusEntity(CoordinatorEntity):
+    """Base entity for Nikobus devices with common device info."""
+
+    def __init__(
+        self,
+        coordinator: NikobusDataCoordinator,
+        address: str,
+        name: str,
+        model: str,
+    ) -> None:
+        """Initialize the entity with shared device information."""
+        super().__init__(coordinator)
+        self._address = address
+        self._device_name = name
+        self._device_model = model
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information for Home Assistant."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._address)},
+            name=self._device_name,
+            manufacturer=BRAND,
+            model=self._device_model,
+        )


### PR DESCRIPTION
### Motivation
- Centralize shared device metadata and reduce duplication across Nikobus entities.
- Replace ad-hoc per-entity event handling with a single registry-backed listener to avoid multiple listeners and improve lookup.
- Use proper binary sensor semantics instead of a generic sensor model for button press sensors.
- Ensure scheduled reset callbacks are tracked and cleaned up when entities are removed.

### Description
- Add `custom_components/nikobus/entity.py` introducing `NikobusEntity` that provides `device_info` and standardizes initialization with `coordinator`, `address`, `name`, and `model`.
- Refactor `custom_components/nikobus/binary_sensor.py` to use `BinarySensorEntity` and inherit from `NikobusEntity`, update the module docstring, and remove duplicate device info logic.
- Implement a shared registry in `hass.data` and a single global listener stored under a listener key to route `nikobus_button_pressed` events to the correct sensor via address lookup.
- Replace ad-hoc `call_later` usage with `async_call_later` for reset scheduling and add `async_added_to_hass`, `async_will_remove_from_hass`, and `_cancel_reset` to manage lifecycle and pending reset callbacks.

### Testing
- No automated unit tests or integration tests were executed for this change.
- Static linting or type checks were not run as part of this rollout.
- Manual runtime verification was not recorded in automated test logs.
- No automated tests failed during the change (none were run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a6ef3d280832cbd7f449f226b0cb2)