### PR TITLE
Add available property to NikobusEntity to reflect connection state

### DIFF
--- a/custom_components/nikobus/entity.py
+++ b/custom_components/nikobus/entity.py
@@ -41,6 +41,11 @@ class NikobusEntity(CoordinatorEntity[NikobusDataCoordinator]):
         )
 
     @property
+    def available(self) -> bool:
+        """Return True only when the coordinator is healthy and the connection is live."""
+        return super().available and self.coordinator.nikobus_connection.is_connected
+
+    @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return shared state attributes safely."""
         return {


### PR DESCRIPTION
## Summary

- `CoordinatorEntity.available` only returns `False` when the last coordinator *poll* failed — it does not react to a live TCP/serial disconnection
- All Nikobus entities were therefore showing stale state values with no indication that the bus was unreachable
- Overriding `available` in `NikobusEntity` to also check `nikobus_connection.is_connected` means every entity becomes unavailable as soon as the connection drops, and recovers automatically when it is re-established

## Test plan

- [ ] With a healthy connection, confirm all entities show as available
- [ ] Disconnect the Nikobus interface — confirm entities transition to unavailable in the HA UI
- [ ] Reconnect — confirm entities become available again

https://claude.ai/code/session_01N4TEWbHTS7UiBJ2xFaTtue