### PR TITLE
Handle write_json_data failure when persisting discovered buttons

### DIFF
--- a/custom_components/nikobus/nkbactuator.py
+++ b/custom_components/nikobus/nkbactuator.py
@@ -176,7 +176,12 @@ class NikobusActuator:
                 "impacted_module": [{"address": "", "group": ""}],
             }
             self._dict_button_data.setdefault("nikobus_button", {})[address] = new_button
-            await self._coordinator.nikobus_config.write_json_data("nikobus_button_config.json", "button", self._dict_button_data)
+            try:
+                await self._coordinator.nikobus_config.write_json_data(
+                    "nikobus_button_config.json", "button", self._dict_button_data
+                )
+            except Exception as err:
+                _LOGGER.warning("Failed to persist discovered button %s to config: %s", address, err)
 
     async def process_button_modules(self, button_data: Dict[str, Any], button_address: str, press_context: Optional[Dict[str, Any]]) -> None:
         """Refresh states for specific modules impacted by this button."""


### PR DESCRIPTION
## Summary

- `button_discovery()` in `nkbactuator.py` called `write_json_data()` with no error handling
- A file I/O error (permissions, disk full, etc.) was silently swallowed: the button existed in memory but was not persisted to disk, and nothing in the logs indicated this
- Wrapped the call in `try/except` and added a `_LOGGER.warning()` so the failure is visible without crashing the button press handling flow

## Test plan

- [ ] Discover a new button — confirm it is written to `nikobus_button_config.json`
- [ ] Simulate a write failure (e.g. make the config directory read-only) — confirm a warning is logged and HA does not crash

https://claude.ai/code/session_01N4TEWbHTS7UiBJ2xFaTtue