### PR TITLE
Restore extra attributes for Nikobus switch, light, and cover entities

### DIFF
--- a/custom_components/nikobus/cover.py
+++ b/custom_components/nikobus/cover.py
@@ -238,6 +238,7 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
         self.hass = hass
         self._address = address
         self._channel = channel
+        self._channel_description = channel_description
         self._description = module_desc
         self._model = module_model
         self._state = STATE_STOPPED
@@ -275,7 +276,17 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
     @property
     def extra_state_attributes(self) -> Dict[str, Any]:
         attrs = super().extra_state_attributes or {}
-        attrs.update({"position": self._position, "state": self._state})
+        attrs.update(
+            {
+                "address": self._address,
+                "channel": self._channel,
+                "channel_description": self._channel_description,
+                "module_description": self._device_name,
+                "module_model": self._device_model,
+                "position": self._position,
+                "state": self._state,
+            }
+        )
         return attrs
 
     @property

--- a/custom_components/nikobus/light.py
+++ b/custom_components/nikobus/light.py
@@ -150,6 +150,17 @@ class NikobusLightEntity(NikobusEntity, LightEntity):
         return self._is_on if self._is_on is not None else self.brightness > 0
 
     @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return extra state attributes."""
+        return {
+            "address": self._address,
+            "channel": self._channel,
+            "channel_description": self._channel_description,
+            "module_description": self._device_name,
+            "module_model": self._device_model,
+        }
+
+    @property
     def brightness(self) -> int:
         """Return the brightness of the light (0..255)."""
         if self._brightness is not None:
@@ -247,6 +258,17 @@ class NikobusRelayLightEntity(NikobusEntity, LightEntity):
     def is_on(self) -> bool:
         return self._is_on if self._is_on is not None else self._read_current_state()
 
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return extra state attributes."""
+        return {
+            "address": self._address,
+            "channel": self._channel,
+            "channel_description": self._channel_description,
+            "module_description": self._device_name,
+            "module_model": self._device_model,
+        }
+
     @callback
     def _handle_coordinator_update(self) -> None:
         self._is_on = None
@@ -329,6 +351,17 @@ class NikobusCoverLightEntity(NikobusEntity, LightEntity):
     @property
     def is_on(self) -> bool:
         return self._is_on if self._is_on is not None else self._read_current_state()
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return extra state attributes."""
+        return {
+            "address": self._address,
+            "channel": self._channel,
+            "channel_description": self._channel_description,
+            "module_description": self._device_name,
+            "module_model": self._device_model,
+        }
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/nikobus/switch.py
+++ b/custom_components/nikobus/switch.py
@@ -122,6 +122,17 @@ class NikobusSwitchCoverEntity(NikobusEntity, SwitchEntity):
         )
 
     @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return extra state attributes."""
+        return {
+            "address": self._address,
+            "channel": self.channel,
+            "channel_description": self.channel_description,
+            "module_description": self._device_name,
+            "module_model": self._device_model,
+        }
+
+    @property
     def is_on(self) -> bool:
         """Return True if the simulated switch (cover open) is on."""
         return self.coordinator.get_cover_state(self.address, self.channel) == 0x01
@@ -183,6 +194,17 @@ class NikobusSwitchEntity(NikobusEntity, SwitchEntity):
     def is_on(self) -> bool:
         """Return True if the switch is on."""
         return self._is_on if self._is_on is not None else self._read_current_state()
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return extra state attributes."""
+        return {
+            "address": self._address,
+            "channel": self._channel,
+            "channel_description": self._channel_description,
+            "module_description": self._device_name,
+            "module_model": self._device_model,
+        }
 
     @callback
     def _handle_coordinator_update(self) -> None:


### PR DESCRIPTION
### Motivation
- Restore entity `extra_state_attributes` that were removed, so switches, lights, and covers expose module and channel metadata again.
- Ensure cover entities also include channel description and keep existing `position`/`state` attributes for proper state inspection.

### Description
- Added `extra_state_attributes` to `NikobusSwitchEntity` and `NikobusSwitchCoverEntity` to return `address`, `channel`, `channel_description`, `module_description`, and `module_model`.
- Added `extra_state_attributes` to `NikobusLightEntity`, `NikobusRelayLightEntity`, and `NikobusCoverLightEntity` to expose the same metadata.
- In `NikobusCoverEntity` initialized `self._channel_description` and extended `extra_state_attributes` to include `address`, `channel`, `channel_description`, `module_description`, `module_model`, plus the existing `position` and `state`.
- Changes made in `custom_components/nikobus/switch.py`, `custom_components/nikobus/light.py`, and `custom_components/nikobus/cover.py` and reuse base `NikobusEntity` device name/model fields for module metadata.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964c50bb4c8832cb3bcfd72845144b0)