### PR TITLE
Use running event loop when creating stop completion future

### DIFF
--- a/custom_components/nikobus/cover.py
+++ b/custom_components/nikobus/cover.py
@@ -642,7 +642,7 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
 
         if send_stop and direction_for_stop:
             try:
-                stop_done = loop.create_future()
+                stop_done = asyncio.get_running_loop().create_future()
 
                 def _completion_handler() -> None:
                     async def _run() -> None:


### PR DESCRIPTION
### Motivation
- A `NameError` occurred in `_stop_motion` because `loop` was not defined when creating the stop completion future, causing stop handling to fail.
- The change ensures the future is created on the currently running event loop so the completion callback can set it reliably.
- This increases robustness of the cover stop workflow and prevents unhandled exceptions during stop operations.

### Description
- Replaced `loop.create_future()` with `asyncio.get_running_loop().create_future()` in `custom_components/nikobus/cover.py`.
- The modification is localized to the `_stop_motion` method where the stop completion future is created and awaited with `coordinator.api.stop_cover`.
- No other functional changes were made beyond using the active event loop to create the future.

### Testing
- No automated tests were run for this change.
- No test failures were reported because automated testing was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69650df43454832cb5bdd25ae3e53965)