### PR TITLE
fix: six bugs across config, discovery, connection, and listener

### DIFF
--- a/custom_components/nikobus/discovery/dimmer_decoder.py
+++ b/custom_components/nikobus/discovery/dimmer_decoder.py
@@ -16,6 +16,7 @@ from .protocol import (
     get_push_button_address,
     reverse_hex,
 )
+from ..const import DEVICE_INVENTORY_ANSWER as DEVICE_INVENTORY
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/nikobus/discovery/discovery.py
+++ b/custom_components/nikobus/discovery/discovery.py
@@ -613,9 +613,11 @@ class NikobusDiscovery:
             dict_data = getattr(self._coordinator, "dict_module_data", {})
             for module_type, modules in dict_data.items():
                 if module_type not in ("pc_link", "pc_logic", "feedback_module", "other_module"):
-                    for module in modules:
-                        if "address" in module:
-                            all_addresses.append(module["address"])
+                    module_iter = modules.values() if isinstance(modules, dict) else modules
+                    for module in module_iter:
+                        addr = module.get("address") if isinstance(module, dict) else None
+                        if addr:
+                            all_addresses.append(addr)
             
             if not all_addresses:
                 _LOGGER.warning("No output modules found in config to scan.")

--- a/custom_components/nikobus/discovery/fileio.py
+++ b/custom_components/nikobus/discovery/fileio.py
@@ -417,7 +417,7 @@ async def update_button_data(hass, discovered_devices, key_mapping, convert_niko
         for idx, key in enumerate(keys, start=1):
             if key in mapping:
                 add_value = int(mapping[key], 16)
-                new_nibble_value = original_nibble + add_value
+                new_nibble_value = (original_nibble + add_value) & 0xF
                 new_nibble_hex = f"{new_nibble_value:X}"
                 updated_addr = new_nibble_hex + converted_address[1:]
                 channels_data[f"channel_{idx}"] = {

--- a/custom_components/nikobus/discovery/protocol.py
+++ b/custom_components/nikobus/discovery/protocol.py
@@ -150,7 +150,7 @@ def get_push_button_address(
     except Exception:
         return None, button_address
 
-    new_nibble_value = original_nibble + add_value
+    new_nibble_value = (original_nibble + add_value) & 0xF
     new_nibble_hex = f"{new_nibble_value:X}"
     final_push_button_address = new_nibble_hex + push_button_address[1:]
 

--- a/custom_components/nikobus/nkbconfig.py
+++ b/custom_components/nikobus/nkbconfig.py
@@ -232,12 +232,9 @@ class NikobusConfig:
 
     def _transform_button_data_for_writing(self, data: dict) -> dict:
         """Transform button data from a dictionary back to a list for saving."""
-        button_data_list = [
-            {
-                "description": details["description"],
-                "address": address,
-                "impacted_module": details["impacted_module"],
-            }
-            for address, details in data.get("nikobus_button", {}).items()
-        ]
+        button_data_list = []
+        for address, details in data.get("nikobus_button", {}).items():
+            entry = dict(details)
+            entry["address"] = address
+            button_data_list.append(entry)
         return {"nikobus_button": button_data_list}

--- a/custom_components/nikobus/nkbconnect.py
+++ b/custom_components/nikobus/nkbconnect.py
@@ -135,8 +135,8 @@ class NikobusConnect:
             data = await self._reader.readuntil(b'\r')
             return data
         except asyncio.LimitOverrunError:
-            # Buffer full, read whatever is there to clear it
-            await self._reader.read(1024)
+            _LOGGER.error("Read buffer overrun — disconnecting")
+            await self.disconnect()
             raise NikobusReadError("Buffer overrun")
         except (OSError, asyncio.IncompleteReadError) as err:
             _LOGGER.error("Read failed: %s", err)

--- a/custom_components/nikobus/nkblistener.py
+++ b/custom_components/nikobus/nkblistener.py
@@ -79,6 +79,10 @@ class NikobusEventListener:
                 continue
             except Exception as err:
                 _LOGGER.error("Listener loop error: %s", err)
+                if not self._connection.is_connected:
+                    _LOGGER.warning("Connection lost — listener loop exiting.")
+                    self._running = False
+                    break
                 await asyncio.sleep(1)
 
     def _extract_frames(self, raw: str) -> list[str]:


### PR DESCRIPTION
## Summary

- **nkbconfig.py** — `_transform_button_data_for_writing` now preserves all button fields instead of only `description`, `address`, `impacted_module`. Previously, auto-discovering a new button silently dropped `operation_time`, `discovered_link`, and any other fields from all existing buttons (data loss).
- **dimmer_decoder.py** — Import `DEVICE_INVENTORY_ANSWER` from `const.py`. The `_chunk_from_message` method referenced undefined `DEVICE_INVENTORY`, causing `NameError` whenever dimmer discovery ran.
- **discovery.py** — Fix "ALL" module scan. After config transform, `modules` is a `dict[str, dict]`, so iterating it yielded keys (strings), not module dicts. The scan silently found zero modules every time.
- **nkblistener.py** — Exit the listener loop when the connection drops, instead of spinning forever logging errors every 1 second with no reconnection.
- **nkbconnect.py** — Call `disconnect()` on `LimitOverrunError` instead of reading 1024 bytes and leaving the connection in a potentially corrupt buffer state.
- **protocol.py + fileio.py** — Mask nibble addition to 4 bits (`& 0xF`) to prevent overflow producing 7-character addresses instead of the expected 6.

## Behaviour change

| Location | Before | After |
|---|---|---|
| `nkbconfig.py` | Only 3 fields preserved on button write | All fields preserved |
| `dimmer_decoder.py` | `NameError` crash on dimmer discovery | Decoder works using `DEVICE_INVENTORY_ANSWER` |
| `discovery.py` "ALL" scan | Always finds 0 modules, logs warning | Correctly iterates module values |
| `nkblistener.py` after disconnect | Spins forever, error every 1s | Logs warning and exits loop |
| `nkbconnect.py` buffer overrun | Reads 1024 bytes, connection stays up corrupt | Disconnects cleanly |
| `protocol.py` / `fileio.py` nibble | Can produce `"1D"` (2 chars) | Wraps to single hex digit |

## Test plan

- [ ] Discover a new button, verify existing buttons retain `operation_time` and `discovered_link` in config file
- [ ] Run dimmer module discovery — verify no `NameError`
- [ ] Run "Scan ALL modules" discovery — verify modules are found
- [ ] Simulate connection drop — verify listener loop exits cleanly without log spam
- [ ] Verify serial buffer overrun triggers clean disconnect
- [ ] Verify button address nibble computation stays 6 characters for edge-case addresses

https://claude.ai/code/session_01N4TEWbHTS7UiBJ2xFaTtue