### PR TITLE
Allow fresh install without pre-existing config files

### DIFF
--- a/custom_components/nikobus/nkbconfig.py
+++ b/custom_components/nikobus/nkbconfig.py
@@ -38,6 +38,7 @@ class NikobusConfig:
 
         except FileNotFoundError:
             self._handle_file_not_found(file_path, data_type)
+            await self._create_empty_config(file_path, data_type)
             return {}
 
         except json.JSONDecodeError as err:
@@ -166,6 +167,22 @@ class NikobusConfig:
                 data_type.capitalize(),
                 file_path,
             )
+
+    @staticmethod
+    async def _create_empty_config(file_path: str, data_type: str) -> None:
+        """Create an empty skeleton config file so the library can update it later."""
+        _EMPTY_SKELETONS = {
+            "module": {},
+            "button": {"nikobus_button": []},
+            "scene": {},
+        }
+        skeleton = _EMPTY_SKELETONS.get(data_type, {})
+        try:
+            async with aio_open(file_path, "w") as file:
+                await file.write(json.dumps(skeleton, indent=4))
+            _LOGGER.info("Created empty %s config: %s", data_type, file_path)
+        except OSError as err:
+            _LOGGER.warning("Could not create empty %s config: %s", data_type, err)
 
     async def write_json_data(self, file_name: str, data_type: str, data: dict) -> None:
         """Write data to a JSON file, transforming it into a list format if necessary."""

--- a/custom_components/nikobus/nkbconfig.py
+++ b/custom_components/nikobus/nkbconfig.py
@@ -36,11 +36,9 @@ class NikobusConfig:
                 data = json.loads(await file.read())
             return self._transform_loaded_data(data, data_type)
 
-        except FileNotFoundError as err:
+        except FileNotFoundError:
             self._handle_file_not_found(file_path, data_type)
-            if data_type in ("scene", "button"):
-                return {}
-            raise NikobusDataError(f"Missing required {data_type} file: {file_path}") from err
+            return {}
 
         except json.JSONDecodeError as err:
             _LOGGER.error("Failed to decode JSON in %s file: %s", data_type, err, exc_info=True)
@@ -150,19 +148,23 @@ class NikobusConfig:
 
     def _handle_file_not_found(self, file_path: str, data_type: str) -> None:
         """Handle the case where the configuration file is not found."""
-        if data_type == "button":
+        if data_type == "module":
             _LOGGER.info(
-                "Button configuration file not found: %s. A new file will be created upon discovering the first button.",
+                "Module configuration file not found: %s. "
+                "Run PC-Link inventory discovery to populate it.",
                 file_path,
             )
-        elif data_type == "scene":
+        elif data_type == "button":
             _LOGGER.info(
-                "Scene configuration file not found: %s. Skipping.",
+                "Button configuration file not found: %s. "
+                "A new file will be created upon discovering the first button.",
                 file_path,
             )
         else:
-            raise NikobusDataError(
-                f"{data_type.capitalize()} configuration file not found: {file_path}"
+            _LOGGER.info(
+                "%s configuration file not found: %s. Skipping.",
+                data_type.capitalize(),
+                file_path,
             )
 
     async def write_json_data(self, file_name: str, data_type: str, data: dict) -> None:


### PR DESCRIPTION
## Summary

- Missing `nikobus_module_config.json` no longer blocks integration setup with `NikobusDataError`
- All missing config files (module, button, scene) now return empty data and log an info message
- **Empty skeleton files are created on disk** so the `nikobus_connect` library's fileio can find and update them during discovery
  - `nikobus_module_config.json` → `{}`
  - `nikobus_button_config.json` → `{"nikobus_button": []}`
  - `nikobus_scene_config.json` → `{}`
- Enables fresh install → connect → run PC-Link inventory discovery → config files populated

## Test plan

- [ ] Delete all `nikobus_*_config.json` files and restart HA — integration should start without errors and create empty skeleton files
- [ ] Run `nikobus.query_module_inventory` (no address) — PC-Link discovery should populate `nikobus_module_config.json` and `nikobus_button_config.json`
- [ ] Run `nikobus.query_module_inventory` with a module address — discovered button relationships should be merged into the button config (not skipped as "ghost")
- [ ] Restart HA — integration should load the newly created config files normally

https://claude.ai/code/session_01TrDQPALW7CtXHPTiJfaAJA