### PR TITLE
Fix cover position reaching zero when closing

### DIFF
--- a/custom_components/nikobus/cover.py
+++ b/custom_components/nikobus/cover.py
@@ -627,7 +627,9 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
             while self._in_motion and self._direction:
                 estimated_position = self._position_estimator.get_position()
                 if estimated_position is not None:
-                    self._position = _clamp_position(estimated_position) or self._position
+                    clamped_position = _clamp_position(estimated_position)
+                    if clamped_position is not None:
+                        self._position = clamped_position
 
                 elapsed = time.monotonic() - start_time
                 if self._button_operation_time and elapsed >= self._button_operation_time:


### PR DESCRIPTION
## Summary
- ensure clamped cover position updates even when the value is zero during motion

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956f6a6b970832cb8146d6c9d369982)