### PR TITLE
Support discovery dependencies for module inventory

### DIFF
--- a/custom_components/nikobus/nkbcommand.py
+++ b/custom_components/nikobus/nkbcommand.py
@@ -278,6 +278,8 @@ class NikobusCommandHandler:
     ) -> None:
         """Queue a command for processing."""
         _LOGGER.debug("Queueing command: %s", command)
+        if self._coordinator.discovery_running and self._is_discovery_command(command):
+            _LOGGER.debug("Queueing discovery command: %s", command)
         command_item = {
             "command": command,
             "address": address,
@@ -295,6 +297,11 @@ class NikobusCommandHandler:
         except NikobusError as err:
             _LOGGER.error("Failed to send command %s: %s", command, err, exc_info=True)
             raise
+
+    @staticmethod
+    def _is_discovery_command(command: str) -> bool:
+        """Return True when the command is part of discovery."""
+        return command.startswith("#A") or command.startswith("$14")
 
     async def set_output_states(
         self,


### PR DESCRIPTION
### Motivation
- Enable the advanced discovery implementation from `discovery/` to run in the main integration by satisfying its external dependencies (listener routing, command queuing, module registry, parsing/persistence). 
- Ensure inbound frames are normalized (strip STX/ETX/CRLF and buffer partial frames) so discovery parsers receive complete messages as expected. 
- Persist and merge discovered module data into the coordinator registry so discovery output is immediately usable for state refresh and entity setup. 

### Description
- `custom_components/nikobus/nkbconfig.py`: added `load_optional_json_data`, enhanced `_transform_module_data` to accept list/dict formats and `other_module`, and added `_normalize_module_channels` to normalize integer channel counts and channel lists. 
- `custom_components/nikobus/coordinator.py`: load optional `nikobus_module_discovered.json` during `connect()` and merge it via `_merge_discovered_modules` so discovered modules appear in `dict_module_data` and are used to seed `nikobus_module_states`. 
- `custom_components/nikobus/nkblistener.py`: implement frame buffering/normalization in `_extract_frames`, iterate extracted frames in `listen_for_events`, add defensive handling when `process_mode_button_press` is not present, and add discovery-oriented debug logs and routing context. 
- `custom_components/nikobus/nkbcommand.py`: add a small debug hook in `queue_command` and `_is_discovery_command` to surface when discovery commands are enqueued. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697234c4b1d0832c83614480ab0d7fc0)