### PR TITLE
Improve discovery chunk alignment and scoring

### DIFF
--- a/tests/test_discovery_chunking.py
+++ b/tests/test_discovery_chunking.py
@@ -1,0 +1,65 @@
+import pytest
+
+from custom_components.nikobus.discovery.discovery import NikobusDiscovery
+
+
+class DummyCommandQueue:
+    async def clear_command_queue(self):  # pragma: no cover - not used in these tests
+        return None
+
+
+class DummyCoordinator:
+    def __init__(self):
+        self.discovery_running = False
+        self.discovery_module = False
+        self.discovery_module_address = None
+        self.nikobus_command = DummyCommandQueue()
+
+    def get_button_channels(self, _):
+        return 8
+
+    def get_module_type(self, _):  # pragma: no cover - helper for completeness
+        return None
+
+
+@pytest.mark.parametrize(
+    "message, module_type, expected_chunk",
+    [
+        (
+            "$0522$1E6C0E5F1550000300B4FF452CA9",
+            "dimmer_module",
+            ["5F1550000300B4FF"],
+        ),
+        (
+            "$0522$1EABCD73EE80053000B412ABCDEF",
+            "dimmer_module",
+            ["73EE80053000B412"],
+        ),
+        (
+            "$0522$1E000177C958022BFF112233",
+            "switch_module",
+            ["77C958022BFF"],
+        ),
+    ],
+)
+def test_chunk_alignment_does_not_swallow_crc(message, module_type, expected_chunk):
+    coordinator = DummyCoordinator()
+    discovery = NikobusDiscovery(None, coordinator)
+    discovery._module_type = module_type
+
+    matched_header = message.split("$")[1]
+    matched_header = f"${matched_header}${message.split('$')[2][:2]}"  # rebuild like DEVICE_INVENTORY entries
+    header_suffix = matched_header.split("$")[-1]
+    frame_body = message[len(matched_header) :]
+
+    address = (header_suffix + frame_body[:4]).upper()
+    payload_and_crc = frame_body[4:]
+
+    analysis = discovery._analyze_frame_payload(address, payload_and_crc)
+
+    assert analysis is not None
+    assert analysis["chunks"] == expected_chunk
+    assert not analysis["remainder"]
+    if analysis["crc_len"]:
+        assert analysis["crc"] == payload_and_crc[-analysis["crc_len"] :]
+


### PR DESCRIPTION
## Summary
- add scoring-based frame segmentation that evaluates CRC length and chunk size candidates
- refactor module inventory parsing to use the alignment solver and emit debug rationale
- add regression tests to ensure CRC/footer bytes are not swallowed for dimmer and switch frames

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957b9c2409c832cab5384e736a4fa4f)