### PR TITLE
Discovery UX fixes: live PC Link progress and wait for actual completion

### DIFF
--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -297,7 +297,7 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
         if self._discovery_task is None:
             self._discovery_kind = "pc_link"
             self._discovery_task = self.hass.async_create_task(
-                coordinator.start_pc_link_inventory()
+                coordinator.start_pc_link_inventory(auto_reload=False)
             )
 
         return await self._progress_step("discovery_pc_link")
@@ -315,7 +315,7 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
         if self._discovery_task is None:
             self._discovery_kind = "module_scan"
             self._discovery_task = self.hass.async_create_task(
-                coordinator.start_module_scan()
+                coordinator.start_module_scan(auto_reload=False)
             )
 
         return await self._progress_step("discovery_modules")

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -281,6 +281,13 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         # PC Link inventory response
         await self.nikobus_discovery.parse_inventory_response(message)
 
+        # Count this frame toward the PC Link progress bar.
+        self.discovery_registers_done = min(
+            self.discovery_registers_total,
+            self.discovery_registers_done + 1,
+        )
+        devices_found = len(getattr(self.nikobus_discovery, "discovered_devices", {}) or {})
+
         # Early termination: stop scanning after consecutive empty registry blocks.
         if self._is_empty_inventory_block(message):
             if self._discovery_found_data:
@@ -291,12 +298,25 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                         self._consecutive_empty_blocks,
                     )
                     await self._abort_discovery_early()
+                    return
+            self._update_discovery_state(
+                phase=DISCOVERY_PHASE_PC_LINK,
+                message=(
+                    f"PC Link inventory: {self.discovery_registers_done}/"
+                    f"{self.discovery_registers_total} registers, "
+                    f"{devices_found} device(s) found"
+                ),
+            )
         else:
             self._discovery_found_data = True
             self._consecutive_empty_blocks = 0
             self._update_discovery_state(
                 phase=DISCOVERY_PHASE_PC_LINK,
-                message="PC Link inventory: found devices, continuing scan…",
+                message=(
+                    f"PC Link inventory: {self.discovery_registers_done}/"
+                    f"{self.discovery_registers_total} registers, "
+                    f"{devices_found} device(s) found"
+                ),
             )
 
     def _update_module_scan_progress(self) -> None:
@@ -692,8 +712,12 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         if self.discovery_phase == DISCOVERY_PHASE_FINISHED:
             return 100
         if self.discovery_phase == DISCOVERY_PHASE_PC_LINK:
-            # No reliable total — use a coarse indicator based on found data.
-            return 50 if self._discovery_found_data else 10
+            if self.discovery_registers_total:
+                pct = int(
+                    (self.discovery_registers_done / self.discovery_registers_total) * 100
+                )
+                return min(99, pct)
+            return 10
         if self.discovery_phase == DISCOVERY_PHASE_MODULE_SCAN:
             total = self.discovery_modules_total or 1
             done = self.discovery_modules_done
@@ -742,6 +766,8 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             raise HomeAssistantError("A Nikobus discovery is already running")
         self._discovery_found_data = False
         self._consecutive_empty_blocks = 0
+        # PC Link inventory scans register range 0xA4-0xFF = 92 frames.
+        # This is a rough total; early termination may stop the scan sooner.
         self._update_discovery_state(
             phase=DISCOVERY_PHASE_PC_LINK,
             message="Scanning PC Link registry for modules and buttons…",
@@ -749,7 +775,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             modules_done=0,
             modules_total=0,
             registers_done=0,
-            registers_total=0,
+            registers_total=92,
             error=None,
         )
         try:

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -100,6 +100,9 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self.discovery_registers_done: int = 0
         self.discovery_registers_total: int = 0
         self.discovery_last_error: str | None = None
+        self._discovery_finished_event: asyncio.Event = asyncio.Event()
+        self._discovery_finished_event.set()  # idle = already set
+        self._discovery_auto_reload: bool = True
         self._stopping: bool = False
         self._reconnect_task: asyncio.Task | None = None
         self._last_connected: datetime | None = None
@@ -683,12 +686,19 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                     target[addr] = info
 
     async def _handle_discovery_finished(self) -> None:
-        """Reload config entry once discovery is complete."""
+        """Signal discovery completion; optionally reload the config entry."""
         self.discovery_running = False
         self._update_discovery_state(
             phase=DISCOVERY_PHASE_FINISHED,
             message="Discovery finished",
         )
+        self._discovery_finished_event.set()
+
+        # Skip the auto-reload when the options flow triggered the discovery;
+        # the flow will reload via its final async_create_entry call.
+        if not self._discovery_auto_reload:
+            return
+
         if self._reload_task and not self._reload_task.done():
             return
 
@@ -758,14 +768,16 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             self.discovery_last_error = error
         async_dispatcher_send(self.hass, SIGNAL_DISCOVERY_STATE)
 
-    async def start_pc_link_inventory(self) -> None:
-        """Run a PC Link inventory discovery and track progress."""
+    async def start_pc_link_inventory(self, *, auto_reload: bool = True) -> None:
+        """Run a PC Link inventory discovery and wait until it completes."""
         if not self.nikobus_discovery:
             raise HomeAssistantError("Nikobus discovery is not initialized")
         if self.discovery_running:
             raise HomeAssistantError("A Nikobus discovery is already running")
         self._discovery_found_data = False
         self._consecutive_empty_blocks = 0
+        self._discovery_auto_reload = auto_reload
+        self._discovery_finished_event.clear()
         # PC Link inventory scans register range 0xA4-0xFF = 92 frames.
         # This is a rough total; early termination may stop the scan sooner.
         self._update_discovery_state(
@@ -780,6 +792,9 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         )
         try:
             await self.nikobus_discovery.start_inventory_discovery()
+            # The library returns after queueing commands; wait for the
+            # on_discovery_finished callback to actually fire.
+            await self._discovery_finished_event.wait()
         except Exception as err:
             self._update_discovery_state(
                 phase=DISCOVERY_PHASE_ERROR,
@@ -787,10 +802,16 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 error=str(err),
             )
             self.discovery_running = False
+            self._discovery_finished_event.set()
             raise
 
-    async def start_module_scan(self, module_address: str | None = None) -> None:
-        """Run module inventory discovery (single module or ALL)."""
+    async def start_module_scan(
+        self,
+        module_address: str | None = None,
+        *,
+        auto_reload: bool = True,
+    ) -> None:
+        """Run module inventory discovery and wait until it completes."""
         if not self.nikobus_discovery:
             raise HomeAssistantError("Nikobus discovery is not initialized")
         if self.discovery_running:
@@ -810,6 +831,8 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 total += len(modules) if isinstance(modules, dict) else 0
             message = f"Scanning {total} modules…" if total else "Scanning modules…"
 
+        self._discovery_auto_reload = auto_reload
+        self._discovery_finished_event.clear()
         self._update_discovery_state(
             phase=DISCOVERY_PHASE_MODULE_SCAN,
             message=message,
@@ -822,6 +845,9 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         )
         try:
             await self.nikobus_discovery.query_module_inventory(target)
+            # The library returns after queueing commands; wait for the
+            # on_discovery_finished callback to actually fire.
+            await self._discovery_finished_event.wait()
         except Exception as err:
             self._update_discovery_state(
                 phase=DISCOVERY_PHASE_ERROR,
@@ -829,4 +855,5 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 error=str(err),
             )
             self.discovery_running = False
+            self._discovery_finished_event.set()
             raise


### PR DESCRIPTION
## Summary

Two follow-up fixes for the discovery UX introduced in #265:

### 1. Live progress during PC Link inventory
Previously PC Link progress was hard-coded to 10%/50%. Now:
- `registers_total` initialized to 92 (scan range `0xA4-0xFF`)
- `registers_done` incremented on every inventory frame received
- Live message: `PC Link inventory: N/92 registers, M device(s) found`
- Percentage computed from `registers_done / registers_total`

### 2. Wait for actual discovery completion
The library's `query_module_inventory()` and `start_inventory_discovery()` return as soon as commands are queued — not when the scan actually finishes. The options flow task completed immediately and the "Discovery finished" dialog showed the first progress snapshot (e.g. `Scanning C9A5 1/6 — 0%`).

Fix:
- Added `asyncio.Event` set by `_handle_discovery_finished`
- `start_pc_link_inventory()` / `start_module_scan()` now wait on that event after queueing commands
- Added `auto_reload=False` flag so the options flow can suppress the coordinator's automatic config entry reload (avoiding a race with the flow's own `async_create_entry` reload). Bridge button presses still auto-reload as before.

## Test plan

- [ ] Options flow → Discover modules & buttons → progress counter advances through the PC Link registry
- [ ] Options flow → Scan all modules for button links → "Discovery finished" dialog shows `Discovery finished` (not the first progress message)
- [ ] Bridge "Discover modules & buttons" button still reloads the integration automatically when done

https://claude.ai/code/session_01KXy4CgkcVVqS8SAkFF7JEA