### PR TITLE
Optimize Nikobus manifest metadata

### DIFF
--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -6,9 +6,8 @@
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
   "config_flow": true,
-  "dependencies": [],
   "requirements": ["aiofiles>=23.2.0"],
   "iot_class": "local_polling",
-  "loggers": ["custom_components.nikobus"],
+  "loggers": ["nikobus"],
   "after_dependencies": ["device_registry"]
 }


### PR DESCRIPTION
### Motivation
- The manifest contained an empty `dependencies` array and a non-standard logger name which can cause confusion and inconsistent logging.
- Metadata should align with the integration domain and Home Assistant expectations for clarity and maintainability.

### Description
- Removed the empty `dependencies` entry from `custom_components/nikobus/manifest.json`.
- Normalized the `loggers` entry from `"custom_components.nikobus"` to the integration domain `"nikobus"`.
- No other manifest fields were modified.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a738a48d4832cb8f9add8c0968f52)