### PR TITLE
Remove legacy use_as_* routing flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ After installation, an example file is available at `/config/custom_components/n
 - `channels`: Each channel can have a description; keep descriptions unique across modules to avoid duplicate entity names.
 - For buttons with feedback LEDs, set `led_on` and `led_off` addresses (case-sensitive, format like `8AA8FA`). Leave blank if unused.
 - For roller outputs, add `operation_time` (seconds to fully open/close) so the integration can simulate shutter positioning.
-- To expose a roller (cover) output as a standard switch, set `use_as_switch` to `true` for that channel; the integration will create a switch entity that opens on "on" and stops on "off".
+- To expose a roller (cover) output as a standard switch, set `entity_type` to `switch` for that channel; the integration will create a switch entity that opens on "on" and stops on "off".
 - Prefix an unused output description with `not_in_use` to skip creating entities for it.
 
 ### Switch Module Example
@@ -278,7 +278,7 @@ After installation, an example file is available at `/config/custom_components/n
       "model": "05-001-02",
       "address": "9105",
       "channels": [
-        {"description": "R1 Output 1", "operation_time": "40", "led_on": "", "led_off": "", use_as_switch: true},
+        {"description": "R1 Output 1", "operation_time": "40", "led_on": "", "led_off": "", "entity_type": "switch"},
         {"description": "R1 Output 2", "operation_time": "40", "led_on": "", "led_off": ""},
         {"description": "R1 Output 3", "operation_time": "40"},
         {"description": "R1 Output 4", "operation_time": "40"},

--- a/custom_components/nikobus/router.py
+++ b/custom_components/nikobus/router.py
@@ -57,8 +57,7 @@ def build_routing(
 
     Routing decisions are centralized to ensure exactly one entity per channel,
     independent of platform setup order. The per-channel entity_type is resolved
-    using (in priority order) explicit entity_type, legacy use_as_* flags, then
-    module defaults.
+    using explicit entity_type then module defaults.
     """
 
     routing: dict[str, list[EntitySpec]] = {"cover": [], "switch": [], "light": []}
@@ -106,11 +105,6 @@ def _resolve_entity_type(module_type: str, channel_info: Mapping[str, Any]) -> s
             explicit_type,
             module_type,
         )
-
-    if channel_info.get("use_as_switch", False):
-        return "switch"
-    if channel_info.get("use_as_light", False):
-        return "light"
 
     if module_type == "roller_module":
         return "cover"


### PR DESCRIPTION
### Motivation
- Remove legacy `use_as_*` routing flags and standardize on the `entity_type` configuration for channel routing.
- Simplify routing resolution so `_resolve_entity_type` only honors explicit `entity_type` and module defaults.
- Update user documentation and examples to reflect `entity_type` usage for roller outputs.

### Description
- Removed checks for `use_as_switch` and `use_as_light` from `custom_components/nikobus/router.py` and updated the `build_routing` docstring to reflect the new resolution order.
- Kept `entity_type` validation (`_is_supported_entity_type`) and mapping (`_map_entity_type`) logic intact to validate and map explicit types.
- Updated `README.md` to replace `use_as_switch` guidance with `entity_type` and modified the roller example channel to `{"entity_type": "switch"}`.

### Testing
- Ran a repository search (`rg "use_as_" -n`) to confirm legacy flags are no longer referenced and it returned no matches.
- No automated unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964baaf457c832c86ca933e50430ac0)