### PR TITLE
Improve Nikobus service metadata

### DIFF
--- a/custom_components/nikobus/services.yaml
+++ b/custom_components/nikobus/services.yaml
@@ -1,5 +1,11 @@
 query_module_inventory:
-  description: "Trigger a Nikobus module inventory."
+  name: Query module inventory
+  description: Trigger a Nikobus module inventory scan for all modules or a single module.
   fields:
     module_address:
-      description: "Module address"
+      name: Module address
+      description: Optional Nikobus module address to limit the inventory scan.
+      example: "05"
+      required: false
+      selector:
+        text:


### PR DESCRIPTION
### Motivation
- Make the `query_module_inventory` service more user friendly in Home Assistant by providing a display name and clearer description. 
- Document optional use of a single module address to limit inventory scans.
- Enable UI rendering of the `module_address` input by adding a selector and example.

### Description
- Updated `custom_components/nikobus/services.yaml` to add a `name` and expanded `description` for the `query_module_inventory` service. 
- Enhanced the `module_address` field with `name`, a clearer `description`, an `example` value, `required: false`, and a `selector` using `text`. 
- No runtime code or service handler behavior was changed; this change only improves service metadata shown in the Home Assistant UI.

### Testing
- No automated tests were run for this change.
- No test failures reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a781f11f8832c8fbe5080b10666ef)