### PR TITLE
Standardize unique IDs for module entities

### DIFF
--- a/custom_components/nikobus/cover.py
+++ b/custom_components/nikobus/cover.py
@@ -260,7 +260,7 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
         self._button_operation_time: Optional[float] = None
 
         self._attr_name = channel_description
-        self._attr_unique_id = f"{DOMAIN}_{self._address}_{self._channel}"
+        self._attr_unique_id = f"{DOMAIN}_cover_{self._address}_{self._channel}"
         self._attr_device_class = CoverDeviceClass.SHUTTER
 
         _LOGGER.debug(

--- a/custom_components/nikobus/light.py
+++ b/custom_components/nikobus/light.py
@@ -113,7 +113,7 @@ class NikobusLightEntity(NikobusEntity, LightEntity):
         self._channel = channel
         self._channel_description = channel_description
 
-        self._attr_unique_id = f"{DOMAIN}_{self._address}_{self._channel}"
+        self._attr_unique_id = f"{DOMAIN}_light_{self._address}_{self._channel}"
         self._attr_name = channel_description
 
         # Supported color modes: brightness

--- a/custom_components/nikobus/switch.py
+++ b/custom_components/nikobus/switch.py
@@ -174,7 +174,7 @@ class NikobusSwitchEntity(NikobusEntity, SwitchEntity):
         self._channel = channel
         self._channel_description = channel_description
 
-        self._attr_unique_id = f"{DOMAIN}_{self._address}_{self._channel}"
+        self._attr_unique_id = f"{DOMAIN}_switch_{self._address}_{self._channel}"
         self._attr_name = channel_description
         self._is_on: bool | None = None
 


### PR DESCRIPTION
## Summary
- add entity-type prefixes to light, switch, and cover unique IDs
- align known unique ID generation with the new patterns including roller use_as_switch handling

## Testing
- python -m compileall custom_components/nikobus

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d17694414832cbb999ddffc7cec21)