### PR TITLE
Fix inventory discovery handling

### DIFF
--- a/custom_components/nikobus/discovery/discovery.py
+++ b/custom_components/nikobus/discovery/discovery.py
@@ -353,6 +353,9 @@ class NikobusDiscovery:
                 normalized_address,
                 self._module_type,
             )
+            if self.discovery_stage == "inventory":
+                return
+
             await self._finalize_discovery(normalized_address)
             return
 
@@ -364,8 +367,8 @@ class NikobusDiscovery:
     async def parse_inventory_response(self, payload):
         try:
             self.discovery_stage = self.discovery_stage or "inventory"
-            if payload.startswith("$0510$"):
-                payload = payload[6:]
+            if payload.startswith("$") and "$" in payload[1:]:
+                payload = payload.split("$")[-1]
             payload = payload.lstrip("$")
             payload_bytes = bytes.fromhex(payload)
             data_bytes = payload_bytes[2:18] if len(payload_bytes) >= 18 else payload_bytes[2:]

--- a/custom_components/nikobus/nkblistener.py
+++ b/custom_components/nikobus/nkblistener.py
@@ -159,6 +159,7 @@ class NikobusEventListener:
         if DEVICE_ADDRESS_INVENTORY in message:
             _LOGGER.debug("Device address inventory: %s", message)
             if discovery_running:
+                self.nikobus_discovery._schedule_inventory_timeout()
                 module_address = self.nikobus_discovery.normalize_module_address(
                     message[3:7],
                     source="device_address_inventory",


### PR DESCRIPTION
## Summary
- keep inventory discovery running for non-output modules when collecting broadcast responses
- refresh the inventory timeout when processing broadcast address frames and make inventory parsing tolerate different prefixes

## Testing
- pytest tests/test_discovery_chunking.py *(fails: missing `homeassistant` dependency in test environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aedf2a4b4832c92fec2ba2deb3927)