### PR TITLE
Improve coordinator reconfigure and service cleanup

### DIFF
--- a/custom_components/nikobus/__init__.py
+++ b/custom_components/nikobus/__init__.py
@@ -69,9 +69,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.info("Starting manual Nikobus discovery with module_address: %s", module_address)
         await coordinator.discover_devices(module_address)
 
-    hass.services.async_register(
-        DOMAIN, "query_module_inventory", handle_module_discovery, SCAN_MODULE_SCHEMA
-    )
+    if not hass.services.has_service(DOMAIN, "query_module_inventory"):
+        hass.services.async_register(
+            DOMAIN,
+            "query_module_inventory",
+            handle_module_discovery,
+            SCAN_MODULE_SCHEMA,
+        )
 
     # Forward the setup to all configured platforms.
     try:
@@ -173,6 +177,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not unload_ok:
         _LOGGER.error("Failed to unload Nikobus platforms.")
         return False
+
+    if hass.services.has_service(DOMAIN, "query_module_inventory"):
+        hass.services.async_remove(DOMAIN, "query_module_inventory")
 
     _LOGGER.info("Nikobus integration fully unloaded.")
     return True

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -375,6 +375,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
         self._has_feedback_module = entry.data.get(CONF_HAS_FEEDBACK_MODULE, False)
         self._prior_gen3 = entry.data.get(CONF_PRIOR_GEN3, False)
         self._update_interval = self._get_update_interval()
+        self.update_interval = self._update_interval
 
         await self.connect()
         await self.async_refresh()

--- a/custom_components/nikobus/nkblistener.py
+++ b/custom_components/nikobus/nkblistener.py
@@ -118,10 +118,7 @@ class NikobusEventListener:
                 crc8_str,
                 message,
             )
-            raise NikobusDataError(
-                "CRC8 mismatch: calculated %s, expected %s, message %s"
-                % (calc_crc8_val, crc8_str, message)
-            )
+            return False
         _LOGGER.debug(
             "CRC8 match: calculated %s, expected %s, message %s",
             calc_crc8_val,


### PR DESCRIPTION
### Motivation
- Prevent duplicate or stale manual discovery service handlers and ensure they are removed on unload to avoid side effects.
- Apply configuration changes to the coordinator's polling interval so `async_reconfigure` takes effect immediately.
- Make message validation more resilient to malformed frames to avoid raising exceptions during event processing.

### Description
- Guard registration of the `query_module_inventory` service in `async_setup_entry` and remove it in `async_unload_entry` if present to prevent duplicates and stale handlers.
- Apply the new refresh interval during reconfigure by setting `self.update_interval = self._update_interval` in `NikobusDataCoordinator.async_reconfigure` so the `DataUpdateCoordinator` respects changes.
- Change `NikobusEventListener.validate_crc` to return `False` on CRC mismatches instead of raising `NikobusDataError`, reducing exception propagation for malformed messages.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a80cd3d44832caf8350e42ec44790)