### PR TITLE
Add nikobus_button_operation event to avoid duplicate pressed events

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The integration emits structured Home Assistant bus events for every button pres
 - Classification: `nikobus_short_button_pressed` (press duration < 3s) and `nikobus_long_button_pressed` (press duration ≥ 3s). The 3-second threshold is defined as `LONG_PRESS` in `custom_components/nikobus/const.py`.
 - Release-duration buckets (rounded down): `nikobus_button_pressed_0` (< 1s), `nikobus_button_pressed_1` (1–<2s), `nikobus_button_pressed_2` (2–<3s), and `nikobus_button_pressed_3` (≥ 3s).
 - Hold milestones (emitted while still pressed): `nikobus_button_timer_1`, `_2`, and `_3` at 1s, 2s, and 3s respectively.
+- Post-refresh notification: `nikobus_button_operation` when the integration refreshes impacted modules after the press, including metadata such as the impacted module address/group and configured operation time.
 
 All events share the same payload keys so automations can rely on a consistent schema:
 

--- a/custom_components/nikobus/nkbactuator.py
+++ b/custom_components/nikobus/nkbactuator.py
@@ -16,6 +16,9 @@ from .const import BUTTON_TIMER_THRESHOLDS, DIMMER_DELAY, REFRESH_DELAY, SHORT_P
 _LOGGER = logging.getLogger(__name__)
 
 
+BUTTON_OPERATION_EVENT = "nikobus_button_operation"
+
+
 @dataclass
 class PressState:
     """Track the state of an in-flight button press."""
@@ -449,7 +452,7 @@ class NikobusActuator:
                 }
 
                 self._fire_event(
-                    "nikobus_button_pressed",
+                    BUTTON_OPERATION_EVENT,
                     state,
                     state_value="released",
                     duration=duration_s,
@@ -481,7 +484,7 @@ class NikobusActuator:
                 press_id,
             )
             self._fire_event(
-                "nikobus_button_pressed",
+                BUTTON_OPERATION_EVENT,
                 state,
                 state_value="released",
                 duration=duration_s,


### PR DESCRIPTION
## Summary
- add a dedicated `nikobus_button_operation` event for post-refresh notifications instead of reusing `nikobus_button_pressed`
- document the new event in the README event list

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695199d91f4c832cb24ec40b61c78ae4)