### PR TITLE
Use HA timezone for last_discovered

### DIFF
--- a/custom_components/nikobus/discovery/fileio.py
+++ b/custom_components/nikobus/discovery/fileio.py
@@ -3,7 +3,8 @@ import json
 import logging
 import os
 import tempfile
-from datetime import datetime, timezone
+
+from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -273,7 +274,7 @@ async def update_module_data(hass, discovered_devices):
         return candidate
 
     def _refresh_discovered_info(channels_count: int, device: dict) -> dict:
-        timestamp = device.get("last_seen") or datetime.now(timezone.utc).isoformat()
+        timestamp = device.get("last_seen") or dt_util.now().isoformat()
         discovery_info = {
             "name": device.get("discovered_name") or device.get("description", ""),
             "device_type": device.get("device_type"),


### PR DESCRIPTION
## Summary
- use Home Assistant datetime helpers to generate `last_discovered` timestamps with the configured timezone

## Testing
- pytest -q (fails: missing homeassistant dependency in test environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69595ffec0d0832c8812dd35bc181346)