### PR TITLE
Record Nikobus button activity with enriched context and update last_pressed for physical presses

### DIFF
--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -8,7 +8,6 @@ from typing import Any, Callable
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -99,11 +98,14 @@ class NikobusButtonEntity(NikobusEntity, ButtonEntity):
         self._last_press_address: str | None = None
         self._last_press_channel: int | None = None
         self._last_press_module_address: str | None = None
+        self._last_press_event_type: str | None = None
+        self._last_press_raw: dict[str, Any] | None = None
+        self._last_press_id: str | None = None
         self._unsub_button_events: list[Callable[[], None]] = []
 
         self._attr_name = f"Nikobus Push Button {normalized_address}"
         self._attr_unique_id = f"{DOMAIN}_push_button_{normalized_address}"
-        self._attr_state = STATE_UNKNOWN
+        self._attr_last_pressed = None
 
         # Option set in the config entry
         self._prior_gen3: bool = config_entry.data.get(
@@ -123,15 +125,19 @@ class NikobusButtonEntity(NikobusEntity, ButtonEntity):
             "address": self.discovery_address,
             "channel": self.discovery_channel,
             "key": self.discovery_key,
+            "operation_time": self._operation_time,
             "last_press_type": self._last_press_type,
             "last_press_source": self._last_press_source,
             "last_press_timestamp": self._last_press_timestamp,
             "last_press_address": self._last_press_address,
             "last_press_channel": self._last_press_channel,
             "last_press_module_address": self._last_press_module_address,
+            "last_press_event_type": self._last_press_event_type,
+            "last_press_raw": self._last_press_raw,
         }
 
         if self.impacted_modules_info:
+            attributes["impacted_modules"] = list(self.impacted_modules_info)
             attributes["user_impacted_modules"] = ", ".join(
                 f"{module['address']}_{module['group']}"
                 for module in self.impacted_modules_info
@@ -166,11 +172,25 @@ class NikobusButtonEntity(NikobusEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Handle button press event."""
+        press_timestamp = datetime.now(timezone.utc).isoformat()
+        module_address, channel = self._coordinator._derive_button_context(
+            self._address
+        )
         event_data = {
             "address": self._address,
             "operation_time": self._operation_time,
+            "ts": press_timestamp,
+            "source": "ha",
+            "module_address": module_address,
+            "channel": channel,
         }
         try:
+            self._record_press(
+                source="ha",
+                press_type="press",
+                event_type="ha_button_pressed",
+                event_data=event_data,
+            )
             _LOGGER.info("Processing HA button press: %s", self._address)
             await self._coordinator.async_event_handler("ha_button_pressed", event_data)
 
@@ -225,22 +245,93 @@ class NikobusButtonEntity(NikobusEntity, ButtonEntity):
         if event_address != self._address:
             return
 
+        source = event.data.get("source")
+        if source == "ha":
+            return
+
         event_type = event.event_type
-        press_type = {
+        press_type_map = {
             "nikobus_short_button_pressed": "short",
             "nikobus_long_button_pressed": "long",
             "nikobus_button_released": "release",
             "nikobus_button_pressed": "press",
-            "nikobus_button_operation": "press",
-        }.get(event_type, "press")
+            "nikobus_button_operation": "operation",
+        }
+        press_type = press_type_map.get(event_type, "press")
 
-        self._last_press_type = press_type
-        self._attr_state = press_type
-        self._last_press_source = event.data.get("source")
-        self._last_press_timestamp = event.data.get(
-            "ts", datetime.now(timezone.utc).isoformat()
+        if press_type in {"release", "operation"}:
+            return
+
+        press_id = event.data.get("press_id")
+        update_last_pressed = True
+        if press_type in {"short", "long"} and press_id and press_id == self._last_press_id:
+            update_last_pressed = False
+
+        self._record_press(
+            source=source or "nikobus",
+            press_type=press_type,
+            event_type=event_type,
+            event_data=event.data,
+            update_last_pressed=update_last_pressed,
         )
-        self._last_press_address = event_address
-        self._last_press_channel = event.data.get("channel")
-        self._last_press_module_address = event.data.get("module_address")
+
+    def _record_press(
+        self,
+        *,
+        source: str,
+        press_type: str,
+        event_type: str,
+        event_data: dict[str, Any],
+        update_last_pressed: bool = True,
+    ) -> None:
+        """Update last-pressed state and emit a normalized activity event."""
+        _LOGGER.debug(
+            "Recording press for %s: source=%s press_type=%s event_type=%s data=%s",
+            self._address,
+            source,
+            press_type,
+            event_type,
+            event_data,
+        )
+        timestamp = event_data.get("ts") or datetime.now(timezone.utc).isoformat()
+        try:
+            parsed_timestamp = datetime.fromisoformat(timestamp)
+            if parsed_timestamp.tzinfo is None:
+                parsed_timestamp = parsed_timestamp.replace(tzinfo=timezone.utc)
+        except ValueError:
+            parsed_timestamp = datetime.now(timezone.utc)
+            timestamp = parsed_timestamp.isoformat()
+
+        if update_last_pressed:
+            self._attr_last_pressed = parsed_timestamp
+        self._last_press_type = press_type
+        self._last_press_source = source
+        self._last_press_timestamp = timestamp
+        self._last_press_address = (event_data.get("address") or self._address).strip().upper()
+        self._last_press_channel = event_data.get("channel")
+        self._last_press_module_address = event_data.get("module_address")
+        self._last_press_event_type = event_type
+        self._last_press_raw = dict(event_data)
+        self._last_press_id = event_data.get("press_id")
+
+        if update_last_pressed:
+            activity_payload = {
+                "address": self._last_press_address,
+                "source": source,
+                "press_type": press_type,
+                "event_type": event_type,
+                "timestamp": timestamp,
+                "channel": self._last_press_channel,
+                "module_address": self._last_press_module_address,
+                "operation_time": self._operation_time,
+                "impacted_modules": list(self.impacted_modules_info),
+                "user_impacted_modules": ", ".join(
+                    f"{module['address']}_{module['group']}"
+                    for module in self.impacted_modules_info
+                )
+                if self.impacted_modules_info
+                else None,
+                "raw": dict(event_data),
+            }
+            self.hass.bus.async_fire("nikobus_button_activity", activity_payload)
         self.async_write_ha_state()

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -431,7 +431,8 @@ class NikobusDataCoordinator(DataUpdateCoordinator):
             "duration_s": None,
             "bucket": None,
             "threshold_s": None,
-            "source": "simulated",
+            "source": "ha",
+            "operation_time": operation_time,
         }
         _LOGGER.debug(
             "Firing simulated nikobus_button_pressed event: %s", event_data


### PR DESCRIPTION
### Motivation
- Ensure physical Nikobus button presses produce the same History/Activity entries as HA `button.press` calls by updating the button domain's last-pressed state.
- Provide a single, consistent update path for HA- and bus-originated presses and expose richer contextual attributes for automations and the logbook.
- Avoid duplicate Activity entries for the same physical press (short/long classification should not double-log an initial press).

### Description
- Added a unified recorder method `_record_press(...)` in `custom_components/nikobus/button.py` that sets the Home Assistant `last_pressed` (`_attr_last_pressed`) timestamp, updates enriched attributes (`last_press_*`), and writes state once for Activity/History visibility.
- Normalized handling so `async_press()` (HA source) and `_handle_button_event()` (Nikobus source) call `_record_press`, and HA-fired events now include `source: "ha"` and `operation_time` in `custom_components/nikobus/coordinator.py`.
- Emit a single normalized bus event `nikobus_button_activity` with enriched payload (source, `press_type`, `event_type`, timestamp, `module_address`, `channel`, `impacted_modules`, `operation_time`, and raw event data) for automations.
- Prevent duplicated history entries by ignoring `release`/`operation` events for Activity, and suppress redundant `short`/`long` updates when they share the same `press_id` as the initial press; added debug logging and new extra attributes (`last_press_event_type`, `last_press_raw`, `impacted_modules`, etc.).
- Updated `README.md` to document the new `nikobus_button_activity` event, `source: "ha"` semantics, and the enriched entity attributes.

### Testing
- No automated tests were executed as part of this change.
- Changes were limited to `custom_components/nikobus/button.py`, `custom_components/nikobus/coordinator.py`, and `README.md` and validated via static inspection and local commits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f8c754210832ca2be4e94336e0f9f)