### PR TITLE
Fix four issues from third review pass

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -236,7 +236,15 @@ class NikobusDataCoordinator(DataUpdateCoordinator[bool]):
         if address not in self.nikobus_module_states:
             return
         state = self.nikobus_module_states[address]
-        new_values = bytearray.fromhex(value)
+        try:
+            new_values = bytearray.fromhex(value)
+        except ValueError:
+            _LOGGER.warning(
+                "set_bytearray_group_state: invalid hex %r for module %s — ignoring",
+                value,
+                address,
+            )
+            return
         if int(group) == 1:
             limit = min(6, len(state))
             state[0:limit] = new_values[:limit]

--- a/custom_components/nikobus/nkbconnect.py
+++ b/custom_components/nikobus/nkbconnect.py
@@ -53,7 +53,11 @@ class NikobusConnect:
             
             self._is_connected = True
             _LOGGER.info("Connected to Nikobus on %s", self._connection_string)
-            await self._handshake()
+            try:
+                await self._handshake()
+            except Exception:
+                self._is_connected = False
+                raise
 
         except (OSError, asyncio.TimeoutError) as err:
             self._is_connected = False

--- a/custom_components/nikobus/nkblistener.py
+++ b/custom_components/nikobus/nkblistener.py
@@ -46,7 +46,7 @@ class NikobusEventListener:
 
         self._running = False
         self._listener_task: asyncio.Task | None = None
-        self.response_queue: asyncio.Queue[str] = asyncio.Queue()
+        self.response_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=200)
         self._frame_buffer = ""
         self._module_group = 1
         self._has_feedback_module: bool = config_entry.data.get(CONF_HAS_FEEDBACK_MODULE, False)
@@ -116,7 +116,10 @@ class NikobusEventListener:
                     await self._actuator.handle_button_press(message[idx+2:idx+8])
 
             if any(message.startswith(cmd) for cmd in COMMAND_PROCESSED):
-                await self.response_queue.put(message)
+                try:
+                    self.response_queue.put_nowait(message)
+                except asyncio.QueueFull:
+                    _LOGGER.warning("Response queue full — dropping bus message: %s", message)
                 return
 
             if self._has_feedback_module:
@@ -128,19 +131,28 @@ class NikobusEventListener:
                     if self.validate_crc(message):
                         await self._feedback_callback(self._module_group, message)
                         # Ensure commands awaiting this answer can see it
-                        await self.response_queue.put(message)
+                        try:
+                            self.response_queue.put_nowait(message)
+                        except asyncio.QueueFull:
+                            _LOGGER.warning("Response queue full — dropping bus message: %s", message)
                     return
 
             if any(message.startswith(r) for r in MANUAL_REFRESH_COMMAND):
                 if self.validate_crc(message) and not message.startswith(BUTTON_COMMAND_PREFIX):
-                    await self.response_queue.put(message)
+                    try:
+                        self.response_queue.put_nowait(message)
+                    except asyncio.QueueFull:
+                        _LOGGER.warning("Response queue full — dropping bus message: %s", message)
                 return
         else:
             if any(message.startswith(inv) for inv in DEVICE_INVENTORY_ANSWER):
                 await self._handle_discovery_frame(message)
                 return
 
-        await self.response_queue.put(message)
+        try:
+            self.response_queue.put_nowait(message)
+        except asyncio.QueueFull:
+            _LOGGER.warning("Response queue full — dropping bus message: %s", message)
 
     def validate_crc(self, message: str) -> bool:
         if message.count("$") > 1:

--- a/custom_components/nikobus/scene.py
+++ b/custom_components/nikobus/scene.py
@@ -180,9 +180,12 @@ class NikobusSceneEntity(NikobusEntity, Scene):
         stop_state = bytearray(state)
         for idx in indexes:
             stop_state[idx] = STATE_STOPPED
-            
+
         _LOGGER.debug("Timed stop for rollers on module %s", module_id)
-        await self._apply_module_state(module_id, stop_state)
+        try:
+            await self._apply_module_state(module_id, stop_state)
+        except Exception as err:
+            _LOGGER.error("Failed to send timed stop for module %s: %s", module_id, err)
 
     def _state_to_byte(self, module_type: str | None, state: Any) -> int | None:
         """Convert friendly state strings/values to Nikobus bytes."""


### PR DESCRIPTION
## Summary

Four genuine issues found in a third review pass after all previous PRs were merged.

### 1. `coordinator.py` — unhandled `ValueError` in `set_bytearray_group_state`
`bytearray.fromhex(value)` raised an unhandled `ValueError` if the bus returned a non-hex string. Now logs a warning and returns, leaving the existing state intact.

### 2. `nkbconnect.py` — `_is_connected` stays `True` after a failed handshake
`_is_connected` was set to `True` before `_handshake()` ran. `NikobusConnectionError` from a failed handshake is not an `OSError`, so the outer `except` block never reset `_is_connected`. Subsequent `ping()` calls would skip reconnection, thinking the connection was live. Now resets `_is_connected = False` on any handshake failure before re-raising.

### 3. `nkblistener.py` — unbounded `response_queue`
`response_queue` had no `maxsize`. If the command consumer stalled, bus responses accumulated indefinitely. Added `maxsize=200` and switched all `await put()` calls to `put_nowait()` with a warning on `QueueFull` — consistent with the command queue fix in PR #201.

### 4. `scene.py` — no error handling in `_delayed_roller_stop`
`_apply_module_state()` was called in an untracked fire-and-forget task with no error handling. A failure (queue full, connection lost) was silently swallowed, leaving rollers running indefinitely. Now catches and logs any exception.

## Test plan

- [ ] Normal switch/cover/scene operations unaffected
- [ ] A garbled bus response to `get_output_state` logs a warning instead of crashing
- [ ] A failed handshake on connect leaves the integration in a clean disconnected state
- [ ] Saturating the response queue drops messages with a warning, command timeouts retry correctly
- [ ] A scene roller stop failure is logged and does not crash the integration

https://claude.ai/code/session_01N4TEWbHTS7UiBJ2xFaTtue