### PR TITLE
Fix state desync when command queue is full in nkbAPI

### DIFF
--- a/custom_components/nikobus/nkbAPI.py
+++ b/custom_components/nikobus/nkbAPI.py
@@ -40,16 +40,15 @@ class NikobusAPI:
         )
 
     async def _dispatch_action(
-        self, 
-        module_key: str, 
-        address: str, 
-        channel: int, 
-        target_state: int, 
-        cmd_key: str, 
+        self,
+        module_key: str,
+        address: str,
+        channel: int,
+        target_state: int,
+        cmd_key: str,
         completion_handler: Callable | None = None
     ) -> None:
         """Unified dispatcher for all module actions."""
-        self._coordinator.set_bytearray_state(address, channel, target_state)
         chan_info = self._get_channel_info(module_key, address, channel)
         bus_cmd = chan_info.get(cmd_key)
 
@@ -65,6 +64,9 @@ class NikobusAPI:
         except NikobusError as err:
             _LOGGER.error("API Action failed for %s: %s", address, err)
             raise
+
+        # Update in-memory state only after the command is successfully queued
+        self._coordinator.set_bytearray_state(address, channel, target_state)
 
     #### SWITCHES
     async def turn_on_switch(self, address: str, channel: int, completion_handler: Callable | None = None) -> None:
@@ -125,12 +127,11 @@ class NikobusAPI:
 
     async def stop_cover(self, address: str, channel: int, direction: str, completion_handler: Callable | None = None) -> None:
         """Stop cover movement."""
-        self._coordinator.set_bytearray_state(address, channel, STATE_OFF)
         chan_info = self._get_channel_info("roller_module", address, channel)
-        
+
         # Decide which stop command to send based on current direction
         cmd_key = "led_on" if direction == "opening" else "led_off"
-        
+
         try:
             if bus_cmd := chan_info.get(cmd_key):
                 await self._send_bus_command(bus_cmd, completion_handler)
@@ -139,6 +140,9 @@ class NikobusAPI:
         except NikobusError as err:
             _LOGGER.error("API Cover Action failed for %s: %s", address, err)
             raise
+
+        # Update in-memory state only after the command is successfully queued
+        self._coordinator.set_bytearray_state(address, channel, STATE_OFF)
 
     async def set_output_states_for_module(self, address: str, completion_handler: Callable | None = None) -> None:
         """Batch update all output states for a specific module."""


### PR DESCRIPTION
## Summary

`_dispatch_action()` and `stop_cover()` called `set_bytearray_state()` **before** queuing the command. Since PR #201 switched `queue_command` to `put_nowait()`, a full queue raises `NikobusError` immediately — after the in-memory state was already updated to the new value but before the command was sent to hardware.

The result: the coordinator's bytearray reflects the intended new state, hardware has the old state, and the entity's optimistic revert (`_is_on = None`) has no effect because `get_switch_state()` reads the now-corrupted bytearray.

**Fix:** move `set_bytearray_state()` to after the `try/except` block so in-memory state is only updated when the command has been successfully queued.

## Behaviour change

| Scenario | Before | After |
|----------|--------|-------|
| Command queued successfully | bytearray updated, command sent | same |
| Queue full (`NikobusError`) | bytearray updated, command NOT sent → desync | bytearray unchanged, error raised → consistent |

## Test plan

- [ ] Normal switch/cover/dimmer operations work as before
- [ ] Saturate the queue (100+ commands) — failed commands leave hardware and in-memory state consistent

https://claude.ai/code/session_01N4TEWbHTS7UiBJ2xFaTtue