### PR TITLE
Fix stale ir_slot comment for nikobus-connect 0.1.4

### DIFF
--- a/tests/test_inventory_parsing.py
+++ b/tests/test_inventory_parsing.py
@@ -109,7 +109,7 @@ class TestInventoryParsing(unittest.IsolatedAsyncioTestCase):
             self.discovery._cancel_timeout()
 
         mapping = self.discovery._decoded_buffer["command_mapping"]
-        # Key is (push_button_address, channel, ir_slot) — match on first two components
+        # Key is (push_button_address, key_raw, ir_code) — match on first two components
         matching_key = next(
             (k for k in mapping if k[0] == "AA0000" and k[1] == 1), None
         )


### PR DESCRIPTION
## Summary

- Fix stale comment in `tests/test_inventory_parsing.py`: `ir_slot` renamed to `ir_code` to match nikobus-connect 0.1.4 tuple key structure

## Context

Compatibility review of Nikobus-HA against nikobus-connect v0.1.4 changes (removed fields: `ir_slot`, `ir_channel`, `ir_channel_code`, `ir_channel_number`, `ir_channel_bank`; new field: `ir_code`). The codebase is fully compatible — no code references the removed fields. Only this stale comment needed updating.

https://claude.ai/code/session_01KXy4CgkcVVqS8SAkFF7JEA