### PR TITLE
Improve roller channel selection stability

### DIFF
--- a/custom_components/nikobus/discovery/protocol.py
+++ b/custom_components/nikobus/discovery/protocol.py
@@ -1,9 +1,12 @@
 import logging
+from typing import Any
 
 _LOGGER = logging.getLogger(__name__)
 
 
 _DIMMER_CANDIDATE_SUCCESS: dict[str, int] = {}
+_ROLLER_CHANNEL_POSITION_STATS: dict[str, dict[str, Any]] = {}
+_ROLLER_CHANNEL_LOCK_FRAMES = 10
 
 
 def _module_channel_count_or_default(
@@ -364,6 +367,113 @@ def _nibble_low(raw_bytes, idx):
         return None
 
 
+def _extract_all_nibbles(raw_bytes: list[str]):
+    nibble_map: list[tuple[str, int | None]] = []
+    for idx, _ in enumerate(raw_bytes):
+        nibble_map.append((f"byte{idx}_hi", _nibble_high(raw_bytes, idx)))
+        nibble_map.append((f"byte{idx}_lo", _nibble_low(raw_bytes, idx)))
+    return nibble_map
+
+
+def _roller_tracker_key(module_address: str | None, channel_count: int | None) -> str:
+    key = module_address or "unknown"
+    if channel_count is not None:
+        return f"{key}|{channel_count}"
+    return key
+
+
+def _reset_or_get_roller_tracker(key: str, channel_count: int | None):
+    tracker = _ROLLER_CHANNEL_POSITION_STATS.get(key)
+    if tracker is None or tracker.get("channel_count") != channel_count:
+        tracker = {
+            "channel_count": channel_count,
+            "counts": {},
+            "frames": 0,
+            "locked_source": None,
+        }
+        _ROLLER_CHANNEL_POSITION_STATS[key] = tracker
+    return tracker
+
+
+def _record_roller_channel_observations(
+    tracker: dict[str, Any],
+    channel_count: int | None,
+    channel_candidates: list[tuple[str, int | None]],
+):
+    if channel_count is None:
+        return tracker
+
+    in_range_seen = False
+    for source, candidate in channel_candidates:
+        if candidate is None:
+            continue
+        if 0 <= candidate < channel_count:
+            tracker["counts"][source] = tracker["counts"].get(source, 0) + 1
+            in_range_seen = True
+
+    if in_range_seen:
+        tracker["frames"] = tracker.get("frames", 0) + 1
+
+    if (
+        tracker.get("locked_source") is None
+        and tracker.get("frames", 0) >= _ROLLER_CHANNEL_LOCK_FRAMES
+        and tracker.get("counts")
+    ):
+        tracker["locked_source"] = max(
+            tracker["counts"].items(), key=lambda item: (item[1], item[0])
+        )[0]
+
+    return tracker
+
+
+def _prioritize_roller_channel_candidates(
+    channel_candidates: list[tuple[str, int | None]],
+    channel_count: int | None,
+    tracker: dict[str, Any],
+):
+    ordered = list(channel_candidates)
+    selection_reason = "original_order"
+    source_order = {source: idx for idx, (source, _) in enumerate(channel_candidates)}
+
+    locked_source = tracker.get("locked_source")
+    if locked_source:
+        locked_candidate = next(
+            (candidate for candidate in channel_candidates if candidate[0] == locked_source),
+            None,
+        )
+        if locked_candidate:
+            ordered = [locked_candidate] + [c for c in channel_candidates if c[0] != locked_source]
+            selection_reason = f"locked_source:{locked_source}"
+            return ordered, selection_reason
+
+    if channel_count is not None:
+        in_range_candidates = [
+            (source, candidate)
+            for source, candidate in channel_candidates
+            if candidate is not None and 0 <= candidate < channel_count
+        ]
+
+        if in_range_candidates:
+            if len(in_range_candidates) > 1:
+                in_range_candidates = sorted(
+                    in_range_candidates,
+                    key=lambda item: (
+                        -tracker.get("counts", {}).get(item[0], 0),
+                        source_order.get(item[0], 0),
+                    ),
+                )
+                selection_reason = "in_range_most_frequent"
+            else:
+                selection_reason = "single_in_range"
+
+            ordered = in_range_candidates + [
+                candidate for candidate in ordered if candidate not in in_range_candidates
+            ]
+            return ordered, selection_reason
+
+    return ordered, selection_reason
+
+
 def _channel_index_from_mask(
     channel_raw: int | None,
     channel_mapping: dict[int, str],
@@ -694,6 +804,8 @@ def _decode_roller(
     *,
     logical_channel_count: int | None = None,
     module_address: str | None = None,
+    raw_chunk_hex: str | None = None,
+    reversed_chunk_hex: str | None = None,
 ):
     # Roller frames reuse the normalized layout but fields can shift.
     # We therefore probe multiple candidate nibbles for key/mode and
@@ -749,53 +861,56 @@ def _decode_roller(
         module_address, "roller_module", logical_channel_count, coordinator_get_module_channels
     )
 
+    channel_key = _roller_tracker_key(module_address, channel_count)
+    tracker = _reset_or_get_roller_tracker(channel_key, channel_count)
+    tracker = _record_roller_channel_observations(tracker, channel_count, channel_candidates)
+
+    nibble_map = _extract_all_nibbles(raw_bytes)
+
     _LOGGER.debug(
-        "Channel count comparison | module_address=%s module_channel_count=%s button_channel_count=%s",
+        "Roller decode debug | module_address=%s module_channel_count=%s raw_chunk=%s reversed_chunk=%s button_address=%s push_button_address=%s nibbles=%s",
+        module_address,
+        channel_count,
+        raw_chunk_hex or payload_hex,
+        reversed_chunk_hex or payload_hex,
+        button_address,
+        push_button_address,
+        nibble_map,
+    )
+
+    _LOGGER.debug(
+        "Channel count comparison | module_address=%s module_channel_count=%s button_channel_count=%s tracker_frames=%s tracker_counts=%s tracker_locked=%s",
         module_address,
         channel_count,
         button_channel_count,
+        tracker.get("frames"),
+        tracker.get("counts"),
+        tracker.get("locked_source"),
     )
 
-    preferred = []
-    fallback = []
-    mode_candidates_for_channel = []
-
-    for source, candidate in channel_candidates:
-        if source == mode_source:
-            mode_candidates_for_channel.append((source, candidate))
-            continue
-
-        in_range = (
-            channel_count is not None
-            and candidate is not None
-            and 0 <= candidate < channel_count
-        )
-        (preferred if in_range else fallback).append((source, candidate))
-
-    reordered = preferred or []
-    reordered.extend(fallback)
-    reordered.extend(mode_candidates_for_channel)
-    channel_candidates = reordered or channel_candidates
+    ordered_channels, selection_reason = _prioritize_roller_channel_candidates(
+        channel_candidates, channel_count, tracker
+    )
 
     channel_raw = None
     channel_mask = None
     channel_source = None
 
-    for source, candidate in channel_candidates:
+    for source, candidate in ordered_channels:
         idx, mask = _channel_index_from_mask(candidate, channel_mapping, "roller_module")
         if idx is None:
             continue
-        if channel_count is None or idx < channel_count:
+        if channel_count is None or 0 <= idx < channel_count:
             channel_raw = idx
             channel_mask = mask
             channel_source = source
             break
 
-    if channel_raw is None and channel_candidates:
+    if channel_raw is None and ordered_channels:
         channel_raw, channel_mask = _channel_index_from_mask(
-            channel_candidates[0][1], channel_mapping, "roller_module"
+            ordered_channels[0][1], channel_mapping, "roller_module"
         )
-        channel_source = channel_candidates[0][0]
+        channel_source = ordered_channels[0][0]
 
     if channel_raw in {0xE, 0xF}:
         _LOGGER.debug(
@@ -839,14 +954,20 @@ def _decode_roller(
     )
 
     _LOGGER.debug(
-        "Channel extraction | raw_chunk=%s reversed_payload=%s candidates=%s selected=%s mask=%s channel_count=%s button_channel_count=%s",
+        "Channel extraction | raw_chunk=%s reversed_payload=%s candidates=%s ordered_candidates=%s selected=%s selected_source=%s mask=%s channel_count=%s button_channel_count=%s selection_reason=%s tracker_frames=%s tracker_locked=%s tracker_counts=%s",
         payload_hex,
         raw_bytes,
         channel_candidates,
+        ordered_channels,
         channel_raw,
+        channel_source,
         channel_mask,
         channel_count,
         button_channel_count,
+        selection_reason,
+        tracker.get("frames"),
+        tracker.get("locked_source"),
+        tracker.get("counts"),
     )
 
     _LOGGER.debug(
@@ -1179,6 +1300,8 @@ def decode_command_payload(
             raw_bytes,
             logical_channel_count=logical_channel_count,
             module_address=module_address,
+            raw_chunk_hex=raw_payload_hex,
+            reversed_chunk_hex=reversed_payload_hex,
         )
     elif module_type == "dimmer_module":
         decoded = _decode_dimmer(


### PR DESCRIPTION
## Summary
- add debug instrumentation for roller module decoding with nibble dumps and raw frame context
- track roller channel nibble stability and lock onto the most frequent in-range position
- base roller channel selection and validation on the deterministic locked nibble

## Testing
- pytest tests/test_protocol.py *(fails: ModuleNotFoundError: No module named 'homeassistant.util')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695983d622dc832ca864309b663be8b1)