### PR TITLE
Align with nikobus-connect 0.1.4 field renames and add get_button_channels

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -402,6 +402,22 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 return m_type
         return None
 
+    def get_button_channels(self, button_address: str) -> int | None:
+        """Return the operation-point count for a physical button address.
+
+        Called by nikobus-connect decoders to derive the push-button (bus)
+        address from the physical device address found in module firmware.
+        Looks up ``linked_button[].address`` across all button entries.
+        """
+        normalized = (button_address or "").upper()
+        for button in (self.dict_button_data or {}).get("nikobus_button", {}).values():
+            for info in button.get("linked_button") or []:
+                if isinstance(info, dict) and (info.get("address") or "").upper() == normalized:
+                    ch = info.get("channels")
+                    if isinstance(ch, int) and ch > 0:
+                        return ch
+        return None
+
     def get_cover_operation_time(
         self, module_id: str, channel: int, direction: str = "up", default: float = 30.0
     ) -> float:

--- a/custom_components/nikobus/nkbactuator.py
+++ b/custom_components/nikobus/nkbactuator.py
@@ -321,7 +321,7 @@ class NikobusActuator:
         """Determine primary module/channel link for a button from config."""
         button_data = self._dict_button_data.get("nikobus_button", {}).get(address, {})
         impacted = button_data.get("impacted_module") or []
-        links = button_data.get("discovered_links") or []
+        links = button_data.get("linked_modules") or []
 
         # Try impacted_module first, skipping empty placeholder entries
         module_addr = None
@@ -332,7 +332,7 @@ class NikobusActuator:
 
         channel = None
 
-        # Fall back to discovered_links if no configured impacted_module
+        # Fall back to linked_modules if no configured impacted_module
         if not module_addr and links:
             first_link = links[0]
             module_addr = first_link.get("module_address")

--- a/tests/test_inventory_parsing.py
+++ b/tests/test_inventory_parsing.py
@@ -102,7 +102,7 @@ class TestInventoryParsing(unittest.IsolatedAsyncioTestCase):
 
         message = "$2E1234ABCD"
         with patch(
-            "nikobus_connect.discovery.discovery.merge_discovered_links",
+            "nikobus_connect.discovery.discovery.merge_linked_modules",
             _fake_merge,
         ):
             await self.discovery.parse_module_inventory_response(message)


### PR DESCRIPTION
## Summary

- Rename `discovered_links` → `linked_modules` in `_derive_button_context()` (nkbactuator.py)
- Rename mock path `merge_discovered_links` → `merge_linked_modules` (test)
- Add `get_button_channels()` to coordinator — enables nikobus-connect decoders to derive push-button addresses from physical device addresses during discovery

## Context

Aligns with nikobus-connect v0.1.4 field renames (fdebrus/nikobus-connect#5):
- `discovered_info` → `linked_button`
- `discovered_links` → `linked_modules`
- `merge_discovered_links()` → `merge_linked_modules()`

The new `get_button_channels()` method looks up `linked_button[].address` across all button entries and returns the channel count. Without this, nikobus-connect decoders couldn't resolve push-button addresses, causing most button-to-module links to be lost during discovery.

https://claude.ai/code/session_01KXy4CgkcVVqS8SAkFF7JEA