### PR TITLE
Migrate to unified nikobus-connect package

### DIFF
--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -18,7 +18,7 @@ from .const import (
     DOMAIN,
 )
 from .exceptions import NikobusConnectionError
-from nikobusconnect import NikobusConnect
+from nikobus_connect import NikobusConnect
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -13,8 +13,8 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from nikobusconnect import NikobusAPI, NikobusCommandHandler, NikobusConnect, NikobusEventListener
-from nikobusconnect.exceptions import NikobusConnectionError, NikobusDataError
+from nikobus_connect import NikobusAPI, NikobusCommandHandler, NikobusConnect, NikobusEventListener
+from nikobus_connect.exceptions import NikobusConnectionError, NikobusDataError
 
 from .const import (
     CONF_CONNECTION_STRING,
@@ -27,7 +27,7 @@ from .const import (
     RECONNECT_DELAY_INITIAL,
     RECONNECT_DELAY_MAX,
 )
-from nikobus_discovery import NikobusDiscovery, InventoryQueryType
+from nikobus_connect.discovery import NikobusDiscovery, InventoryQueryType
 from .nkbactuator import NikobusActuator
 from .nkbconfig import NikobusConfig
 

--- a/custom_components/nikobus/exceptions.py
+++ b/custom_components/nikobus/exceptions.py
@@ -1,6 +1,6 @@
-"""Nikobus exceptions — re-exported from the nikobusconnect library."""
+"""Nikobus exceptions — re-exported from the nikobus_connect library."""
 
-from nikobusconnect.exceptions import (  # noqa: F401
+from nikobus_connect.exceptions import (  # noqa: F401
     NikobusConnectionError,
     NikobusDataError,
     NikobusError,

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -9,8 +9,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobusconnect==2.0.0",
-    "nikobus-discovery==0.1.0"
+    "nikobus-connect==0.1.0"
   ],
   "iot_class": "local_polling",
   "loggers": ["nikobus"]

--- a/tests/test_inventory_parsing.py
+++ b/tests/test_inventory_parsing.py
@@ -4,7 +4,7 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
-from nikobus_discovery import DecodedCommand, InventoryResult, NikobusDiscovery
+from nikobus_connect.discovery import DecodedCommand, InventoryResult, NikobusDiscovery
 
 
 def _build_inventory_payload(device_type: int, address_bytes: bytes, length: int = 18) -> str:
@@ -100,7 +100,7 @@ class TestInventoryParsing(unittest.IsolatedAsyncioTestCase):
 
         message = "$2E1234ABCD"
         with patch(
-            "nikobus_discovery.discovery.merge_discovered_links",
+            "nikobus_connect.discovery.discovery.merge_discovered_links",
             _fake_merge,
         ):
             await self.discovery.parse_module_inventory_response(message)


### PR DESCRIPTION
## Summary

- Replace `nikobusconnect` and `nikobus-discovery` dependencies with the unified `nikobus-connect==0.1.0` package
- Update all imports across `config_flow.py`, `exceptions.py`, `coordinator.py`, and `tests/test_inventory_parsing.py` to use the new module paths (`nikobus_connect` and `nikobus_connect.discovery`)

## Test plan

- [ ] Verify `nikobus-connect` installs correctly and exposes all expected symbols
- [ ] Run `tests/test_inventory_parsing.py` to confirm patched import paths work
- [ ] Test Nikobus integration config flow (connection, hardware, polling steps)
- [ ] Verify discovery functionality via `nikobus_connect.discovery`

https://claude.ai/code/session_012w57S8AbkW59eVTj2TDboZ