### PR TITLE
Log warnings on silent fallbacks in coordinator and router

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -169,6 +169,11 @@ class NikobusDataCoordinator(DataUpdateCoordinator[bool]):
             try:
                 self.nikobus_module_states[address] = bytearray.fromhex(state_hex)
             except ValueError:
+                _LOGGER.warning(
+                    "Module %s returned invalid hex state %r — resetting to zero",
+                    address,
+                    state_hex,
+                )
                 self.nikobus_module_states[address] = bytearray(chan_count)
 
             await self.async_event_handler(

--- a/custom_components/nikobus/router.py
+++ b/custom_components/nikobus/router.py
@@ -63,7 +63,10 @@ def _modules_to_address_map(modules: Any) -> dict[str, Mapping[str, Any]]:
             if isinstance(item, Mapping) and item.get("address")
         }
         
-    # CLEANUP: Crucial fallback to prevent AttributeError crash on .items() later
+    _LOGGER.warning(
+        "_modules_to_address_map received unexpected type %s — no entities will be created for this module group",
+        type(modules).__name__,
+    )
     return {}
 
 


### PR DESCRIPTION
## Summary

Two places silently discarded errors with no log output:

- **`coordinator._refresh_module_type()`**: a `ValueError` from `bytearray.fromhex()` (invalid hex state returned by the bus) was caught and silently reset to zeros. Now logs a warning with the offending module address and hex string.
- **`router._modules_to_address_map()`**: an unexpected module data type (not dict or list) returned `{}` with only a code comment. Now emits a warning naming the unexpected type so misconfigured module sections are visible in HA logs.

## Test plan

- [ ] Normal operation produces no new warnings
- [ ] A module returning garbage hex state logs a warning and resets cleanly
- [ ] A malformed module config section logs a warning and produces no entities for that group

https://claude.ai/code/session_01N4TEWbHTS7UiBJ2xFaTtue