### PR TITLE
Refactor discovery decoding into modular decoders

### DIFF
--- a/custom_components/nikobus/discovery/decoders/__init__.py
+++ b/custom_components/nikobus/discovery/decoders/__init__.py
@@ -1,0 +1,12 @@
+from .base import DecodedCommand, Decoder
+from .dimmer_decoder import DimmerDecoder
+from .switch_decoder import SwitchDecoder
+from .shutter_decoder import ShutterDecoder
+
+__all__ = [
+    "DecodedCommand",
+    "Decoder",
+    "DimmerDecoder",
+    "SwitchDecoder",
+    "ShutterDecoder",
+]

--- a/custom_components/nikobus/discovery/decoders/base.py
+++ b/custom_components/nikobus/discovery/decoders/base.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+
+@dataclass
+class DecodedCommand:
+    module_type: str
+    raw_message: str
+    prefix_hex: str | None = None
+    chunk_hex: str | None = None
+    payload_hex: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class Decoder(Protocol):
+    module_type: str
+
+    def can_handle(self, module_type: str) -> bool:
+        """Return True if this decoder can process the given module type."""
+
+    def decode(self, message: str) -> list[DecodedCommand]:
+        """Decode the incoming message or chunk into structured commands."""

--- a/custom_components/nikobus/discovery/decoders/dimmer_decoder.py
+++ b/custom_components/nikobus/discovery/decoders/dimmer_decoder.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ..mapping import CHANNEL_MAPPING, DIMMER_MODE_MAPPING, DIMMER_TIMER_MAPPING, KEY_MAPPING_MODULE
+from ..protocol import (
+    _build_dimmer_candidates,
+    _calculate_timer_values,
+    convert_nikobus_address,
+    get_button_address,
+    get_push_button_address,
+    reverse_hex,
+)
+from .base import DecodedCommand
+
+_LOGGER = logging.getLogger(__name__)
+
+EXPECTED_CHUNK_LEN = 16
+
+
+class DimmerDecoder:
+    module_type = "dimmer_module"
+
+    def __init__(self, coordinator):
+        self._coordinator = coordinator
+
+    def can_handle(self, module_type: str) -> bool:
+        return module_type == self.module_type
+
+    def _decode_fields(self, payload_hex: str) -> dict[str, Any] | None:
+        raw_bytes = [payload_hex[i : i + 2] for i in range(0, len(payload_hex), 2)]
+        button_address_hex = payload_hex[-6:]
+        button_address = get_button_address(button_address_hex)
+        num_channels = self._coordinator.get_button_channels(button_address)
+
+        candidates = _build_dimmer_candidates(
+            raw_bytes, CHANNEL_MAPPING, KEY_MAPPING_MODULE, DIMMER_MODE_MAPPING, num_channels
+        )
+        passing = [c for c in candidates if c["valid_all"]]
+        if not passing and candidates:
+            passing = sorted(
+                candidates,
+                key=lambda c: (int(c["valid_key"]), int(c["valid_channel"]), int(c["valid_mode"])),
+                reverse=True,
+            )[:1]
+
+        if not passing:
+            _LOGGER.error("No valid candidate interpretations for dimmer payload: %s", payload_hex)
+            return None
+
+        selected = max(passing, key=lambda c: c.get("count", 0))
+        key_raw = selected.get("key_raw")
+        channel_raw = selected.get("channel_raw")
+        mode_raw = selected.get("mode_raw")
+        t1_raw = selected.get("t1_raw")
+        t2_raw = selected.get("t2_raw")
+
+        push_button_address, normalized_button = get_push_button_address(
+            key_raw,
+            button_address,
+            KEY_MAPPING_MODULE,
+            self._coordinator.get_button_channels,
+            convert_nikobus_address,
+        )
+
+        channel_label = CHANNEL_MAPPING.get(channel_raw, f"Unknown Channel ({channel_raw})")
+        mode_label = DIMMER_MODE_MAPPING.get(mode_raw, f"Unknown Mode ({mode_raw})")
+
+        t1_val, t2_val = _calculate_timer_values(
+            "dimmer_module", mode_raw, t1_raw, t2_raw, {"dimmer_module": DIMMER_TIMER_MAPPING}
+        )
+
+        return {
+            "payload": payload_hex,
+            "button_address": normalized_button,
+            "push_button_address": push_button_address,
+            "key_raw": key_raw,
+            "channel_raw": channel_raw,
+            "mode_raw": mode_raw,
+            "t1_raw": t1_raw,
+            "t2_raw": t2_raw,
+            "K": f"{key_raw}",
+            "C": f"{channel_label}",
+            "T1": t1_val,
+            "T2": t2_val,
+            "M": f"{mode_label}",
+            "raw_bytes": raw_bytes,
+        }
+
+    def _chunk_from_message(self, message: str) -> tuple[str | None, str | None, str | None]:
+        from ..const import DEVICE_INVENTORY
+
+        matched_header = next((candidate for candidate in DEVICE_INVENTORY if message.startswith(candidate)), None)
+        if matched_header is None:
+            return None, None, None
+
+        header_suffix = matched_header.split("$")[-1]
+        frame_body = message[len(matched_header) :]
+        if len(frame_body) < 4:
+            return header_suffix, None, None
+
+        address = (header_suffix + frame_body[:4]).upper()
+        payload_and_crc = frame_body[4:]
+        return address, payload_and_crc[:EXPECTED_CHUNK_LEN], payload_and_crc[EXPECTED_CHUNK_LEN:]
+
+    def decode(self, message: str) -> list[DecodedCommand]:
+        message = message.strip()
+        address, chunk_hex, crc_region = self._chunk_from_message(message)
+
+        if chunk_hex is None or address is None:
+            _LOGGER.debug("Dimmer decoder unable to extract chunk from message: %s", message)
+            return []
+
+        chunk_hex = chunk_hex.upper()
+        if len(chunk_hex) != EXPECTED_CHUNK_LEN:
+            _LOGGER.error(
+                "Dimmer chunk extraction failed | chunk=%s len=%s expected=%s",
+                chunk_hex,
+                len(chunk_hex),
+                EXPECTED_CHUNK_LEN,
+            )
+            return []
+
+        payload_hex = reverse_hex(chunk_hex)
+        if len(payload_hex) != EXPECTED_CHUNK_LEN:
+            _LOGGER.error(
+                "Dimmer payload reversal mismatch | payload=%s len=%s expected=%s",
+                payload_hex,
+                len(payload_hex),
+                EXPECTED_CHUNK_LEN,
+            )
+            return []
+
+        decoded_fields = self._decode_fields(payload_hex)
+        if decoded_fields is None:
+            return []
+
+        decoded_fields.update({"crc_region": crc_region, "module_address": address})
+
+        command = DecodedCommand(
+            module_type=self.module_type,
+            raw_message=message,
+            prefix_hex=address,
+            chunk_hex=chunk_hex,
+            payload_hex=payload_hex,
+            metadata=decoded_fields,
+        )
+
+        _LOGGER.debug(
+            "Dimmer decoded chunk | address=%s chunk_len=%s payload_len=%s payload=%s",
+            address,
+            len(chunk_hex),
+            len(payload_hex),
+            payload_hex,
+        )
+
+        return [command]

--- a/custom_components/nikobus/discovery/decoders/shutter_decoder.py
+++ b/custom_components/nikobus/discovery/decoders/shutter_decoder.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .switch_decoder import ShutterDecoder
+
+__all__ = ["ShutterDecoder"]

--- a/custom_components/nikobus/discovery/decoders/switch_decoder.py
+++ b/custom_components/nikobus/discovery/decoders/switch_decoder.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ..mapping import CHANNEL_MAPPING, KEY_MAPPING_MODULE, SWITCH_MODE_MAPPING, SWITCH_TIMER_MAPPING
+from ..protocol import convert_nikobus_address, decode_command_payload, reverse_hex
+from .base import DecodedCommand
+
+_LOGGER = logging.getLogger(__name__)
+
+
+_CRC_CANDIDATES = (6, 8, 0)
+_CHUNK_SIZE_CANDIDATES = (12, 16, 20, 24)
+_SCORING_WEIGHTS = {
+    "decode_success": 10.0,
+    "decode_failure": 2.5,
+    "expected_length_bonus": 3.0,
+    "filler_penalty": 5.0,
+    "reserved_pattern_penalty": 2.0,
+    "key_plausible_bonus": 1.5,
+    "channel_plausible_bonus": 1.5,
+    "mode_present_bonus": 1.0,
+    "remainder_penalty": 1.2,
+    "crc_penalty": 0.5,
+}
+
+
+def _chunk_expected_lengths(module_type: str) -> int | None:
+    return {
+        "switch_module": 12,
+        "roller_module": 12,
+    }.get(module_type)
+
+
+class BaseChunkingDecoder:
+    module_type: str
+
+    def __init__(self, coordinator, module_type: str):
+        self._coordinator = coordinator
+        self.module_type = module_type
+
+    def can_handle(self, module_type: str) -> bool:
+        return module_type == self.module_type
+
+    def _score_chunk(self, chunk: str) -> tuple[float, dict[str, Any]]:
+        chunk = chunk.strip().upper()
+        reversed_chunk = reverse_hex(chunk)
+        score = 0.0
+        reasons: list[str] = []
+
+        expected_len = _chunk_expected_lengths(self.module_type)
+        if expected_len and len(chunk) == expected_len:
+            score += _SCORING_WEIGHTS["expected_length_bonus"]
+            reasons.append(f"matches_expected_len({expected_len})")
+
+        bytes_pairs = [chunk[i : i + 2] for i in range(0, len(chunk), 2)]
+        filler_ratio = sum(1 for b in bytes_pairs if b in {"FF", "00"}) / max(
+            1, len(bytes_pairs)
+        )
+        if filler_ratio > 0.5:
+            score -= _SCORING_WEIGHTS["filler_penalty"]
+            reasons.append("filler_ratio")
+
+        decoded: dict[str, Any] | None = None
+        try:
+            decoded = decode_command_payload(
+                reversed_chunk,
+                self.module_type,
+                KEY_MAPPING_MODULE,
+                CHANNEL_MAPPING,
+                {"switch_module": SWITCH_MODE_MAPPING, "roller_module": SWITCH_MODE_MAPPING},
+                {
+                    "switch_module": SWITCH_TIMER_MAPPING,
+                    "roller_module": SWITCH_TIMER_MAPPING,
+                },
+                self._coordinator.get_button_channels,
+                convert_nikobus_address,
+            )
+        except Exception as err:  # pragma: no cover - defensive
+            _LOGGER.debug("Decode error while scoring chunk %s: %s", chunk, err)
+
+        if decoded:
+            score += _SCORING_WEIGHTS["decode_success"]
+            reasons.append("decoded")
+            key_raw = decoded.get("key_raw")
+            channel_raw = decoded.get("channel_raw")
+            mode_raw = decoded.get("mode_raw")
+            if isinstance(key_raw, int) and 0 <= key_raw <= 0x0F:
+                score += _SCORING_WEIGHTS["key_plausible_bonus"]
+                reasons.append("key_plausible")
+            if isinstance(channel_raw, int) and 0 <= channel_raw <= 0x0F:
+                score += _SCORING_WEIGHTS["channel_plausible_bonus"]
+                reasons.append("channel_plausible")
+            if mode_raw is not None:
+                score += _SCORING_WEIGHTS["mode_present_bonus"]
+        else:
+            score -= _SCORING_WEIGHTS["decode_failure"]
+            reasons.append("decode_failed")
+
+        if filler_ratio > 0.75:
+            score -= _SCORING_WEIGHTS["reserved_pattern_penalty"]
+            reasons.append("reserved_pattern")
+
+        return score, {
+            "chunk": chunk,
+            "reversed": reversed_chunk,
+            "decoded": decoded,
+            "score": score,
+            "reasons": reasons,
+        }
+
+    def _solve_chunk_alignment(self, payload_hex: str) -> dict[str, Any]:
+        payload_hex = payload_hex.upper()
+        n = len(payload_hex)
+
+        from functools import lru_cache
+
+        @lru_cache(None)
+        def _best_from(idx: int) -> tuple[float, list[str], list[dict[str, Any]]]:
+            if idx >= n:
+                return 0.0, [], []
+
+            best_score = -float("inf")
+            best_chunks: list[str] = []
+            best_meta: list[dict[str, Any]] = []
+
+            remainder_penalty = -_SCORING_WEIGHTS["remainder_penalty"] * ((n - idx) / 2)
+            best_score = remainder_penalty
+
+            for size in _CHUNK_SIZE_CANDIDATES:
+                if idx + size > n:
+                    continue
+                chunk = payload_hex[idx : idx + size]
+                chunk_score, chunk_meta = self._score_chunk(chunk)
+                next_score, next_chunks, next_meta = _best_from(idx + size)
+                total = chunk_score + next_score
+                if total > best_score:
+                    best_score = total
+                    best_chunks = [chunk] + next_chunks
+                    best_meta = [chunk_meta] + next_meta
+
+            return best_score, best_chunks, best_meta
+
+        score, chunks, meta = _best_from(0)
+        consumed_length = sum(len(ch) for ch in chunks)
+        remainder = payload_hex[consumed_length:]
+
+        return {
+            "score": score,
+            "chunks": chunks,
+            "meta": meta,
+            "remainder": remainder,
+        }
+
+    def analyze_frame_payload(self, payload_buffer: str, payload_and_crc: str) -> dict[str, Any] | None:
+        payload_and_crc = payload_and_crc.upper()
+        best: dict[str, Any] | None = None
+        for crc_len in _CRC_CANDIDATES:
+            if crc_len < 0 or len(payload_and_crc) < crc_len:
+                continue
+
+            data_region = payload_and_crc[: len(payload_and_crc) - crc_len]
+            trailing_crc = payload_and_crc[len(payload_and_crc) - crc_len :]
+
+            combined_payload = (payload_buffer + data_region).upper()
+            alignment = self._solve_chunk_alignment(combined_payload)
+            total_score = alignment["score"]
+            if alignment["remainder"]:
+                total_score -= _SCORING_WEIGHTS["crc_penalty"]
+
+            candidate = {
+                "crc_len": crc_len,
+                "crc": trailing_crc,
+                "payload_region": data_region,
+                "chunks": alignment["chunks"],
+                "meta": alignment["meta"],
+                "remainder": alignment["remainder"],
+                "score": total_score,
+            }
+
+            _LOGGER.debug(
+                "CRC candidate evaluated | crc_len=%s crc=%s chunks=%s score=%.2f remainder=%s",
+                crc_len,
+                trailing_crc,
+                [len(ch) for ch in alignment["chunks"]],
+                total_score,
+                alignment["remainder"],
+            )
+
+            if best is None or candidate["score"] > best["score"]:
+                best = candidate
+
+        return best
+
+    def decode(self, message: str) -> list[DecodedCommand]:
+        chunk = message.strip().upper()
+        reversed_chunk = reverse_hex(chunk)
+        decoded = decode_command_payload(
+            reversed_chunk,
+            self.module_type,
+            KEY_MAPPING_MODULE,
+            CHANNEL_MAPPING,
+            {"switch_module": SWITCH_MODE_MAPPING, "roller_module": SWITCH_MODE_MAPPING},
+            {
+                "switch_module": SWITCH_TIMER_MAPPING,
+                "roller_module": SWITCH_TIMER_MAPPING,
+            },
+            self._coordinator.get_button_channels,
+            convert_nikobus_address,
+        )
+
+        if decoded is None or decoded.get("push_button_address") is None:
+            _LOGGER.debug("Skipped chunk during decode: %r", reversed_chunk)
+            return []
+
+        command = DecodedCommand(
+            module_type=self.module_type,
+            raw_message=message,
+            prefix_hex=None,
+            chunk_hex=chunk,
+            payload_hex=reversed_chunk,
+            metadata=decoded,
+        )
+        _LOGGER.debug("Decoded chunk: %r", reversed_chunk)
+        return [command]
+
+
+class SwitchDecoder(BaseChunkingDecoder):
+    def __init__(self, coordinator):
+        super().__init__(coordinator, "switch_module")
+
+
+class ShutterDecoder(BaseChunkingDecoder):
+    def __init__(self, coordinator):
+        super().__init__(coordinator, "roller_module")


### PR DESCRIPTION
## Summary
- add modular decoder classes for switch, shutter, and dimmer discovery payloads
- rewrite dimmer decoder to enforce fixed payload sizing and deterministic chunk extraction
- simplify discovery orchestrator and add lightweight decoder harness

## Testing
- pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957c3255f5c832cab0f7bc25f6223d5)