### PR TITLE
Track per-button release times for interval events

### DIFF
--- a/custom_components/nikobus/nkbactuator.py
+++ b/custom_components/nikobus/nkbactuator.py
@@ -32,7 +32,7 @@ class NikobusActuator:
         self._debounce_time_ms = 150
         self._last_address: Optional[str] = None
         self._last_press_time: Optional[float] = None
-        self._last_release_time: Optional[float] = None
+        self._last_release_times: Dict[str, float] = {}
         self._press_task: Optional[asyncio.Task] = None
         self._press_task_active = False
         self._timer_tasks: List[asyncio.Task] = []
@@ -55,14 +55,16 @@ class NikobusActuator:
     def _fire_press_interval_event(self, address: str, current_time: float) -> None:
         """Fire an event describing how long it has been since the last release."""
 
-        if self._last_release_time is None:
+        last_release_time = self._last_release_times.get(address)
+
+        if last_release_time is None:
             _LOGGER.debug(
                 "No previous release time recorded for address %s; skipping interval event",
                 address,
             )
             return
 
-        time_since_release = current_time - self._last_release_time
+        time_since_release = current_time - last_release_time
         if time_since_release < 1:
             event_type = "nikobus_button_pressed_0"
         elif time_since_release < 2:
@@ -156,7 +158,7 @@ class NikobusActuator:
 
                     self._cancel_unneeded_timers(press_duration)
                     self._fire_duration_event(address, press_duration)
-                    self._last_release_time = current_time
+                    self._last_release_times[address] = current_time
                     break
         except asyncio.CancelledError:
             _LOGGER.warning("Press task for address %s was cancelled", address)


### PR DESCRIPTION
## Summary
- track button release timestamps per address to emit accurate press interval events

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695032764a58832cb34d6fa80b5172ab)