### PR TITLE
Refactor Nikobus light to use shared entity base

### DIFF
--- a/custom_components/nikobus/light.py
+++ b/custom_components/nikobus/light.py
@@ -13,11 +13,11 @@ from homeassistant.components.light import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers import device_registry as dr
 
 from .const import DOMAIN, BRAND
 from .coordinator import NikobusDataCoordinator
+from .entity import NikobusEntity
 from .exceptions import NikobusError
 
 _LOGGER = logging.getLogger(__name__)
@@ -90,7 +90,7 @@ def _register_nikobus_dimmer_device(
     )
 
 
-class NikobusLightEntity(CoordinatorEntity, LightEntity):
+class NikobusLightEntity(NikobusEntity, LightEntity):
     """Represents a Nikobus dimmer light entity within Home Assistant."""
 
     def __init__(
@@ -103,12 +103,15 @@ class NikobusLightEntity(CoordinatorEntity, LightEntity):
         module_model: str,
     ) -> None:
         """Initialize the light entity from the Nikobus system configuration."""
-        super().__init__(coordinator)
+        super().__init__(
+            coordinator=coordinator,
+            address=address,
+            name=module_name,
+            model=module_model,
+        )
         self._address = address
         self._channel = channel
         self._channel_description = channel_description
-        self._module_name = module_name
-        self._module_model = module_model
 
         self._attr_unique_id = f"{DOMAIN}_{self._address}_{self._channel}"
         self._attr_name = channel_description
@@ -120,16 +123,6 @@ class NikobusLightEntity(CoordinatorEntity, LightEntity):
         # Internal state variables
         self._is_on: bool | None = None
         self._brightness: int | None = None
-
-    @property
-    def device_info(self) -> dict[str, Any]:
-        """Return device information about this light."""
-        return {
-            "identifiers": {(DOMAIN, self._address)},
-            "manufacturer": BRAND,
-            "name": self._module_name,
-            "model": self._module_model,
-        }
 
     @property
     def is_on(self) -> bool:


### PR DESCRIPTION
### Motivation
- Remove duplicated device information and centralize common entity behavior in a shared base class.
- Ensure consistent `device_info` and reduce per-entity boilerplate across Nikobus platforms.

### Description
- Updated `custom_components/nikobus/light.py` to import and inherit from `NikobusEntity` instead of `CoordinatorEntity` and adjusted the class signature accordingly.
- Changed `NikobusLightEntity.__init__` to call `super().__init__(coordinator=..., address=..., name=..., model=...)` and removed the duplicated `_module_name`, `_module_model`, and the `device_info` property.
- Kept existing light behavior (brightness handling, `is_on`, coordinator updates, and turn on/off logic) intact while relying on the shared device info implementation.
- Cleaned up imports by adding `from .entity import NikobusEntity` and removing the now-unused `CoordinatorEntity` import.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a7348c440832ca64e8e7ddc880648)