### PR TITLE
Route PC Link $18 inventory messages to PC Link handler during discovery

### DIFF
--- a/custom_components/nikobus/nkblistener.py
+++ b/custom_components/nikobus/nkblistener.py
@@ -164,7 +164,10 @@ class NikobusEventListener:
         if DEVICE_ADDRESS_INVENTORY in message:
             _LOGGER.debug("Device address inventory: %s", message)
             if discovery_running:
-                await self.nikobus_discovery.query_module_inventory(message[3:7])
+                if self._should_use_pclink_inventory_parser():
+                    self.nikobus_discovery.handle_device_address_inventory(message)
+                else:
+                    await self.nikobus_discovery.query_module_inventory(message[3:7])
             else:
                 if hasattr(self.nikobus_discovery, "process_mode_button_press"):
                     await self.nikobus_discovery.process_mode_button_press(message)


### PR DESCRIPTION
### Motivation
- Prevent $18 PC Link inventory responses from being misinterpreted as module inventory during discovery by routing them to the PC Link inventory handler.

### Description
- Update `custom_components/nikobus/nkblistener.py` so `dispatch_message` calls `nikobus_discovery.handle_device_address_inventory(message)` when `_should_use_pclink_inventory_parser()` is true, and otherwise continues to call `query_module_inventory(message[3:7])`.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697242056a8c832c90813cabffd55026)