### PR TITLE
Refine deterministic discovery decoding

### DIFF
--- a/custom_components/nikobus/discovery/dimmer_decoder.py
+++ b/custom_components/nikobus/discovery/dimmer_decoder.py
@@ -98,7 +98,7 @@ def decode(payload_hex: str, raw_bytes: list[str], context) -> dict[str, Any] | 
         "M": DIMMER_MODE_MAPPING.get(mode_raw),
     }
 
-    _LOGGER.debug(
+    _LOGGER.info(
         "Discovery decoded | type=dimmer module=%s button=%s key=%s channel=%s mode=%s",
         context.module_address,
         normalized_button,

--- a/custom_components/nikobus/discovery/protocol.py
+++ b/custom_components/nikobus/discovery/protocol.py
@@ -136,11 +136,10 @@ def get_push_button_address(
         except Exception:  # pragma: no cover - defensive
             num_channels = None
 
-    fallback_count = num_channels or 4
-    mapping = KEY_MAPPING_MODULE.get(fallback_count, {})
-    if not mapping:
-        mapping = next(iter(KEY_MAPPING_MODULE.values()), {})
+    if num_channels is None or num_channels not in KEY_MAPPING_MODULE:
+        return None, button_address
 
+    mapping = KEY_MAPPING_MODULE[num_channels]
     if key_index not in mapping:
         return None, button_address
 
@@ -183,7 +182,7 @@ def decode_command_payload(
     if raw_bytes is None:
         return None
 
-    resolved_channel_count: int | None = module_channel_count
+    resolved_channel_count: int | None = None
     coordinator_count: int | None = None
     if coordinator and module_address:
         try:
@@ -194,14 +193,13 @@ def decode_command_payload(
             )
 
     fallback_reason: str | None = None
-    if coordinator_count:
+    if coordinator_count is not None:
         resolved_channel_count = coordinator_count
-    elif module_channel_count:
+    elif module_channel_count is not None:
         resolved_channel_count = module_channel_count
         fallback_reason = "inventory"
     else:
-        resolved_channel_count = 12
-        fallback_reason = "default"
+        fallback_reason = "unknown"
 
     if (
         fallback_reason

--- a/custom_components/nikobus/discovery/shutter_decoder.py
+++ b/custom_components/nikobus/discovery/shutter_decoder.py
@@ -104,7 +104,7 @@ def decode(payload_hex: str, raw_bytes: list[str], context) -> dict[str, Any] | 
         "M": ROLLER_MODE_MAPPING.get(mode_raw),
     }
 
-    _LOGGER.debug(
+    _LOGGER.info(
         "Discovery decoded | type=roller module=%s button=%s key=%s channel=%s mode=%s",
         context.module_address,
         normalized_button,

--- a/custom_components/nikobus/discovery/switch_decoder.py
+++ b/custom_components/nikobus/discovery/switch_decoder.py
@@ -113,7 +113,7 @@ def decode(payload_hex: str, raw_bytes: list[str], context) -> dict[str, Any] | 
         "M": SWITCH_MODE_MAPPING.get(mode_raw),
     }
 
-    _LOGGER.debug(
+    _LOGGER.info(
         "Discovery decoded | type=switch module=%s button=%s key=%s channel=%s mode=%s",
         context.module_address,
         normalized_button,


### PR DESCRIPTION
## Summary
- simplify channel count resolution and avoid heuristic defaults during discovery decode
- tighten push button address resolution to only use known button channel mappings
- standardize decoder logging to a single INFO line per decoded command using deterministic channel rules

## Testing
- pytest *(fails: missing `homeassistant` package for discovery tests in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695acd1987a8832c896ad3c95a3f8860)