### PR TITLE
Improve discovery payload decoding reliability

### DIFF
--- a/custom_components/nikobus/discovery/chunk_decoder.py
+++ b/custom_components/nikobus/discovery/chunk_decoder.py
@@ -72,7 +72,7 @@ class BaseChunkingDecoder:
         decoded: dict[str, Any] | None = None
         try:
             decoded = decode_command_payload(
-                reversed_chunk,
+                chunk,
                 self.module_type,
                 KEY_MAPPING_MODULE,
                 CHANNEL_MAPPING,
@@ -86,6 +86,8 @@ class BaseChunkingDecoder:
                 },
                 self._coordinator.get_button_channels,
                 convert_nikobus_address,
+                reverse_before_decode=True,
+                raw_chunk_hex=chunk,
             )
         except Exception as err:  # pragma: no cover - defensive
             _LOGGER.debug("Decode error while scoring chunk %s: %s", chunk, err)
@@ -221,7 +223,7 @@ class BaseChunkingDecoder:
         chunk = message.strip().upper()
         reversed_chunk = reverse_hex(chunk)
         decoded = decode_command_payload(
-            reversed_chunk,
+            chunk,
             self.module_type,
             KEY_MAPPING_MODULE,
             CHANNEL_MAPPING,
@@ -235,6 +237,8 @@ class BaseChunkingDecoder:
             },
             self._coordinator.get_button_channels,
             convert_nikobus_address,
+            reverse_before_decode=True,
+            raw_chunk_hex=chunk,
         )
 
         if decoded is None or decoded.get("push_button_address") is None:

--- a/custom_components/nikobus/discovery/discovery.py
+++ b/custom_components/nikobus/discovery/discovery.py
@@ -213,6 +213,14 @@ class NikobusDiscovery:
                 }
                 self.discovered_devices[converted_address] = base_device
 
+            _LOGGER.debug(
+                "Inventory classification | module_address=%s device_type=%s model=%s channels=%s",
+                converted_address,
+                device_type_hex,
+                model,
+                channels,
+            )
+
             _LOGGER.info(
                 "Discovered %s - %s, Model: %s, at Address: %s",
                 category,


### PR DESCRIPTION
## Summary
- normalize discovery decoding to apply byte reversal with detailed diagnostics
- map channel bitmasks to valid indices using inventory channel counts and additional logging
- expand protocol tests for raw chunk decoding and invalid channel validation

## Testing
- pytest tests/test_protocol.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958336c8400832cbc91a646607bef26)