### PR TITLE
Fix button config JSON update handling

### DIFF
--- a/custom_components/nikobus/discovery/discovery.py
+++ b/custom_components/nikobus/discovery/discovery.py
@@ -201,10 +201,10 @@ class NikobusDiscovery:
             )
 
             if category == "Module":
-                await update_module_data(self._hass.config.path(""), self.discovered_devices)
+                await update_module_data(self._hass, self.discovered_devices)
             elif category == "Button":
                 await update_button_data(
-                    self._hass.config.path(""),
+                    self._hass,
                     self.discovered_devices,
                     KEY_MAPPING,
                     convert_nikobus_address,
@@ -334,7 +334,7 @@ class NikobusDiscovery:
                 )
 
             updated_buttons, links_added, outputs_added = await merge_discovered_links(
-                self._hass.config.path(""), command_mapping
+                self._hass, command_mapping
             )
             _LOGGER.info(
                 "Discovered links merged into config: %d buttons updated, %d link blocks added, %d outputs added.",

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -1,4 +1,5 @@
 import asyncio
+from pathlib import Path
 
 from custom_components.nikobus.discovery.fileio import (
     merge_discovered_links,
@@ -10,6 +11,19 @@ from custom_components.nikobus.discovery.fileio import (
 def test_merge_discovered_links_deduplicates_outputs(tmp_path):
     async def _run():
         file_path = tmp_path / "nikobus_button_config.json"
+
+        class DummyConfig:
+            def __init__(self, base_path: Path):
+                self._base_path = base_path
+
+            def path(self, *args):
+                return str(Path(self._base_path, *args))
+
+        class DummyHass:
+            def __init__(self, base_path: Path):
+                self.config = DummyConfig(base_path)
+
+        hass = DummyHass(tmp_path)
 
         initial_data = {
             "nikobus_button": [
@@ -81,7 +95,7 @@ def test_merge_discovered_links_deduplicates_outputs(tmp_path):
         }
 
         updated_buttons, links_added, outputs_added = await merge_discovered_links(
-            str(tmp_path), command_mapping
+            hass, command_mapping
         )
 
         assert updated_buttons == 1


### PR DESCRIPTION
## Summary
- ensure button JSON updates use the Home Assistant config path with directory creation and richer logging
- normalize addresses during discovery merges, log unmatched mappings, and skip writes when no changes occur
- improve atomic write error reporting and update tests for the new Hass-based file path usage

## Testing
- pytest tests/test_fileio.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957a9d3f030832cba5910df3e6caa73)