### PR TITLE
Improve PC Link inventory handling

### DIFF
--- a/custom_components/nikobus/nkblistener.py
+++ b/custom_components/nikobus/nkblistener.py
@@ -159,13 +159,7 @@ class NikobusEventListener:
         if DEVICE_ADDRESS_INVENTORY in message:
             _LOGGER.debug("Device address inventory: %s", message)
             if discovery_running:
-                self.nikobus_discovery._schedule_inventory_timeout()
-                module_address = self.nikobus_discovery.normalize_module_address(
-                    message[3:7],
-                    source="device_address_inventory",
-                    reverse_bus_order=True,
-                )
-                await self.nikobus_discovery.query_module_inventory(module_address)
+                self.nikobus_discovery.handle_device_address_inventory(message)
             else:
                 await self.nikobus_discovery.process_mode_button_press(message)
             return


### PR DESCRIPTION
## Summary
- add a dedicated handler to collect PC Link inventory addresses and reschedule timeouts
- run identity queries from collected inventory addresses before starting register scans
- update logging and listener wiring to reflect the PC Link inventory phase

## Testing
- `python -m pytest tests/test_discovery_chunking.py` *(fails: missing homeassistant dependency in test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b8ad1eae0832c92bcd87502fc7f7a)