### PR TITLE
Start cover motion optimistically for HA commands

### DIFF
--- a/custom_components/nikobus/cover.py
+++ b/custom_components/nikobus/cover.py
@@ -513,11 +513,17 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
         self._movement_source = "ha"
         self._target_position = _clamp_position(target_position)
 
+        await self._begin_motion(
+            direction,
+            source="ha",
+            target_position=self._target_position,
+        )
+
         async def completion_handler() -> None:
-            await self._begin_motion(
+            _LOGGER.debug(
+                "Completion received for %s command on %s; motion already started.",
                 direction,
-                source="ha",
-                target_position=self._target_position,
+                self._attr_name,
             )
 
         await self._operate_cover(direction, completion_handler)


### PR DESCRIPTION
### Motivation
- HomeKit only reflects shutter "in motion" state when `is_opening`/`is_closing` changes immediately, so waiting for coordinator/API feedback delays HomeKit updates. 
- Start motion optimistically on HA-initiated commands so HomeKit sees `is_opening`/`is_closing` right away and then follows position updates. 
- Preserve existing behavior for physical Nikobus button events (`source="nikobus"`).
- Ensure no duplicate motion loops are spawned and task cancellation remains correct.

### Description
- In ` _request_cover_motion ` call ` _begin_motion (direction, source="ha", target_position=...)` immediately before issuing the API command. 
- Convert the API `completion_handler` into a no-op log so the completion does not re-trigger ` _begin_motion `.
- Keep the existing duplicate-start guarding inside ` _begin_motion ` and continue using `_safe_cancel` to prevent duplicate motion tasks. 
- No changes were made to ` _process_state_change ` for `source="ha"` logic aside from relying on existing guards to avoid reinitialization.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964ee62e58c832ca0b9ed8f22a0069e)