### PR TITLE
fix: close connection on handshake failure and guard channel index writes

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -228,8 +228,9 @@ class NikobusDataCoordinator(DataUpdateCoordinator[bool]):
     @callback
     def set_bytearray_state(self, address: str, channel: int, value: int) -> None:
         """Manually update a specific channel in the state buffer."""
-        if address in self.nikobus_module_states:
-            self.nikobus_module_states[address][channel - 1] = value
+        state = self.nikobus_module_states.get(address)
+        if state and 0 < channel <= len(state):
+            state[channel - 1] = value
 
     def set_bytearray_group_state(self, address: str, group: int, value: str) -> None:
         """Safely update a module group from a hex string."""

--- a/custom_components/nikobus/nkbconnect.py
+++ b/custom_components/nikobus/nkbconnect.py
@@ -56,7 +56,7 @@ class NikobusConnect:
             try:
                 await self._handshake()
             except Exception:
-                self._is_connected = False
+                await self.disconnect()
                 raise
 
         except (OSError, asyncio.TimeoutError) as err:


### PR DESCRIPTION
## Summary

- **`nkbconnect.py`**: Call `await self.disconnect()` when `_handshake()` fails instead of only resetting `_is_connected`. Previously the TCP/serial writer was left open; HA raises `ConfigEntryNotReady` and retries, opening a second connection while the first is still live.
- **`coordinator.py`**: Add bounds check to `set_bytearray_state()` — mirrors the identical guard already in `get_bytearray_state()`. Without it, a channel value of 0, negative, or beyond the buffer length raises an unhandled `IndexError`.

## Behaviour change

| Location | Before | After |
|---|---|---|
| `nkbconnect.py` — handshake failure | `_is_connected = False`, writer stays open | `disconnect()` called — writer closed, reader/writer set to `None` |
| `coordinator.py:set_bytearray_state` | Writes without bounds check; raises `IndexError` on out-of-range channel | Silently skips write when channel is out of range |

## Test plan

- [ ] Simulate handshake failure (e.g. disconnect serial cable after TCP connect): verify no leaked file descriptor / socket on the second connection attempt
- [ ] Confirm `is_connected` is `False` after a failed handshake
- [ ] Pass `channel=0` and `channel > len(buffer)` to `set_bytearray_state` — verify no exception raised

https://claude.ai/code/session_01N4TEWbHTS7UiBJ2xFaTtue