### PR TITLE
Handle ALL module discovery requests

### DIFF
--- a/custom_components/nikobus/__init__.py
+++ b/custom_components/nikobus/__init__.py
@@ -65,8 +65,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def handle_module_discovery(call: ServiceCall) -> None:
         """Manually trigger device discovery."""
-        module_address = call.data.get("module_address", "")
-        _LOGGER.info("Starting manual Nikobus discovery with module_address: %s", module_address)
+        module_address = (call.data.get("module_address", "") or "").strip().upper()
+        _LOGGER.info(
+            "Starting manual Nikobus discovery with module_address: %s", module_address
+        )
         await coordinator.discover_devices(module_address)
 
     if not hass.services.has_service(DOMAIN, "query_module_inventory"):

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -159,6 +159,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
 
     async def discover_devices(self, module_address) -> None:
         """Discover available module / button."""
+        module_address = module_address.upper() if isinstance(module_address, str) else ""
         await self.hass.services.async_call(
             "persistent_notification",
             "create",
@@ -173,7 +174,10 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
         self._discovery_running = True
         _LOGGER.debug("Starting device discovery from Nikobus")
         try:
-            if module_address:
+            if module_address == "ALL":
+                self._discovery_module = False
+                await self.nikobus_discovery.query_module_inventory(module_address)
+            elif module_address:
                 self._discovery_module = True
                 self.discovery_module_address = module_address
                 await self.nikobus_discovery.query_module_inventory(module_address)


### PR DESCRIPTION
## Summary
- normalize manual discovery module address input
- handle the ALL address explicitly to avoid treating it as a single module identifier

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d5e9ead58832caa83eae93933e037)