### PR TITLE
Optimize command handler queue and timeout logic

### DIFF
--- a/custom_components/nikobus/nkbcommand.py
+++ b/custom_components/nikobus/nkbcommand.py
@@ -59,7 +59,7 @@ class NikobusCommandHandler:
 
     async def clear_command_queue(self) -> None:
         """Clear all pending commands in the queue."""
-        while not self._command_queue.empty():
+        while True:
             try:
                 self._command_queue.get_nowait()
                 self._command_queue.task_done()
@@ -111,7 +111,7 @@ class NikobusCommandHandler:
 
     async def get_output_state(self, address: str, group: int) -> str:
         """Get the output state of a module."""
-        _LOGGER.debug(f"Getting output state - Address: {address}, Group: {group}")
+        _LOGGER.debug("Getting output state - Address: %s, Group: %s", address, group)
         command_code = 0x12 if int(group) == 1 else 0x17
         command = make_pc_link_command(command_code, address)
         future = self._coordinator.hass.loop.create_future()
@@ -198,13 +198,15 @@ class NikobusCommandHandler:
         ack_received = False
         answer_received = False
         state: str | None = None
-        end_time = self._coordinator.hass.loop.time() + COMMAND_ACK_WAIT_TIMEOUT
+        loop = self._coordinator.hass.loop
+        end_time = loop.time() + COMMAND_ACK_WAIT_TIMEOUT
 
-        while self._coordinator.hass.loop.time() < end_time:
+        while loop.time() < end_time:
             try:
+                remaining = end_time - loop.time()
                 message = await asyncio.wait_for(
                     self.nikobus_listener.response_queue.get(),
-                    timeout=COMMAND_ANSWER_WAIT_TIMEOUT,
+                    timeout=min(COMMAND_ANSWER_WAIT_TIMEOUT, remaining),
                 )
                 _LOGGER.debug("Message received: %s", message)
                 if wait_ack in message:


### PR DESCRIPTION
### Motivation
- Reduce race conditions and simplify draining of the internal command queue in `clear_command_queue`.
- Avoid building log strings unnecessarily by switching to parameterized logging in `get_output_state`.
- Prevent individual `wait_for` calls from exceeding the overall ACK/answer timeout window when waiting for responses.

### Description
- Replace the `while not self._command_queue.empty()` check with a `while True` + `get_nowait()` pattern to robustly drain the queue in `clear_command_queue`.
- Change `get_output_state` logging from an f-string to parameterized logging using `...%s` to defer formatting until necessary.
- Introduce a local `loop = self._coordinator.hass.loop` and compute `remaining = end_time - loop.time()` to cap `asyncio.wait_for` with `timeout=min(COMMAND_ANSWER_WAIT_TIMEOUT, remaining)` in `_wait_for_ack_and_answer_state`.
- Minor refactorings around loop/time usage to centralize time access via the event loop.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a75a382f8832c8f282875f51a787f)