### PR TITLE
Add detailed button press duration events

### DIFF
--- a/custom_components/nikobus/const.py
+++ b/custom_components/nikobus/const.py
@@ -39,9 +39,10 @@ HANDSHAKE_TIMEOUT: Final[int] = 60  # Timeout for handshake in seconds
 # =============================================================================
 REFRESH_DELAY: Final[float] = 0.5  # Delay before retrieving status after button press
 DIMMER_DELAY: Final[int] = 1  # Delay before retrieving dimmer status
-SHORT_PRESS: Final[int] = 1  # Short press duration in seconds
+SHORT_PRESS: Final[float] = 1.0  # Short press duration in seconds
 MEDIUM_PRESS: Final[int] = 2  # Medium press duration in seconds
-LONG_PRESS: Final[int] = 3  # Long press duration in seconds
+LONG_PRESS: Final[float] = 3.0  # Long press duration threshold in seconds
+BUTTON_TIMER_THRESHOLDS: Final[tuple[int, int, int]] = (1, 2, 3)
 
 # =============================================================================
 # Listener


### PR DESCRIPTION
## Summary
- track per-button press cycles with monotonic timing, milestone timers, and consistent Home Assistant events
- add shared timing constants and payload builder to include identifiers, timestamps, buckets, and thresholds on all button events
- keep module refresh events while enriching them with the new press context data
- update the long-press threshold constant to 3 seconds for consistency

## Testing
- python -m compileall custom_components/nikobus

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69518d76dcd4832c8b740bb52aa0db54)