### PR TITLE
docs: clarify entity_type options and config field requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,9 +218,26 @@ After installation, an example file is available at `/config/custom_components/n
 - `description`: Free text to identify the module (e.g., "Switch Module S1").
 - `model`: The Nikobus reference (e.g., "05-000-02").
 - `channels`: Each channel can have a description; keep descriptions unique across modules to avoid duplicate entity names.
-- For buttons with feedback LEDs, set `led_on` and `led_off` addresses (case-sensitive, format like `8AA8FA`). Leave blank if unused.
-- For roller outputs, add `operation_time` (seconds to fully open/close) so the integration can simulate shutter positioning.
-- To expose a roller (cover) output as a standard switch, set `entity_type` to `switch` for that channel; the integration will create a switch entity that opens on "on" and stops on "off".
+
+**Required vs optional fields**
+
+- **Required (module level)**: `description`, `model`, `address`, and `channels`.
+- **Required (per channel)**: `description`.
+- **Optional (per channel)**:
+  - `led_on` / `led_off`: Feedback LED addresses (case-sensitive, format like `8AA8FA`). Leave blank if unused.
+  - `operation_time`: For roller outputs, the time in seconds to fully open/close. If omitted, the cover will still work but uses a default timing, which may reduce position accuracy.
+  - `entity_type`: Override the default entity type (see matrix below).
+
+**Entity type by module**
+
+`entity_type` controls how Home Assistant exposes each channel. If you omit it, the integration uses the module default.
+
+| Module key | Default entity_type | Allowed entity_type values | Notes |
+| --- | --- | --- | --- |
+| `switch_module` | `switch` | `switch`, `light` | Useful when you want a switch output to show up as a light. |
+| `dimmer_module` | `light` | `light` | Dimmers are always exposed as lights. |
+| `roller_module` | `cover` | `cover`, `switch`, `light` | `switch` maps to open on "on" and stop on "off". |
+
 - Prefix an unused output description with `not_in_use` to skip creating entities for it.
 
 ### Switch Module Example


### PR DESCRIPTION
### Motivation

- Make configuration expectations explicit so users can set `entity_type` correctly and avoid unsupported combinations.
- Explain which fields are required vs optional so users know that `led_on`/`led_off` and `operation_time` are not mandatory.
- Provide an explicit matrix of allowed `entity_type` values per module to reduce configuration errors.
- Improve clarity for preparing `nikobus_module_config.json` and reduce support questions.

### Description

- Update `README.md` to add a "Required vs optional fields" section listing required module- and channel-level keys and optional per-channel keys.
- Add an "Entity type by module" matrix describing defaults and allowed `entity_type` values for `switch_module`, `dimmer_module`, and `roller_module`.
- Clarify formatting and behavior for `led_on`/`led_off` (example format `8AA8FA`) and note that omitting `operation_time` uses a default timing that may reduce position accuracy.
- Reiterate that prefixing a channel `description` with `not_in_use` skips entity creation and that `entity_type: "switch"` on roller channels maps to open on "on" and stop on "off".

### Testing

- No automated tests were run because this is a documentation-only change. 
- The change only modifies `README.md` and does not affect runtime code or existing test suites.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964bc6e50ec832cac89ab85d397e48d)