### PR TITLE
Update button activity on nikobus operation events

### DIFF
--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -153,6 +153,7 @@ class NikobusButtonEntity(NikobusEntity, ButtonEntity):
                 "nikobus_button_released",
                 "nikobus_short_button_pressed",
                 "nikobus_long_button_pressed",
+                "nikobus_button_operation",
             )
         ]
 
@@ -230,6 +231,7 @@ class NikobusButtonEntity(NikobusEntity, ButtonEntity):
             "nikobus_long_button_pressed": "long",
             "nikobus_button_released": "release",
             "nikobus_button_pressed": "press",
+            "nikobus_button_operation": "press",
         }.get(event_type, "press")
 
         self._last_press_type = press_type


### PR DESCRIPTION
### Motivation
- Physical Nikobus operations emitted `nikobus_button_operation` (button operation) events that weren't mapped by the button entity, so the entity `Activity`/state wasn't updated when the physical button was used.

### Description
- Add `nikobus_button_operation` to the button entity listeners and treat it as a `press` event in `_handle_button_event` so operation events update `last_press_*` attributes and entity state.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f897ac3d4832ca3513f715495dd79)