### PR TITLE
Bump nikobus-connect to 0.1.4

### DIFF
--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -9,7 +9,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect==0.1.3"
+    "nikobus-connect==0.1.4"
   ],
   "iot_class": "local_polling",
   "loggers": ["nikobus"]


### PR DESCRIPTION
## Summary

- Bump nikobus-connect requirement from 0.1.3 to 0.1.4

nikobus-connect 0.1.4 includes:
- **Fix shutter decoder channel extraction**: use lower nibble of byte 1 instead of full byte, matching the switch decoder pattern. This was causing all roller module payloads to be rejected with `invalid_channel`.
- **Disable early termination for module register scan**: the previous threshold of 3 consecutive empty responses was too aggressive for roller modules with sparsely-programmed registers, causing most button links to be missed.

## Test plan

- [ ] Run module discovery for roller modules — all programmed button links should now be found
- [ ] Verify switch and dimmer discovery still works correctly (no regression)

https://claude.ai/code/session_01KXy4CgkcVVqS8SAkFF7JEA