### PR TITLE
Reset discovery state after multi-module scan

### DIFF
--- a/custom_components/nikobus/discovery/discovery.py
+++ b/custom_components/nikobus/discovery/discovery.py
@@ -73,6 +73,7 @@ class NikobusDiscovery:
                 while self._coordinator.discovery_module:
                     await asyncio.sleep(0.5)
                 _LOGGER.info("Completed discovery for module: %s", addr)
+            self.reset_state()
             if hasattr(self, "on_discovery_finished") and self.on_discovery_finished:
                 await self.on_discovery_finished()
             return


### PR DESCRIPTION
## Summary
- reset discovery state after iterating all modules so callbacks can fire and queues clear

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d62c237d0832c83aefad4ba9b15a8)