### PR TITLE
Normalize discovery module addresses and skip non-output scans

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -265,7 +265,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
         """Process feedback data from Nikobus."""
         try:
             module_address_raw = data[3:7]
-            module_address = module_address_raw[2:] + module_address_raw[:2]
+            module_address = (module_address_raw[2:] + module_address_raw[:2]).upper()
             module_type = self.get_module_type(module_address)
             module_state_raw = data[9:21]
 
@@ -411,6 +411,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
 
     def get_module_type(self, module_id: str) -> str:
         """Determine the module type based on the module ID."""
+        module_id = (module_id or "").upper()
         for module_type, modules in self.dict_module_data.items():
             if module_id in modules:
                 return module_type
@@ -418,6 +419,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
         return "unknown"
 
     def get_module_channel_count(self, module_id: str) -> int:
+        module_id = (module_id or "").upper()
         for modules in self.dict_module_data.values():
             if module_id in modules:
                 module_data = modules[module_id]

--- a/custom_components/nikobus/nkblistener.py
+++ b/custom_components/nikobus/nkblistener.py
@@ -159,7 +159,12 @@ class NikobusEventListener:
         if DEVICE_ADDRESS_INVENTORY in message:
             _LOGGER.debug("Device address inventory: %s", message)
             if discovery_running:
-                await self.nikobus_discovery.query_module_inventory(message[3:7])
+                module_address = self.nikobus_discovery.normalize_module_address(
+                    message[3:7],
+                    source="device_address_inventory",
+                    reverse_bus_order=True,
+                )
+                await self.nikobus_discovery.query_module_inventory(module_address)
             else:
                 await self.nikobus_discovery.process_mode_button_press(message)
             return


### PR DESCRIPTION
## Summary
- normalize module addresses received during discovery and log canonicalization
- ensure coordinator lookups use canonical addresses and avoid register scans for non-output modules
- keep device address inventory handling consistent for manual discovery flows

## Testing
- python -m pytest tests/test_discovery_chunking.py *(fails: missing `homeassistant` test dependency)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ae23b3210832cac6675212d5ab445)