### PR TITLE
Optimize coordinator logging and refresh logic

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -26,6 +26,7 @@ from .const import (
 from .exceptions import NikobusConnectionError, NikobusDataError
 
 _LOGGER = logging.getLogger(__name__)
+_MODULE_TYPES = ("switch_module", "dimmer_module", "roller_module")
 
 
 class NikobusDataCoordinator(DataUpdateCoordinator):
@@ -42,16 +43,8 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
         self._has_feedback_module = config_entry.data.get(
             CONF_HAS_FEEDBACK_MODULE, False
         )
-        self._prior_gen3 = config_entry.data.get(
-            CONF_PRIOR_GEN3, False
-        )
-
-        # Set update_interval to None if feedback module is present, disabling periodic updates
-        self._update_interval = (
-            None
-            if self._has_feedback_module or self._prior_gen3
-            else timedelta(seconds=self._refresh_interval)
-        )
+        self._prior_gen3 = config_entry.data.get(CONF_PRIOR_GEN3, False)
+        self._update_interval = self._get_update_interval()
 
         super().__init__(
             self.hass,
@@ -77,6 +70,12 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
         self._discovery_module = None
         self.discovery_module_address = None
 
+    def _get_update_interval(self) -> timedelta | None:
+        """Compute the update interval based on configuration."""
+        if self._has_feedback_module or self._prior_gen3:
+            return None
+        return timedelta(seconds=self._refresh_interval)
+
     @property
     def discovery_running(self) -> bool:
         return self._discovery_running
@@ -98,7 +97,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
         try:
             await self.nikobus_connection.connect()
         except NikobusConnectionError as e:
-            _LOGGER.error(f"Failed to connect to Nikobus: {e}")
+            _LOGGER.error("Failed to connect to Nikobus: %s", e)
             raise
         else:
             try:
@@ -151,7 +150,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
                 # Perform an initial data refresh
                 await self.async_refresh()
             except HomeAssistantError as e:
-                _LOGGER.error("Failed to initialize Nikobus components: %s", e)
+                _LOGGER.exception("Failed to initialize Nikobus components: %s", e)
                 raise
 
     async def discover_devices(self, module_address) -> None:
@@ -178,7 +177,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
                 self._discovery_module = False
                 await self.nikobus_command.queue_command("#A")
         except Exception as e:
-            _LOGGER.error("Error during discovery: %s", e)
+            _LOGGER.exception("Error during discovery: %s", e)
             raise
         finally:
             await self.hass.services.async_call(
@@ -200,7 +199,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
 
     async def _refresh_nikobus_data(self) -> bool:
         """Refresh data from all Nikobus modules."""
-        for module_type in ["switch_module", "dimmer_module", "roller_module"]:
+        for module_type in _MODULE_TYPES:
             if module_type in self.dict_module_data:
                 await self._refresh_module_type(self.dict_module_data[module_type])
         return True
@@ -208,10 +207,10 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
     async def _refresh_module_type(self, modules_dict) -> None:
         """Refresh data for a specific type of module."""
         for address, module_data in modules_dict.items():
-            _LOGGER.debug(f"Refreshing data for module address: {address}")
+            _LOGGER.debug("Refreshing data for module address: %s", address)
             channels = module_data.get("channels", [])
             expected_channels = len(channels)
-            groups_to_query = [1] if expected_channels <= 6 else [1, 2]
+            groups_to_query = (1,) if expected_channels <= 6 else (1, 2)
             group_states = []
             for group in groups_to_query:
                 try:
@@ -220,26 +219,37 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
                         or ""
                     )
                     _LOGGER.debug(
-                        f"State for group {group}: {group_state} (Address: {address})"
+                        "State for group %s: %s (Address: %s)",
+                        group,
+                        group_state,
+                        address,
                     )
                     group_states.append(group_state)
                 except Exception as e:
                     _LOGGER.error(
-                        f"Error retrieving state for address {address}, group {group}: {e}"
+                        "Error retrieving state for address %s, group %s: %s",
+                        address,
+                        group,
+                        e,
                     )
             state_hex = "".join(group_states)
             expected_hex_length = expected_channels * 2
             if len(state_hex) < expected_hex_length:
                 state_hex = state_hex.ljust(expected_hex_length, "0")
-                _LOGGER.debug(f"Padded state_hex for module {address} to: {state_hex}")
+                _LOGGER.debug(
+                    "Padded state_hex for module %s to: %s", address, state_hex
+                )
             try:
                 self.nikobus_module_states[address] = bytearray.fromhex(state_hex)
                 _LOGGER.debug(
-                    f"Updated module state for {address}: {self.nikobus_module_states[address].hex()}"
+                    "Updated module state for %s: %s",
+                    address,
+                    self.nikobus_module_states[address].hex(),
                 )
             except ValueError:
                 _LOGGER.error(
-                    f"Invalid hex state received for {address}, setting default state."
+                    "Invalid hex state received for %s, setting default state.",
+                    address,
                 )
                 self.nikobus_module_states[address] = bytearray(expected_channels)
 
@@ -252,8 +262,12 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
             module_state_raw = data[9:21]
 
             _LOGGER.debug(
-                f"Processing feedback data: module_type={module_type}, module_address={module_address}, "
-                f"group={module_group}, module_state={module_state_raw}"
+                "Processing feedback data: module_type=%s, module_address=%s, "
+                "group=%s, module_state=%s",
+                module_type,
+                module_address,
+                module_group,
+                module_state_raw,
             )
 
             if module_address not in self.nikobus_module_states:
@@ -268,7 +282,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
                     module_state_raw
                 )
             else:
-                raise ValueError(f"Invalid module group: {module_group}")
+                raise ValueError("Invalid module group: %s" % module_group)
 
             await self.async_event_handler(
                 "nikobus_refreshed",
@@ -279,7 +293,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
             )
 
         except Exception as e:
-            _LOGGER.error(f"Error processing feedback data: {e}", exc_info=True)
+            _LOGGER.exception("Error processing feedback data: %s", e)
 
     def get_bytearray_state(self, address: str, channel: int) -> int:
         """Get the state of a specific channel, ensuring defaults if missing."""
@@ -303,7 +317,9 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
                 if int(group) == 1
                 else self.nikobus_module_states[address][6:12]
             )
-        _LOGGER.error(f"Module address {address} not found, returning empty bytearray.")
+        _LOGGER.error(
+            "Module address %s not found, returning empty bytearray.", address
+        )
         return bytearray(6)
 
     def set_bytearray_state(self, address: str, channel: int, value: int) -> None:
@@ -311,7 +327,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
         if address in self.nikobus_module_states:
             self.nikobus_module_states[address][channel - 1] = value
         else:
-            _LOGGER.warning(f"Module {address} not found, creating new state array.")
+            _LOGGER.warning("Module %s not found, creating new state array.", address)
             self.nikobus_module_states[address] = bytearray(12)
             self.nikobus_module_states[address][channel - 1] = value
 
@@ -343,7 +359,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
 
     async def async_event_handler(self, event, data) -> None:
         """Handle events with improved logging."""
-        _LOGGER.debug(f"Handling event: {event} with data: {data}")
+        _LOGGER.debug("Handling event: %s with data: %s", event, data)
         if event == "ha_button_pressed":
             await self._handle_ha_button_pressed(data)
         elif event == "nikobus_refreshed":
@@ -358,12 +374,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
         self._refresh_interval = entry.data.get(CONF_REFRESH_INTERVAL, 120)
         self._has_feedback_module = entry.data.get(CONF_HAS_FEEDBACK_MODULE, False)
         self._prior_gen3 = entry.data.get(CONF_PRIOR_GEN3, False)
-
-        self._update_interval = (
-            None
-            if self._has_feedback_module or self._prior_gen3
-            else timedelta(seconds=self._refresh_interval)
-        )
+        self._update_interval = self._get_update_interval()
 
         await self.connect()
         await self.async_refresh()
@@ -373,7 +384,9 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
         address = data.get("address")
         operation_time = data.get("operation_time")
         _LOGGER.debug(
-            f"HA Button {address} pressed with operation_time: {operation_time}"
+            "HA Button %s pressed with operation_time: %s",
+            address,
+            operation_time,
         )
         await self.nikobus_command.queue_command(f"#N{address}\r#E1")
 
@@ -382,7 +395,9 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
         impacted_module_address = data.get("impacted_module_address")
         impacted_module_group = data.get("impacted_module_group")
         _LOGGER.debug(
-            f"Nikobus refreshed for module {impacted_module_address} group {impacted_module_group}"
+            "Nikobus refreshed for module %s group %s",
+            impacted_module_address,
+            impacted_module_group,
         )
 
     def get_module_type(self, module_id: str) -> str:
@@ -390,7 +405,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
         for module_type, modules in self.dict_module_data.items():
             if module_id in modules:
                 return module_type
-        _LOGGER.error(f"Module ID {module_id} not found in known module types")
+        _LOGGER.error("Module ID %s not found in known module types", module_id)
         return "unknown"
 
     def get_module_channel_count(self, module_id: str) -> int:
@@ -398,7 +413,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
             if module_id in modules:
                 module_data = modules[module_id]
                 return len(module_data.get("channels", []))
-        _LOGGER.error(f"Module ID {module_id} not found in module configuration")
+        _LOGGER.error("Module ID %s not found in module configuration", module_id)
         return 0
 
     def get_light_state(self, address: str, channel: int) -> bool:
@@ -499,14 +514,10 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
             addr = button.get("address")
             if addr:
                 known.add(f"{DOMAIN}_button_sensor_{addr}")
-
-        # -----------------------
-        # 4) Push buttons
-        # using: nikobus_push_button_{address}
-        # -----------------------
-        for button in self.dict_button_data.get("nikobus_button", {}).values():
-            addr = button.get("address")
-            if addr:
+                # -----------------------
+                # 4) Push buttons
+                # using: nikobus_push_button_{address}
+                # -----------------------
                 known.add(f"{DOMAIN}_push_button_{addr}")
 
         # -----------------------


### PR DESCRIPTION
### Motivation
- Remove duplicated update-interval calculation and centralize logic so reconfigure updates consistently via a helper.
- Reduce eager string formatting in logs to improve performance and standardize message templates.
- Simplify module refresh iteration and group querying to make state refresh more robust and easier to maintain.
- Improve error handling to provide traceback context for initialization, discovery and feedback processing.

### Description
- Add `_MODULE_TYPES` constant and use it in `_refresh_nikobus_data` to avoid repeated literal lists and lookups.
- Introduce helper `_get_update_interval` and wire it into `__init__` and `async_reconfigure` to compute `update_interval` consistently.
- Replace most eager f-string logs with lazy logging (`_LOGGER.debug("...%s", ...)`) and switch several `error` calls to `exception` for better traceback capture.
- Minor data-handling and ergonomics updates: use a tuple for `groups_to_query`, tighten hex/state logging, and collapse button sensor/push-button unique-id generation into a single loop.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a7102b4cc832c8221038ec69f674e)