### PR TITLE
Optimize nkbconnect connection handling

### DIFF
--- a/custom_components/nikobus/nkbconnect.py
+++ b/custom_components/nikobus/nkbconnect.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import ipaddress
 import logging
+import re
 import socket
 from typing import Literal, Optional
 
@@ -18,6 +19,7 @@ from .exceptions import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+_SERIAL_DEVICE_RE = re.compile(r"^(/dev/tty(USB|S)\d+|/dev/serial/by-id/.+)$")
 
 
 class NikobusConnect:
@@ -118,6 +120,7 @@ class NikobusConnect:
     # -------------------------
     async def _connect_ip(self) -> None:
         """Establish an IP connection (precreate + connect the socket correctly)."""
+        sock: Optional[socket.socket] = None
         try:
             host, port_str = self._connection_string.split(":", 1)
             port = int(port_str)
@@ -145,6 +148,8 @@ class NikobusConnect:
 
             _LOGGER.info("Connected to bridge %s:%d", host, port)
         except (OSError, ValueError) as err:
+            if sock is not None:
+                sock.close()
             await self._safe_close()
             msg = f"Failed to connect to bridge {self._connection_string} - {err}"
             _LOGGER.error(msg)
@@ -174,11 +179,7 @@ class NikobusConnect:
             return "IP"
         except ValueError:
             # Common serial device patterns
-            import re
-
-            if re.match(
-                r"^(/dev/tty(USB|S)\d+|/dev/serial/by-id/.+)$", self._connection_string
-            ):
+            if _SERIAL_DEVICE_RE.match(self._connection_string):
                 return "Serial"
         return "Unknown"
 


### PR DESCRIPTION
### Motivation
- Avoid recompiling the serial-device regex on every validation to reduce runtime overhead.
- Ensure the precreated IP socket is explicitly closed on connection failures to avoid file descriptor leaks.
- Improve robustness of connection handling and make serial-device detection clearer.

### Description
- Hoist the serial device regex to module scope as `_SERIAL_DEVICE_RE` and import `re` at the top of the module.
- Add a local `sock` variable in `async def _connect_ip` and explicitly call `sock.close()` on connection errors before cleanup.
- Replace the inline regex match in `_validate_connection_string` with `_SERIAL_DEVICE_RE.match` and update `custom_components/nikobus/nkbconnect.py` accordingly.

### Testing
- No automated tests were run for this change.
- Changes were committed to the repository and are ready for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a76cba3f8832c962012cc27e39e74)