### PR TITLE
Centralize Nikobus channel -> entity routing and refactor platforms

### DIFF
--- a/custom_components/nikobus/router.py
+++ b/custom_components/nikobus/router.py
@@ -1,0 +1,157 @@
+"""Entity routing for Nikobus module channels."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import Any, Mapping
+
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+_ROUTING_CACHE_KEY = "routing"
+
+
+@dataclass(frozen=True)
+class EntitySpec:
+    """Route a Nikobus channel to a specific Home Assistant domain and kind."""
+
+    domain: str
+    kind: str
+    address: str
+    channel: int
+    channel_description: str
+    module_desc: str
+    module_model: str
+    operation_time: str | None = None
+
+
+def build_unique_id(domain: str, kind: str, address: str, channel: int) -> str:
+    """Build a unique_id that includes domain and kind to avoid collisions."""
+
+    return f"{DOMAIN}_{domain}_{kind}_{address}_{channel}"
+
+
+def get_routing(
+    hass: HomeAssistant, entry: ConfigEntry, dict_module_data: Mapping[str, Any]
+) -> dict[str, list[EntitySpec]]:
+    """Return cached routing data for the config entry."""
+
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    entry_data = domain_data.setdefault(entry.entry_id, {})
+    routing = entry_data.get(_ROUTING_CACHE_KEY)
+    if routing is None:
+        routing = build_routing(dict_module_data)
+        entry_data[_ROUTING_CACHE_KEY] = routing
+    return routing
+
+
+def build_routing(
+    dict_module_data: Mapping[str, Any],
+) -> dict[str, list[EntitySpec]]:
+    """Build routing decisions for all Nikobus modules.
+
+    Routing decisions are centralized to ensure exactly one entity per channel,
+    independent of platform setup order. The per-channel entity_type is resolved
+    using (in priority order) explicit entity_type, legacy use_as_* flags, then
+    module defaults.
+    """
+
+    routing: dict[str, list[EntitySpec]] = {"cover": [], "switch": [], "light": []}
+
+    for module_type, modules in dict_module_data.items():
+        for address, module_data in modules.items():
+            module_desc = module_data.get("description", f"Module {address}")
+            module_model = module_data.get("model", "Unknown Module Model")
+
+            for channel_index, channel_info in enumerate(
+                module_data.get("channels", []), start=1
+            ):
+                channel_description = channel_info.get("description", "")
+                if channel_description.startswith("not_in_use"):
+                    continue
+
+                entity_type = _resolve_entity_type(module_type, channel_info)
+                domain, kind = _map_entity_type(module_type, entity_type)
+
+                routing[domain].append(
+                    EntitySpec(
+                        domain=domain,
+                        kind=kind,
+                        address=address,
+                        channel=channel_index,
+                        channel_description=channel_description,
+                        module_desc=module_desc,
+                        module_model=module_model,
+                        operation_time=channel_info.get("operation_time"),
+                    )
+                )
+
+    return routing
+
+
+def _resolve_entity_type(module_type: str, channel_info: Mapping[str, Any]) -> str:
+    """Resolve the desired entity_type for a channel."""
+
+    explicit_type = channel_info.get("entity_type")
+    if explicit_type:
+        if _is_supported_entity_type(module_type, explicit_type):
+            return explicit_type
+        _LOGGER.warning(
+            "Unsupported entity_type '%s' for module '%s'; falling back to defaults.",
+            explicit_type,
+            module_type,
+        )
+
+    if channel_info.get("use_as_switch", False):
+        return "switch"
+    if channel_info.get("use_as_light", False):
+        return "light"
+
+    if module_type == "roller_module":
+        return "cover"
+    if module_type == "switch_module":
+        return "switch"
+    if module_type == "dimmer_module":
+        return "light"
+
+    return "switch"
+
+
+def _is_supported_entity_type(module_type: str, entity_type: str) -> bool:
+    """Validate entity_type values against module capabilities."""
+
+    if module_type == "roller_module":
+        return entity_type in {"cover", "switch", "light"}
+    if module_type == "switch_module":
+        return entity_type in {"switch", "light"}
+    if module_type == "dimmer_module":
+        return entity_type == "light"
+    return entity_type in {"switch", "light", "cover"}
+
+
+def _map_entity_type(module_type: str, entity_type: str) -> tuple[str, str]:
+    """Map module type + entity_type to domain and semantic control kind."""
+
+    if module_type == "dimmer_module":
+        return "light", "dimmer_light"
+
+    if module_type == "roller_module":
+        if entity_type == "cover":
+            return "cover", "cover"
+        return ("light", "cover_binary") if entity_type == "light" else (
+            "switch",
+            "cover_binary",
+        )
+
+    if module_type == "switch_module":
+        return ("light", "relay_switch") if entity_type == "light" else (
+            "switch",
+            "relay_switch",
+        )
+
+    return "switch", "relay_switch"


### PR DESCRIPTION
### Motivation
- Replace ad-hoc cross-platform `use_as_switch` logic with a single routing mechanism to ensure exactly one Home Assistant entity per physical Nikobus channel.  
- Support flexible per-channel target types (`cover`, `switch`, `light`) while preserving legacy flags (`use_as_switch`, `use_as_light`) and allowing a new `entity_type` field.  
- Remove platform ordering and cross-export coupling so platform setup order no longer affects created entities.  
- Make the design extensible for future entity kinds (e.g. `fan`) and avoid duplicate unique_id collisions across domains/kinds.  

### Description
- Add `custom_components/nikobus/router.py` implementing `EntitySpec`, `build_routing`, `get_routing`, and `build_unique_id` to centralize routing decisions and cache per-config-entry routing.  
- Refactor `cover.py` to consume routing via `get_routing` and create cover entities only for entries in `routing['cover']`, and remove the previous export into `hass.data[DOMAIN]['switch_entities']`.  
- Refactor `switch.py` to consume `routing['switch']`, register module devices once per address, instantiate `NikobusSwitchEntity` for `relay_switch` and `NikobusSwitchCoverEntity` for `cover_binary`, and use `build_unique_id` for unique IDs.  
- Refactor `light.py` to consume `routing['light']`, keep dimmer lights as `dimmer_light`, and add `NikobusRelayLightEntity` and `NikobusCoverLightEntity` to expose on/off semantics for relay and cover-binary routed channels while keeping dimmer brightness behavior; all light entities now use `build_unique_id`.  
- Update orphan/entity cleanup in `coordinator.py:get_known_entity_unique_ids` to compute known IDs from the routed specs (using `build_routing`) so removals align with the new unique ID scheme.  
- Preserve backward compatibility by resolving `entity_type` with priority: explicit `entity_type` → legacy `use_as_switch` / `use_as_light` → module default, and validate supported mappings per module type.  
- Include the `kind` in generated unique IDs (`{DOMAIN}_{domain}_{kind}_{address}_{channel}`) to avoid collisions when the same physical channel can be exposed under different domains/kinds.  
- Add logging warnings for any unhandled routing `kind` to make future extension and debugging easier.  

### Testing
- No automated tests were executed as part of this change.  
- The refactor was compiled and imported locally (static checks via edit/commit), but no unit or integration tests were run.  
- Runtime behavior and entity registration should be validated in a live Home Assistant instance with representative `dict_module_data` configurations.  
- The routing implementation preserves legacy `use_as_*` flags to avoid breaking existing configurations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964b7ae3718832c9cd59328c92ddcc7)