### PR TITLE
Refine discovery decoding lifecycle

### DIFF
--- a/custom_components/nikobus/discovery/dimmer_decoder.py
+++ b/custom_components/nikobus/discovery/dimmer_decoder.py
@@ -115,9 +115,13 @@ class DimmerDecoder:
 
     def __init__(self, coordinator):
         self._coordinator = coordinator
+        self._module_channel_count: int | None = None
 
     def can_handle(self, module_type: str) -> bool:
         return module_type == self.module_type
+
+    def set_module_channel_count(self, module_channel_count: int | None) -> None:
+        self._module_channel_count = module_channel_count
 
     def _chunk_from_message(self, message: str) -> tuple[str | None, str | None, str | None]:
         matched_header = next((candidate for candidate in DEVICE_INVENTORY if message.startswith(candidate)), None)
@@ -166,6 +170,7 @@ class DimmerDecoder:
             module_address=address,
             reverse_before_decode=False,
             raw_chunk_hex=chunk_hex,
+            module_channel_count=self._module_channel_count,
         )
 
         if decoded_fields is None:

--- a/custom_components/nikobus/discovery/fileio.py
+++ b/custom_components/nikobus/discovery/fileio.py
@@ -274,7 +274,11 @@ async def update_module_data(hass, discovered_devices):
         return candidate
 
     def _refresh_discovered_info(channels_count: int, device: dict) -> dict:
-        timestamp = device.get("last_seen") or dt_util.now().isoformat()
+        timestamp = (
+            device.get("last_discovered")
+            or device.get("last_seen")
+            or dt_util.now().isoformat()
+        )
         discovery_info = {
             "name": device.get("discovered_name") or device.get("description", ""),
             "device_type": device.get("device_type"),

--- a/custom_components/nikobus/discovery/shutter_decoder.py
+++ b/custom_components/nikobus/discovery/shutter_decoder.py
@@ -5,14 +5,12 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from .base import DecodedCommand
 from .chunk_decoder import BaseChunkingDecoder
 from .mapping import ROLLER_MODE_MAPPING, ROLLER_TIMER_MAPPING
 from .protocol import (
     _format_channel,
     _is_all_ff,
     _safe_int,
-    decode_command_payload,
     get_button_address,
     get_push_button_address,
 )
@@ -68,7 +66,8 @@ def decode(payload_hex: str, raw_bytes: list[str], context) -> dict[str, Any] | 
         )
         return None
 
-    selector = selector_byte & 0x0F
+    selector = selector_byte & 0x7F
+    channel_raw = selector
     channel_decoded = (selector // 2) + 1
     channel_count = context.module_channel_count
     if channel_count is not None and not (1 <= channel_decoded <= channel_count):
@@ -79,7 +78,6 @@ def decode(payload_hex: str, raw_bytes: list[str], context) -> dict[str, Any] | 
         )
         return None
 
-    channel_raw = channel_decoded
     button_address = get_button_address(payload_hex[-6:])
     push_button_address, normalized_button = get_push_button_address(
         key_raw,
@@ -121,34 +119,6 @@ def decode(payload_hex: str, raw_bytes: list[str], context) -> dict[str, Any] | 
 class ShutterDecoder(BaseChunkingDecoder):
     def __init__(self, coordinator):
         super().__init__(coordinator, "roller_module")
-
-    def decode_chunk(self, chunk: str, module_address: str | None = None) -> list[DecodedCommand]:
-        decoded = decode_command_payload(
-            chunk,
-            self.module_type,
-            self._coordinator,
-            module_address=module_address or self._module_address,
-            reverse_before_decode=True,
-            raw_chunk_hex=chunk,
-        )
-
-        if decoded is None:
-            _LOGGER.debug(
-                "Discovery skipped | type=roller module=%s payload=%s reason=empty_slot",
-                module_address or self._module_address,
-                chunk,
-            )
-            return []
-
-        command = DecodedCommand(
-            module_type=self.module_type,
-            raw_message=chunk,
-            prefix_hex=None,
-            chunk_hex=chunk,
-            payload_hex=chunk,
-            metadata=decoded,
-        )
-        return [command]
 
 
 __all__ = ["ShutterDecoder", "decode"]

--- a/custom_components/nikobus/discovery/switch_decoder.py
+++ b/custom_components/nikobus/discovery/switch_decoder.py
@@ -5,14 +5,12 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from .base import DecodedCommand
 from .chunk_decoder import BaseChunkingDecoder
 from .mapping import SWITCH_MODE_MAPPING, SWITCH_TIMER_MAPPING
 from .protocol import (
     _format_channel,
     _is_all_ff,
     _safe_int,
-    decode_command_payload,
     get_button_address,
     get_push_button_address,
 )
@@ -130,34 +128,6 @@ def decode(payload_hex: str, raw_bytes: list[str], context) -> dict[str, Any] | 
 class SwitchDecoder(BaseChunkingDecoder):
     def __init__(self, coordinator):
         super().__init__(coordinator, "switch_module")
-
-    def decode_chunk(self, chunk: str, module_address: str | None = None) -> list[DecodedCommand]:
-        decoded = decode_command_payload(
-            chunk,
-            self.module_type,
-            self._coordinator,
-            module_address=module_address or self._module_address,
-            reverse_before_decode=True,
-            raw_chunk_hex=chunk,
-        )
-
-        if decoded is None:
-            _LOGGER.debug(
-                "Discovery skipped | type=switch module=%s payload=%s reason=empty_slot",
-                module_address or self._module_address,
-                chunk,
-            )
-            return []
-
-        command = DecodedCommand(
-            module_type=self.module_type,
-            raw_message=chunk,
-            prefix_hex=None,
-            chunk_hex=chunk,
-            payload_hex=chunk,
-            metadata=decoded,
-        )
-        return [command]
 
 
 __all__ = ["SwitchDecoder", "decode"]


### PR DESCRIPTION
## Summary
- adjust discovery lifecycle to finalize only after real completion or timeout and remove noisy logging
- standardize payload handling across switch/roller/dimmer decoders and tighten deterministic channel decoding
- update discovery metadata to use last_discovered timestamps and fallback channel counts for validation

## Testing
- python -m compileall custom_components/nikobus/discovery

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aca3f04ac832cb658042cb8b63e52)