### PR TITLE
Remove duplicate calc_crc1() definition in nkbprotocol.py

### DIFF
--- a/custom_components/nikobus/nkbprotocol.py
+++ b/custom_components/nikobus/nkbprotocol.py
@@ -9,16 +9,6 @@ def int_to_hex(value: int, digits: int) -> str:
 def calc_crc1(data: str) -> int:
     """Calculate CRC-16/ANSI X3.28 (CRC-16-IBM) for the given data."""
     crc = 0xFFFF
-    for j in range(len(data) // 2):
-        crc ^= int(data[j * 2 : (j + 1) * 2], 16) << 8
-        for _ in range(8):
-            crc = (crc << 1) ^ 0x1021 if (crc >> 15) & 1 else crc << 1
-    return crc & 0xFFFF
-
-
-def calc_crc1(data: str) -> int:
-    """Calculate CRC-16/ANSI X3.28 (CRC-16-IBM) using native byte conversion."""
-    crc = 0xFFFF
     for byte in bytes.fromhex(data):
         crc ^= (byte << 8)
         for _ in range(8):


### PR DESCRIPTION
## Summary

- Two definitions of `calc_crc1()` existed in `nkbprotocol.py`; the second silently overrode the first
- Both implementations were mathematically identical (CRC-16/ANSI X3.28, polynomial `0x1021`, init `0xFFFF`)
- Removed the first (manual string-slicing) version, kept the cleaner `bytes.fromhex()` implementation

## Test plan

- [ ] Verify CRC values produced by `calc_crc1()` match expected Nikobus protocol values
- [ ] Confirm `append_crc1()` and `make_pc_link_command()` still produce correct frames
- [ ] Test module state read/write commands end-to-end

https://claude.ai/code/session_01N4TEWbHTS7UiBJ2xFaTtue