### PR TITLE
Simplify deterministic discovery decoding

### DIFF
--- a/custom_components/nikobus/discovery/chunk_decoder.py
+++ b/custom_components/nikobus/discovery/chunk_decoder.py
@@ -21,14 +21,10 @@ class BaseChunkingDecoder:
     def __init__(self, coordinator, module_type: str):
         self._coordinator = coordinator
         self.module_type = module_type
-        self._logical_channel_count: int | None = None
         self._module_address: str | None = None
 
     def can_handle(self, module_type: str) -> bool:
         return module_type == self.module_type
-
-    def set_logical_channel_count(self, channel_count: int | None) -> None:
-        self._logical_channel_count = channel_count
 
     def set_module_address(self, module_address: str | None) -> None:
         self._module_address = module_address
@@ -76,7 +72,6 @@ class BaseChunkingDecoder:
             self.module_type,
             self._coordinator,
             module_address=module_address or self._module_address,
-            logical_channel_count=self._logical_channel_count,
             reverse_before_decode=True,
             raw_chunk_hex=chunk,
         )

--- a/custom_components/nikobus/discovery/switch_decoder.py
+++ b/custom_components/nikobus/discovery/switch_decoder.py
@@ -41,7 +41,7 @@ def decode(payload_hex: str, raw_bytes: list[str], context) -> dict[str, Any] | 
 
     if _is_all_ff(payload_hex, 12):
         _LOGGER.debug(
-            "Discovery skipped | type=switch module=%s payload=%s reason=empty_slot",
+            "Discovery skipped | type=switch module=%s reason=empty_slot payload=%s",
             context.module_address,
             payload_hex,
         )
@@ -49,7 +49,7 @@ def decode(payload_hex: str, raw_bytes: list[str], context) -> dict[str, Any] | 
 
     if len(raw_bytes) != 6:
         _LOGGER.debug(
-            "Discovery skipped | type=switch module=%s payload=%s reason=invalid_length",
+            "Discovery skipped | type=switch module=%s reason=invalid_length payload=%s",
             context.module_address,
             payload_hex,
         )
@@ -63,7 +63,7 @@ def decode(payload_hex: str, raw_bytes: list[str], context) -> dict[str, Any] | 
 
     if None in (key_raw, channel_raw, mode_raw):
         _LOGGER.debug(
-            "Discovery skipped | type=switch module=%s payload=%s reason=invalid_length",
+            "Discovery skipped | type=switch module=%s reason=invalid_length payload=%s",
             context.module_address,
             payload_hex,
         )
@@ -71,16 +71,19 @@ def decode(payload_hex: str, raw_bytes: list[str], context) -> dict[str, Any] | 
 
     if mode_raw not in SWITCH_MODE_MAPPING:
         _LOGGER.debug(
-            "Discovery skipped | type=switch module=%s payload=%s reason=unknown_mode",
+            "Discovery skipped | type=switch module=%s reason=unknown_mode payload=%s",
             context.module_address,
             payload_hex,
         )
         return None
 
     channel_count = context.module_channel_count
-    if channel_count is not None and not (0 <= channel_raw < channel_count):
+    channel_decoded = channel_raw + 1 if channel_raw is not None else None
+    if channel_count is not None and (
+        channel_decoded is None or not (1 <= channel_decoded <= channel_count)
+    ):
         _LOGGER.debug(
-            "Discovery skipped | type=switch module=%s payload=%s reason=invalid_channel",
+            "Discovery skipped | type=switch module=%s reason=invalid_channel payload=%s",
             context.module_address,
             payload_hex,
         )
@@ -101,25 +104,24 @@ def decode(payload_hex: str, raw_bytes: list[str], context) -> dict[str, Any] | 
         "push_button_address": push_button_address,
         "key_raw": key_raw,
         "channel_raw": channel_raw,
+        "channel": channel_decoded,
         "mode_raw": mode_raw,
         "t1_raw": t1_raw,
         "t2_raw": t2_raw,
         "K": key_raw,
-        "C": _format_channel(channel_raw),
+        "C": _format_channel(channel_decoded),
         "T1": t1_val,
         "T2": t2_val,
         "M": SWITCH_MODE_MAPPING.get(mode_raw),
     }
 
     _LOGGER.debug(
-        "Discovery decoded | type=switch module=%s button=%s key=%s channel=%s mode=%s t1=%s t2=%s",
+        "Discovery decoded | type=switch module=%s button=%s key=%s channel=%s mode=%s",
         context.module_address,
         normalized_button,
         key_raw,
-        decoded["C"],
+        decoded["channel"],
         decoded["M"],
-        t1_val,
-        t2_val,
     )
 
     return decoded
@@ -135,7 +137,6 @@ class SwitchDecoder(BaseChunkingDecoder):
             self.module_type,
             self._coordinator,
             module_address=module_address or self._module_address,
-            logical_channel_count=self._logical_channel_count,
             reverse_before_decode=True,
             raw_chunk_hex=chunk,
         )

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,325 +1,68 @@
 import logging
+
 import pytest
 
-from custom_components.nikobus.discovery.discovery import add_to_command_mapping
-from custom_components.nikobus.discovery.mapping import (
-    CHANNEL_MAPPING,
-    DIMMER_MODE_MAPPING,
-    DIMMER_TIMER_MAPPING,
-    KEY_MAPPING_MODULE,
-    SWITCH_MODE_MAPPING,
-    SWITCH_TIMER_MAPPING,
+from custom_components.nikobus.discovery.protocol import decode_command_payload
+
+
+class DummyCoordinator:
+    def __init__(self, channels: int = 4):
+        self._channels = channels
+
+    def get_module_channel_count(self, module_address: str | None) -> int:
+        return self._channels
+
+    def get_button_channels(self, button_address: str) -> int:
+        return 4
+
+
+@pytest.mark.parametrize(
+    "payload,module_type",
+    [
+        ("FFFFFFFFFFFF", "switch_module"),
+        ("FFFFFFFFFFFF", "roller_module"),
+        ("FFFFFFFFFFFFFFFF", "dimmer_module"),
+    ],
 )
-from custom_components.nikobus.discovery.protocol import (
-    convert_nikobus_address,
-    decode_command_payload,
-    _DIMMER_CANDIDATE_SUCCESS,
-)
-
-
-MODE_MAPPINGS = {
-    "switch_module": SWITCH_MODE_MAPPING,
-    "dimmer_module": DIMMER_MODE_MAPPING,
-}
-
-TIMER_MAPPINGS = {
-    "switch_module": SWITCH_TIMER_MAPPING,
-    "dimmer_module": DIMMER_TIMER_MAPPING,
-}
-
-
-def _get_channels(_):
-    return 4
-
-
-def _get_eight_channels(_):
-    return 8
-
-
-@pytest.fixture(autouse=True)
-def reset_candidate_success():
-    _DIMMER_CANDIDATE_SUCCESS.clear()
-    yield
-    _DIMMER_CANDIDATE_SUCCESS.clear()
-
-
-def test_decode_skips_terminator_and_filler_records():
+def test_all_ff_payloads_are_skipped(payload, module_type):
     assert (
-        decode_command_payload(
-            "FFFFFFFFFFFF",
-            "switch_module",
-            KEY_MAPPING_MODULE,
-            CHANNEL_MAPPING,
-            MODE_MAPPINGS,
-            TIMER_MAPPINGS,
-            _get_channels,
-            convert_nikobus_address,
-        )
-        is None
-    )
-
-    assert (
-        decode_command_payload(
-            "00F000000001",
-            "switch_module",
-            KEY_MAPPING_MODULE,
-            CHANNEL_MAPPING,
-            MODE_MAPPINGS,
-            TIMER_MAPPINGS,
-            _get_channels,
-            convert_nikobus_address,
-        )
-        is None
-    )
-
-    assert (
-        decode_command_payload(
-            "001000FFFFFF",
-            "switch_module",
-            KEY_MAPPING_MODULE,
-            CHANNEL_MAPPING,
-            MODE_MAPPINGS,
-            TIMER_MAPPINGS,
-            _get_channels,
-            convert_nikobus_address,
-        )
+        decode_command_payload(payload, module_type, DummyCoordinator(), module_address="C9A5")
         is None
     )
 
 
-def test_decode_valid_record():
+def test_switch_channel_is_decoded_with_offset():
     decoded = decode_command_payload(
-        "001000000001",
-        "switch_module",
-        KEY_MAPPING_MODULE,
-        CHANNEL_MAPPING,
-        MODE_MAPPINGS,
-        TIMER_MAPPINGS,
-        _get_channels,
-        convert_nikobus_address,
+        "001000000001", "switch_module", DummyCoordinator(channels=4), module_address="C9A5"
     )
 
     assert decoded is not None
-    assert decoded["key_raw"] == 1
-    assert decoded["channel_raw"] == 0
-    assert decoded["push_button_address"] is not None
+    assert decoded["channel"] == 1
+    assert decoded["M"].startswith("M01")
 
 
-def test_command_mapping_supports_one_to_many_and_deduplication():
-    first = decode_command_payload(
-        "001000000001",
-        "switch_module",
-        KEY_MAPPING_MODULE,
-        CHANNEL_MAPPING,
-        MODE_MAPPINGS,
-        TIMER_MAPPINGS,
-        _get_channels,
-        convert_nikobus_address,
-    )
-
-    second = decode_command_payload(
-        "001200000001",
-        "switch_module",
-        KEY_MAPPING_MODULE,
-        CHANNEL_MAPPING,
-        MODE_MAPPINGS,
-        TIMER_MAPPINGS,
-        _get_channels,
-        convert_nikobus_address,
-    )
-
-    mapping = {}
-    assert first is not None
-    assert second is not None
-    add_to_command_mapping(mapping, first, "C9A5")
-    add_to_command_mapping(mapping, second, "C9A5")
-    add_to_command_mapping(mapping, first, "C9A5")
-
-    key = (first["push_button_address"], first["key_raw"])
-    assert key in mapping
-    assert len(mapping[key]) == 2
-    assert mapping[key][0]["channel"] == 1
-    assert mapping[key][1]["channel"] == 3
-
-
-def test_decode_handles_reversed_and_missing_mappings(caplog):
-    caplog.set_level(logging.DEBUG)
-
-    assert (
-        decode_command_payload(
-            "FFFFFFFFFF08",
-            "switch_module",
-            KEY_MAPPING_MODULE,
-            CHANNEL_MAPPING,
-            MODE_MAPPINGS,
-            TIMER_MAPPINGS,
-            _get_channels,
-            convert_nikobus_address,
-        )
-        is None
-    )
-
-    assert (
-        decode_command_payload(
-            "FFFFFFFFFF08",
-            "switch_module",
-            KEY_MAPPING_MODULE,
-            CHANNEL_MAPPING,
-            MODE_MAPPINGS,
-            TIMER_MAPPINGS,
-            _get_channels,
-            convert_nikobus_address,
-        )
-        is None
-    )
-
-    assert (
-        decode_command_payload(
-            "00F000000001",
-            "switch_module",
-            KEY_MAPPING_MODULE,
-            CHANNEL_MAPPING,
-            MODE_MAPPINGS,
-            TIMER_MAPPINGS,
-            _get_channels,
-            convert_nikobus_address,
-        )
-        is None
-    )
-
-    caplog.clear()
+def test_switch_invalid_channel_is_rejected():
     decoded = decode_command_payload(
-        "00D000000001",
-        "switch_module",
-        KEY_MAPPING_MODULE,
-        CHANNEL_MAPPING,
-        MODE_MAPPINGS,
-        TIMER_MAPPINGS,
-        _get_channels,
-        convert_nikobus_address,
+        "001500000001", "switch_module", DummyCoordinator(channels=2), module_address="C9A5"
     )
 
     assert decoded is None
-    warnings = [record for record in caplog.records if record.levelno >= logging.WARNING]
-    assert warnings
 
 
-def test_dimmer_decoder_uses_byte_based_candidates():
-    payload = "0BB4021305787234"
-
+def test_roller_channel_mapping_halves_output_space():
     decoded = decode_command_payload(
-        payload,
-        "dimmer_module",
-        KEY_MAPPING_MODULE,
-        CHANNEL_MAPPING,
-        MODE_MAPPINGS,
-        TIMER_MAPPINGS,
-        _get_eight_channels,
-        convert_nikobus_address,
+        "002001000001", "roller_module", DummyCoordinator(channels=3), module_address="C9A5"
     )
 
     assert decoded is not None
-    assert decoded["key_raw"] in range(0, 8)
-    assert decoded["channel_raw"] in range(0, 12)
-    assert decoded["mode_raw"] in DIMMER_MODE_MAPPING
-    assert decoded["push_button_address"] is not None
+    assert decoded["channel"] == 1
 
 
-def test_normalizes_prefixed_dimmer_payload():
-    payload = "FF08F4AC5440"
-
+def test_dimmer_decoding_uses_fixed_offsets():
     decoded = decode_command_payload(
-        payload,
-        "dimmer_module",
-        KEY_MAPPING_MODULE,
-        CHANNEL_MAPPING,
-        MODE_MAPPINGS,
-        TIMER_MAPPINGS,
-        _get_eight_channels,
-        convert_nikobus_address,
+        "0BB4021305787234", "dimmer_module", DummyCoordinator(channels=8), module_address="C9A5"
     )
 
     assert decoded is not None
-    assert decoded["key_raw"] in range(0, 8)
-    assert decoded["channel_raw"] in range(0, 8)
-
-
-def test_non_dimmer_payload_unchanged_after_normalization():
-    payload = "001000000001"
-
-    decoded = decode_command_payload(
-        payload,
-        "switch_module",
-        KEY_MAPPING_MODULE,
-        CHANNEL_MAPPING,
-        MODE_MAPPINGS,
-        TIMER_MAPPINGS,
-        _get_channels,
-        convert_nikobus_address,
-    )
-
-    assert decoded is not None
+    assert decoded["channel"] == 4
     assert decoded["key_raw"] == 1
-    assert decoded["channel_raw"] == 0
-
-
-def test_validation_rejects_invalid_channel(caplog):
-    caplog.set_level(logging.WARNING)
-
-    payload = "009909000001"
-    decoded = decode_command_payload(
-        payload,
-        "switch_module",
-        KEY_MAPPING_MODULE,
-        CHANNEL_MAPPING,
-        MODE_MAPPINGS,
-        TIMER_MAPPINGS,
-        _get_channels,
-        convert_nikobus_address,
-    )
-
-    assert decoded is None
-    warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
-    assert warnings
-
-
-def test_raw_chunk_channel_bitmask_resolves_within_range():
-    payload = "080835987A74"
-
-    decoded = decode_command_payload(
-        payload,
-        "switch_module",
-        KEY_MAPPING_MODULE,
-        CHANNEL_MAPPING,
-        MODE_MAPPINGS,
-        TIMER_MAPPINGS,
-        _get_channels,
-        convert_nikobus_address,
-        reverse_before_decode=True,
-        raw_chunk_hex=payload,
-    )
-
-    assert decoded is not None
-    assert decoded["channel_raw"] == 10
-    assert decoded.get("C") == CHANNEL_MAPPING[decoded["channel_raw"]]
-    assert decoded.get("channel_mask") is None
-
-
-def test_raw_chunk_channel_bitmask_supports_eight_channel_modules():
-    payload = "080835987A74"
-
-    decoded = decode_command_payload(
-        payload,
-        "switch_module",
-        KEY_MAPPING_MODULE,
-        CHANNEL_MAPPING,
-        MODE_MAPPINGS,
-        TIMER_MAPPINGS,
-        _get_eight_channels,
-        convert_nikobus_address,
-        reverse_before_decode=True,
-        raw_chunk_hex=payload,
-    )
-
-    assert decoded is not None
-    assert decoded["channel_raw"] == 10


### PR DESCRIPTION
## Summary
- align switch, roller, and dimmer decoders to fixed byte offsets with deterministic channel math
- streamline discovery orchestration and logging to single-line summaries
- refresh discovery protocol helpers and tests for the deterministic decoding rules

## Testing
- pytest -q (fails: missing homeassistant.util dependency in test environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ac5556794832cae43b5d82da8a67b)