### PR TITLE
Validate cover operation_time values at setup to prevent ZeroDivisionError

### DIFF
--- a/custom_components/nikobus/cover.py
+++ b/custom_components/nikobus/cover.py
@@ -42,9 +42,11 @@ HUB_IDENTIFIER = "nikobus_hub"
 def _parse_operation_time(value: Any, fallback: float, label: str, address: str) -> float:
     """Parse and validate a cover operation time value.
 
-    Returns the parsed float if it is a positive number, otherwise logs a
-    warning and returns ``fallback``.
+    ``None`` means the field was not configured — silently returns ``fallback``.
+    Any other value that is not a positive number logs a warning before falling back.
     """
+    if value is None:
+        return fallback
     try:
         t = float(value)
         if t > 0:
@@ -98,13 +100,13 @@ async def async_setup_entry(
         )
 
         op_time_up = _parse_operation_time(
-            getattr(spec, "operation_time_up", None),
+            spec.operation_time_up,
             DEFAULT_COVER_OPERATION_TIME,
             "operation_time_up",
             spec.address,
         )
         op_time_down = _parse_operation_time(
-            getattr(spec, "operation_time_down", None),
+            spec.operation_time_down,
             op_time_up,
             "operation_time_down",
             spec.address,


### PR DESCRIPTION
## Summary

- `operation_time_up` / `operation_time_down` from the config were passed directly to `NikobusTravelCalculator` without any validation
- A missing, zero, negative, or non-numeric value would cause a `ZeroDivisionError` or `ValueError` inside `current_position()` with no useful diagnostic pointing back to the config
- Added `_parse_operation_time()` in `cover.py` which validates the value is a positive float and falls back gracefully

`None` (field not configured) is a silent fallback — no warning. A warning is only logged when a value is explicitly present but invalid (zero, negative, non-numeric).

## Behaviour change

| Scenario | Before | After |
|----------|--------|-------|
| `operation_time_up` not set (`None`) | silently uses `DEFAULT_COVER_OPERATION_TIME` | same, no warning |
| `operation_time_down` not set (`None`) | silently falls back to `op_time_up` | same, no warning |
| `operation_time_up = "0"` | `ZeroDivisionError` at first movement | warning logged, falls back to 30s |
| `operation_time_up = ""` | `ValueError` / `TypeError` | warning logged, falls back to 30s |
| `operation_time_up = "-5"` | cover moves in wrong direction | warning logged, falls back to 30s |

## Test plan

- [ ] Cover with valid `operation_time_up` / `operation_time_down` works as before
- [ ] Cover with `operation_time_up` / `operation_time_down` not configured — no warning logged, correct defaults used
- [ ] Cover with `operation_time_up = "0"` logs a warning and uses 30s default instead of crashing
- [ ] Cover with `operation_time_down = "-5"` logs a warning and falls back to `op_time_up`

https://claude.ai/code/session_01N4TEWbHTS7UiBJ2xFaTtue