### PR TITLE
Handle physical button stop events for covers

### DIFF
--- a/custom_components/nikobus/cover.py
+++ b/custom_components/nikobus/cover.py
@@ -414,7 +414,16 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
                 )
             await self._process_state_change(new_state, source="nikobus")
         else:
-            _LOGGER.debug("No state change for %s; ignoring event.", self._attr_name)
+            if self._in_motion and new_state in (STATE_OPENING, STATE_CLOSING):
+                _LOGGER.debug(
+                    "Button press for %s detected without state change; stopping motion.",
+                    self._attr_name,
+                )
+                await self._end_motion()
+            else:
+                _LOGGER.debug(
+                    "No state change for %s; ignoring event.", self._attr_name
+                )
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         await self._request_cover_motion("opening")


### PR DESCRIPTION
## Summary
- stop ongoing cover motion when a physical button press occurs without a reported state change

## Testing
- python -m compileall custom_components/nikobus

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956e2f0c3c4832c8db3b79513c59dd4)