### PR TITLE
Improve roller module decoding and chunk handling

### DIFF
--- a/custom_components/nikobus/discovery/chunk_decoder.py
+++ b/custom_components/nikobus/discovery/chunk_decoder.py
@@ -262,7 +262,7 @@ class BaseChunkingDecoder:
             raw_chunk_hex=chunk,
         )
 
-        if decoded is None or decoded.get("push_button_address") is None:
+        if decoded is None:
             _LOGGER.debug("Skipped chunk during decode: %r", reversed_chunk)
             return []
 


### PR DESCRIPTION
## Summary
- split switch and roller decoding paths with resilient key/mode candidate selection and filler handling
- normalize roller keys using button channel counts, prefer valid mode candidates, and validate using module channel counts with detailed debug logs
- adjust chunk decoder to only drop chunks on decode failure so validated roller payloads are preserved

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69597b2d04e8832c8cad39a951f06889)