### PR TITLE
Replace deprecated pyserial-asyncio with pyserial-asyncio-fast

### DIFF
--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -6,7 +6,7 @@
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
   "config_flow": true,
-  "requirements": ["aiofiles>=23.2.0"],
+  "requirements": ["aiofiles>=23.2.0", "pyserial-asyncio-fast>=0.13"],
   "iot_class": "local_polling",
   "loggers": ["nikobus"],
   "after_dependencies": ["device_registry"]

--- a/custom_components/nikobus/nkbconnect.py
+++ b/custom_components/nikobus/nkbconnect.py
@@ -9,7 +9,7 @@ import re
 import socket
 from typing import Literal, Optional
 
-import serial_asyncio
+import serial_asyncio_fast as serial_asyncio
 
 from .const import BAUD_RATE, COMMANDS_HANDSHAKE
 from .exceptions import (


### PR DESCRIPTION
### Motivation
- `pyserial-asyncio` is deprecated and will be blocked in Home Assistant.
- Replace the deprecated package with `pyserial-asyncio-fast` to preserve serial support.
- Keep the existing integration code that relies on the `serial_asyncio` API working.
- Prevent future breakage due to the removed dependency.

### Description
- Added `pyserial-asyncio-fast>=0.13` to `manifest.json` `requirements`.
- Replaced `import serial_asyncio` with `import serial_asyncio_fast as serial_asyncio` in `custom_components/nikobus/nkbconnect.py`.
- Alias preserves all existing calls to `serial_asyncio` without further code changes.
- No other functional changes were made.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a7fb1a6ac832c89c97582f24a2da2)