### PR TITLE
Record PC Link registry address from inventory frames

### DIFF
--- a/custom_components/nikobus/discovery/discovery.py
+++ b/custom_components/nikobus/discovery/discovery.py
@@ -325,6 +325,11 @@ class NikobusDiscovery:
         normalized = self.normalize_module_address(
             raw_address, source="device_address_inventory", reverse_bus_order=True
         )
+        registry_start = start_index + 4
+        registry_end = registry_start + 6
+        registry_raw = ""
+        if len(clean_message) >= registry_end:
+            registry_raw = (clean_message[registry_start:registry_end] or "").upper()
 
         self._inventory_addresses.add(normalized)
         _LOGGER.debug(
@@ -332,6 +337,15 @@ class NikobusDiscovery:
         )
         _LOGGER.info("Inventory record | address=%s", normalized)
         self._ensure_pc_link_address(normalized, source="device_address_inventory")
+        if registry_raw:
+            existing = self.discovered_devices.get(normalized)
+            if existing is not None:
+                existing["registry_address"] = registry_raw
+            _LOGGER.info(
+                "PC Link registry address recorded | address=%s registry=%s",
+                normalized,
+                registry_raw,
+            )
         self._schedule_inventory_timeout()
 
     def _ensure_pc_link_address(self, address: str, *, source: str) -> None:


### PR DESCRIPTION
### Motivation
- Capture the registry address segment emitted by PC Link inventory responses so the discovery process can retain the PC Link registry info for discovered devices and improve troubleshooting.

### Description
- In `custom_components/nikobus/discovery/discovery.py` parse a 6-hex `registry` segment after the device address inside `handle_device_address_inventory()`, store it as `registry_address` on the existing `self.discovered_devices` entry for that module, and log the recorded registry value.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697248789294832cb69c46f37141823a)