### PR TITLE
Optimize diagnostics device handling

### DIFF
--- a/custom_components/nikobus/entity.py
+++ b/custom_components/nikobus/entity.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -34,3 +37,15 @@ class NikobusEntity(CoordinatorEntity):
             manufacturer=BRAND,
             model=self._device_model,
         )
+
+
+def device_entry_diagnostics(device: DeviceEntry) -> dict[str, Any]:
+    """Return diagnostics data for a Nikobus device entry."""
+    return {
+        "id": device.id,
+        "name": device.name,
+        "model": device.model,
+        "manufacturer": device.manufacturer,
+        "sw_version": device.sw_version,
+        "identifiers": sorted(device.identifiers),
+    }


### PR DESCRIPTION
### Motivation
- Provide a shared diagnostics formatter for device entries to avoid duplicated logic and centralize output formatting.
- Ensure diagnostics only include devices that belong to the current config entry for more accurate output.
- Include device `identifiers` in diagnostics to aid in troubleshooting and device correlation.

### Description
- Added `device_entry_diagnostics` in `custom_components/nikobus/entity.py` that returns a standardized diagnostics dict for a `DeviceEntry` including `identifiers` (sorted).
- Updated `custom_components/nikobus/diagnostics.py` to gather devices via `device_registry.async_entries_for_config_entry` and filter by `ident[0] == DOMAIN` so only devices tied to the config entry are included.
- Replaced the previous inline device dict construction with calls to `device_entry_diagnostics` to produce the `devices_info` list.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a71d26560832caea9fa2b8d71ec9f)