### PR TITLE
Set Nikobus button state to last press type

### DIFF
--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -101,6 +102,7 @@ class NikobusButtonEntity(NikobusEntity, ButtonEntity):
 
         self._attr_name = f"Nikobus Push Button {address}"
         self._attr_unique_id = f"{DOMAIN}_push_button_{address}"
+        self._attr_state = STATE_UNKNOWN
 
         # Option set in the config entry
         self._prior_gen3: bool = config_entry.data.get(
@@ -229,6 +231,7 @@ class NikobusButtonEntity(NikobusEntity, ButtonEntity):
         }.get(event_type, "press")
 
         self._last_press_type = press_type
+        self._attr_state = press_type
         self._last_press_source = event.data.get("source")
         self._last_press_timestamp = event.data.get(
             "ts", datetime.now(timezone.utc).isoformat()


### PR DESCRIPTION
### Motivation
- Ensure the button entity state reflects the last press type (press/short/long/release) so history and UI show a meaningful change instead of just a timestamp.

### Description
- Initialize the button entity state to `STATE_UNKNOWN` by importing `STATE_UNKNOWN` and setting `self._attr_state` in the constructor of `NikobusButtonEntity` in `custom_components/nikobus/button.py`.
- Update the entity state on press events by assigning `self._attr_state = press_type` inside `_handle_button_event` so the HA state becomes `press`, `short`, `long`, or `release`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f7781f8cc832c8bac815f419bf12f)