### PR TITLE
Enhance discovery module config handling

### DIFF
--- a/custom_components/nikobus/nkbconfig.py
+++ b/custom_components/nikobus/nkbconfig.py
@@ -36,7 +36,7 @@ class NikobusConfig:
             return self._transform_loaded_data(data, data_type)
 
         except FileNotFoundError:
-            self._handle_file_not_found(file_path, data_type)
+            return self._handle_file_not_found(file_path, data_type)
 
         except json.JSONDecodeError as err:
             _LOGGER.error(
@@ -83,10 +83,22 @@ class NikobusConfig:
                 "Button configuration file not found: %s. A new file will be created upon discovering the first button.",
                 file_path,
             )
-        else:
-            raise NikobusDataError(
-                f"{data_type.capitalize()} configuration file not found: {file_path}"
+            return None
+
+        if data_type == "module":
+            _LOGGER.info(
+                "Module configuration file not found: %s. It will be created from discovery data when available.",
+                file_path,
             )
+            return {
+                "switch_module": {},
+                "dimmer_module": {},
+                "roller_module": {},
+            }
+
+        raise NikobusDataError(
+            f"{data_type.capitalize()} configuration file not found: {file_path}"
+        )
 
     async def write_json_data(self, file_name: str, data_type: str, data: dict) -> None:
         """Write data to a JSON file, transforming it into a list format if necessary."""

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -5,6 +5,7 @@ from custom_components.nikobus.discovery.fileio import (
     merge_discovered_links,
     read_json_file,
     write_json_file,
+    update_module_data,
 )
 
 
@@ -118,5 +119,151 @@ def test_merge_discovered_links_deduplicates_outputs(tmp_path):
         assert outputs_c9a5[0]["channel"] == 1
         assert outputs_c9a5[0]["payload"] == "OLDPAYLOAD"
         assert outputs_c9a5[1]["channel"] == 2
+
+    asyncio.run(_run())
+
+
+def test_update_module_data_creates_module_config(tmp_path):
+    async def _run():
+        file_path = tmp_path / "nikobus_module_config.json"
+
+        class DummyConfig:
+            def __init__(self, base_path: Path):
+                self._base_path = base_path
+
+            def path(self, *args):
+                return str(Path(self._base_path, *args))
+
+        class DummyHass:
+            def __init__(self, base_path: Path):
+                self.config = DummyConfig(base_path)
+
+        hass = DummyHass(tmp_path)
+
+        discovered_devices = {
+            "C9A5": {
+                "category": "Module",
+                "module_type": "switch_module",
+                "device_type": "01",
+                "discovered_name": "Switch Module",
+                "description": "Switch Module",
+                "model": "05-000-02",
+                "address": "c9a5",
+                "channels_count": 4,
+                "channels": 4,
+                "discovered": True,
+                "last_seen": "2024-01-01T00:00:00+00:00",
+            }
+        }
+
+        await update_module_data(hass, discovered_devices)
+
+        data = await read_json_file(str(file_path))
+        assert data is not None
+
+        switch_modules = data.get("switch_module", [])
+        assert len(switch_modules) == 1
+
+        module = switch_modules[0]
+        assert module["address"] == "C9A5"
+        assert module["channels_count"] == 4
+        assert module["discovered_name"] == "Switch Module"
+        assert module["discovered"] is True
+        assert len(module["channels"]) == 4
+        assert module["channels"][0]["description"] == "not_in_use output_1"
+        assert module["channels"][0]["index"] == 1
+
+    asyncio.run(_run())
+
+
+def test_update_module_data_merges_without_clobbering_user_fields(tmp_path):
+    async def _run():
+        file_path = tmp_path / "nikobus_module_config.json"
+
+        class DummyConfig:
+            def __init__(self, base_path: Path):
+                self._base_path = base_path
+
+            def path(self, *args):
+                return str(Path(self._base_path, *args))
+
+        class DummyHass:
+            def __init__(self, base_path: Path):
+                self.config = DummyConfig(base_path)
+
+        hass = DummyHass(tmp_path)
+
+        initial_data = {
+            "switch_module": [
+                {
+                    "description": "Custom Switch",
+                    "address": "C9A5",
+                    "channels": [{"description": "Living Room"}],
+                    "channels_count": 1,
+                    "discovered_name": "Old Name",
+                }
+            ],
+            "dimmer_module": [],
+            "roller_module": [
+                {
+                    "description": "Custom Roller",
+                    "address": "9105",
+                    "channels": [
+                        {
+                            "description": "Window",
+                            "operation_time": "45",
+                        }
+                    ],
+                }
+            ],
+        }
+
+        await write_json_file(str(file_path), initial_data)
+
+        discovered_devices = {
+            "C9A5": {
+                "category": "Module",
+                "module_type": "switch_module",
+                "device_type": "01",
+                "discovered_name": "New Switch Name",
+                "description": "New Switch Name",
+                "model": "05-000-02",
+                "address": "C9A5",
+                "channels_count": 3,
+                "channels": 3,
+                "last_seen": "2024-01-02T00:00:00+00:00",
+            },
+            "9105": {
+                "category": "Module",
+                "module_type": "roller_module",
+                "device_type": "02",
+                "discovered_name": "Roller Shutter Module",
+                "description": "Roller Shutter Module",
+                "model": "05-001-02",
+                "address": "9105",
+                "channels_count": 2,
+                "channels": 2,
+                "last_seen": "2024-01-02T00:00:00+00:00",
+            },
+        }
+
+        await update_module_data(hass, discovered_devices)
+
+        data = await read_json_file(str(file_path))
+        assert data is not None
+
+        module = data["switch_module"][0]
+        assert module["description"] == "Custom Switch"
+        assert module["discovered_name"] == "New Switch Name"
+        assert module["channels_count"] == 3
+        assert len(module["channels"]) == 3
+        assert module["channels"][0]["description"] == "Living Room"
+        assert module["channels"][1]["description"] == "not_in_use output_2"
+        assert module["channels"][0]["index"] == 1
+
+        roller = data["roller_module"][0]
+        assert roller["channels_count"] == 2
+        assert roller["channels"][0]["operation_time"] == "45"
+        assert roller["channels"][1]["operation_time"] == "00"
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- enrich module discovery metadata with module type hints and timestamps
- merge discovery results into the main module configuration with safe defaults and channel syncing
- allow missing module config files and add tests for the new module data merge logic

## Testing
- pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695933e80b80832cb69e8996db435ea0)