### PR TITLE
Simplify dimmer timer decoding

### DIFF
--- a/custom_components/nikobus/discovery/dimmer_decoder.py
+++ b/custom_components/nikobus/discovery/dimmer_decoder.py
@@ -5,10 +5,9 @@ from typing import Any
 
 from ..const import DEVICE_INVENTORY
 from .base import DecodedCommand
-from .mapping import CHANNEL_MAPPING, DIMMER_MODE_MAPPING, DIMMER_TIMER_MAPPING, KEY_MAPPING_MODULE
+from .mapping import CHANNEL_MAPPING, DIMMER_MODE_MAPPING, KEY_MAPPING_MODULE
 from .protocol import (
     _build_dimmer_candidates,
-    _calculate_timer_values,
     convert_nikobus_address,
     get_button_address,
     get_push_button_address,
@@ -84,9 +83,8 @@ class DimmerDecoder:
         channel_label = CHANNEL_MAPPING.get(channel_raw, f"Unknown Channel ({channel_raw})")
         mode_label = DIMMER_MODE_MAPPING.get(mode_raw, f"Unknown Mode ({mode_raw})")
 
-        t1_val, t2_val = _calculate_timer_values(
-            "dimmer_module", mode_raw, t1_raw, t2_raw, {"dimmer_module": DIMMER_TIMER_MAPPING}
-        )
+        t1_val = None
+        t2_val = None
 
         return {
             "payload": payload_hex,

--- a/custom_components/nikobus/discovery/protocol.py
+++ b/custom_components/nikobus/discovery/protocol.py
@@ -415,14 +415,7 @@ def _calculate_timer_values(module_type, mode_raw, t1_raw, t2_raw, timer_mapping
         elif mode_raw in [1, 2]:
             t1_val = get_timer_value(timer_mapping.get(t1_raw, ["Unknown"]), 2)
     elif module_type == "dimmer_module":
-        if mode_raw in [0, 1, 2, 10, 11]:
-            t1_val = get_timer_value(timer_mapping.get(t1_raw, ["Unknown"]), 1)
-            t2_val = get_timer_value(timer_mapping.get(t2_raw, ["Unknown"]), 2)
-        elif mode_raw == 3:
-            t2_val = get_timer_value(timer_mapping.get(t2_raw, ["Unknown"]), 2)
-        elif mode_raw in [4, 5, 6, 7, 8, 9]:
-            t1_val = get_timer_value(timer_mapping.get(t1_raw, ["Unknown"]), 0)
-            t2_val = get_timer_value(timer_mapping.get(t2_raw, ["Unknown"]), 2)
+        return t1_val, t2_val
     elif module_type == "roller_module":
         t1_val = get_timer_value(timer_mapping.get(t1_raw, ["Unknown"]), 0)
 
@@ -776,12 +769,6 @@ def _build_dimmer_candidates(
         "t2_idx1_lo": _nibble_low(raw_bytes, 1),
         "t2_idx1_hi": _nibble_high(raw_bytes, 1),
     }
-
-    _LOGGER.debug(
-        "Dimmer timer nibble candidates | raw_bytes=%s | indexed=%s",
-        list(enumerate(raw_bytes)),
-        timers_indexed,
-    )
 
     key_options = [
         ("b3_hi", _nibble_high(raw_bytes, 3)),


### PR DESCRIPTION
## Summary
- stop decoding dimmer timer values and default T1/T2 to None when mapping is unknown
- remove verbose dimmer timer nibble logging while leaving channel, mode, and key handling untouched

## Testing
- pytest *(fails: missing `homeassistant` dependency in test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695abdc86aa4832c9945cc99439b41e0)