### PR TITLE
Restore PC Link discovery from #A inventory replies

### DIFF
--- a/tests/test_discovery_pclink.py
+++ b/tests/test_discovery_pclink.py
@@ -1,0 +1,33 @@
+from custom_components.nikobus.discovery.discovery import NikobusDiscovery
+
+
+class DummyCommandQueue:
+    async def clear_command_queue(self):  # pragma: no cover - test stub
+        return None
+
+    async def clear_inventory_commands_for_prefix(self, _):  # pragma: no cover
+        return None
+
+
+class DummyCoordinator:
+    def __init__(self):
+        self.discovery_running = False
+        self.discovery_module = False
+        self.discovery_module_address = None
+        self.nikobus_command = DummyCommandQueue()
+        self.dict_module_data = {"pc_link": {}}
+
+
+def test_device_address_inventory_records_pc_link(monkeypatch):
+    coordinator = DummyCoordinator()
+    discovery = NikobusDiscovery(None, coordinator)
+
+    monkeypatch.setattr(discovery, "_schedule_inventory_timeout", lambda: None)
+
+    discovery.handle_device_address_inventory("\x02$18A1B2\x03")
+
+    assert "B2A1" in discovery.discovered_devices
+    recorded = discovery.discovered_devices["B2A1"]
+    assert recorded["module_type"] == "pc_link"
+    assert recorded["device_type"] == "0A"
+    assert recorded["category"] == "Module"


### PR DESCRIPTION
### Motivation
- Recent refactors changed the inventory discovery flow so PC Link addresses returned by the `#A` inventory command were no longer reliably captured, causing PC Link discovery to regress while advanced module discovery remained in place. 
- The change restores the specialized `#A` handling and address persistence for PC Link without disabling the newer advanced discovery state machine.

### Description
- Harden `start_inventory_discovery` / `handle_device_address_inventory` to strip control characters and locate the `DEVICE_ADDRESS_INVENTORY` marker before extracting the 4-hex address, and add a debug log when queueing `#A`. 
- Add `_ensure_pc_link_address` which normalizes and persists a discovered PC Link entry into `self.discovered_devices` using `DEVICE_TYPES` and `get_module_type_from_device_type`, while avoiding overwriting existing non-PC-Link module records or duplicating known `pc_link` entries from the coordinator. 
- Import `DEVICE_ADDRESS_INVENTORY` and add logging for ignored/malformed records and successful PC Link recordings; preserve existing advanced discovery for other module types and inventory identity queries. 
- Add a unit test `tests/test_discovery_pclink.py` that verifies `handle_device_address_inventory` records a PC Link address from a `#A`-style message containing control characters.

Files changed:
- `custom_components/nikobus/discovery/discovery.py` (add marker handling, control-char stripping, PC Link persistence, extra logs)
- `tests/test_discovery_pclink.py` (new targeted test for PC Link capture)

### Testing
- Added unit test `tests/test_discovery_pclink.py` that exercises `handle_device_address_inventory` and asserts the PC Link record is persisted; the test was committed. 
- Attempted to run `pytest -q tests/test_discovery_pclink.py`, but collection failed in the local test environment with `ModuleNotFoundError: No module named 'homeassistant.util'` because the test environment lacks Home Assistant test stubs; the failure is environmental and not indicative of the discovery logic itself.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697230acf768832c9e0124656bba9d08)