### PR TITLE
Handle list-based module entries during coordinator setup

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -115,7 +115,25 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
 
                 # Initialize module state tracking dynamically based on channels
                 for modules in self.dict_module_data.values():
-                    for address, module_info in modules.items():
+                    if isinstance(modules, dict):
+                        module_items = modules.items()
+                    elif isinstance(modules, list):
+                        module_items = (
+                            (module.get("address"), module) for module in modules
+                        )
+                    else:
+                        _LOGGER.warning(
+                            "Unsupported module data type: %s", type(modules)
+                        )
+                        continue
+
+                    for address, module_info in module_items:
+                        if not address:
+                            _LOGGER.warning(
+                                "Skipping module entry without address: %s",
+                                module_info,
+                            )
+                            continue
                         channels = module_info.get("channels", [])
                         self.nikobus_module_states[address] = bytearray(len(channels))
 


### PR DESCRIPTION
### Motivation
- Fix the `AttributeError: 'list' object has no attribute 'items'` raised during `connect` when `nikobus_module_config.json` contains list-form module entries.
- Ensure the coordinator initializes `nikobus_module_states` correctly regardless of whether module data is a `dict` or a `list`.
- Avoid startup crashes by skipping invalid entries and emitting warnings for unsupported data shapes.

### Description
- Update `custom_components/nikobus/coordinator.py` to detect whether `modules` is a `dict` or a `list` and produce `(address, module)` pairs for iteration.
- Convert list entries into `(module.get("address"), module)` pairs and skip entries that lack an `address` while logging a warning.
- Log and skip unsupported `modules` data types instead of assuming `.items()` is present.
- Continue to allocate `bytearray` per module using the `channels` length from the module info.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963f9825424832c9e3a6a783cdc8787)