### PR TITLE
Handle Nikobus discovery filler records

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,71 @@
+import sys
+import types
+from pathlib import Path
+
+
+def _ensure_module(name: str) -> types.ModuleType:
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+    return module
+
+
+# Stub external dependencies used during module import so unit tests can run
+voluptuous = _ensure_module("voluptuous")
+voluptuous.Schema = lambda *args, **kwargs: None
+voluptuous.Optional = lambda *args, **kwargs: None
+
+homeassistant = _ensure_module("homeassistant")
+homeassistant.core = _ensure_module("homeassistant.core")
+homeassistant.config_entries = _ensure_module("homeassistant.config_entries")
+homeassistant.exceptions = _ensure_module("homeassistant.exceptions")
+
+homeassistant.core.HomeAssistant = type("HomeAssistant", (), {})
+homeassistant.core.ServiceCall = type("ServiceCall", (), {})
+homeassistant.config_entries.ConfigEntry = type("ConfigEntry", (), {})
+homeassistant.exceptions.ConfigEntryNotReady = type(
+    "ConfigEntryNotReady", (Exception,), {}
+)
+homeassistant.exceptions.HomeAssistantError = type("HomeAssistantError", (Exception,), {})
+
+helpers = _ensure_module("homeassistant.helpers")
+helpers.config_validation = _ensure_module("homeassistant.helpers.config_validation")
+helpers.device_registry = _ensure_module("homeassistant.helpers.device_registry")
+helpers.entity_registry = _ensure_module("homeassistant.helpers.entity_registry")
+helpers.update_coordinator = _ensure_module("homeassistant.helpers.update_coordinator")
+helpers.__path__ = []
+helpers.config_validation.string = lambda value: value
+helpers.update_coordinator.DataUpdateCoordinator = type(
+    "DataUpdateCoordinator", (), {}
+)
+helpers.update_coordinator.UpdateFailed = type("UpdateFailed", (Exception,), {})
+
+components = _ensure_module("homeassistant.components")
+components.switch = _ensure_module("homeassistant.components.switch")
+components.light = _ensure_module("homeassistant.components.light")
+components.cover = _ensure_module("homeassistant.components.cover")
+components.binary_sensor = _ensure_module("homeassistant.components.binary_sensor")
+components.button = _ensure_module("homeassistant.components.button")
+components.scene = _ensure_module("homeassistant.components.scene")
+components.switch.DOMAIN = "switch"
+components.light.DOMAIN = "light"
+components.cover.DOMAIN = "cover"
+components.binary_sensor.DOMAIN = "binary_sensor"
+components.button.DOMAIN = "button"
+components.scene.DOMAIN = "scene"
+
+sys.modules.setdefault("serial_asyncio_fast", types.ModuleType("serial_asyncio_fast"))
+aiofiles = types.ModuleType("aiofiles")
+
+
+async def _noop_open(*args, **kwargs):
+    return None
+
+
+aiofiles.open = _noop_open
+sys.modules.setdefault("aiofiles", aiofiles)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,123 @@
+import pytest
+
+from custom_components.nikobus.discovery.discovery import add_to_command_mapping
+from custom_components.nikobus.discovery.mapping import (
+    CHANNEL_MAPPING,
+    KEY_MAPPING_MODULE,
+    SWITCH_MODE_MAPPING,
+    SWITCH_TIMER_MAPPING,
+)
+from custom_components.nikobus.discovery.protocol import (
+    convert_nikobus_address,
+    decode_command_payload,
+)
+
+
+MODE_MAPPINGS = {
+    "switch_module": SWITCH_MODE_MAPPING,
+}
+
+TIMER_MAPPINGS = {
+    "switch_module": SWITCH_TIMER_MAPPING,
+}
+
+
+def _get_channels(_):
+    return 4
+
+
+def test_decode_skips_terminator_and_filler_records():
+    assert (
+        decode_command_payload(
+            "FFFFFFFFFFFF",
+            "switch_module",
+            KEY_MAPPING_MODULE,
+            CHANNEL_MAPPING,
+            MODE_MAPPINGS,
+            TIMER_MAPPINGS,
+            _get_channels,
+            convert_nikobus_address,
+        )
+        is None
+    )
+
+    assert (
+        decode_command_payload(
+            "00F000000001",
+            "switch_module",
+            KEY_MAPPING_MODULE,
+            CHANNEL_MAPPING,
+            MODE_MAPPINGS,
+            TIMER_MAPPINGS,
+            _get_channels,
+            convert_nikobus_address,
+        )
+        is None
+    )
+
+    assert (
+        decode_command_payload(
+            "001000FFFFFF",
+            "switch_module",
+            KEY_MAPPING_MODULE,
+            CHANNEL_MAPPING,
+            MODE_MAPPINGS,
+            TIMER_MAPPINGS,
+            _get_channels,
+            convert_nikobus_address,
+        )
+        is None
+    )
+
+
+def test_decode_valid_record():
+    decoded = decode_command_payload(
+        "001000000001",
+        "switch_module",
+        KEY_MAPPING_MODULE,
+        CHANNEL_MAPPING,
+        MODE_MAPPINGS,
+        TIMER_MAPPINGS,
+        _get_channels,
+        convert_nikobus_address,
+    )
+
+    assert decoded is not None
+    assert decoded["key_raw"] == 1
+    assert decoded["channel_raw"] == 0
+    assert decoded["push_button_address"] is not None
+
+
+def test_command_mapping_supports_one_to_many_and_deduplication():
+    first = decode_command_payload(
+        "001000000001",
+        "switch_module",
+        KEY_MAPPING_MODULE,
+        CHANNEL_MAPPING,
+        MODE_MAPPINGS,
+        TIMER_MAPPINGS,
+        _get_channels,
+        convert_nikobus_address,
+    )
+
+    second = decode_command_payload(
+        "001100000001",
+        "switch_module",
+        KEY_MAPPING_MODULE,
+        CHANNEL_MAPPING,
+        MODE_MAPPINGS,
+        TIMER_MAPPINGS,
+        _get_channels,
+        convert_nikobus_address,
+    )
+
+    mapping = {}
+    add_to_command_mapping(mapping, first, "C9A5")
+    add_to_command_mapping(mapping, second, "C9A5")
+    add_to_command_mapping(mapping, first, "C9A5")
+
+    key = (first["push_button_address"], first["key_raw"])
+    assert key in mapping
+    assert len(mapping[key]) == 2
+    assert mapping[key][0]["channel"] == 0
+    assert mapping[key][1]["channel"] == 1


### PR DESCRIPTION
## Summary
- skip terminator and filler inventory records and avoid raising when key mappings are absent
- build discovery command mappings that allow one push button key to fan out to multiple module outputs with deduplication
- add protocol tests covering invalid records, valid decoding, and one-to-many mapping behaviour

## Testing
- pytest

## Notes
- Terminator payloads (all Fs), payloads ending in an invalid button address (FFFFFF), or any record with key/channel/mode nibble 0xF are ignored during decode.
- Discovery now aggregates results per (push_button_address, key_raw) and stores lists of output definitions to reflect one-to-many mappings.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69579e653c20832c9d9467eebb8a0f3b)