### PR TITLE
Show live progress message and percent in discovery spinner

### DIFF
--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -336,18 +336,19 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
                 return self.async_show_progress_done(next_step_id="discovery_error")
             return self.async_show_progress_done(next_step_id="discovery_done")
 
-        message = (
+        raw_message = (
             coordinator.discovery_status_message
             if coordinator
             else "Discovery in progress…"
         )
         percent = coordinator.discovery_progress_percent if coordinator else 0
+        display = f"{raw_message or 'Starting…'} ({percent}%)"
 
         kwargs: dict[str, Any] = {
             "step_id": step_id,
             "progress_action": "discovery",
             "description_placeholders": {
-                "message": message or "Starting…",
+                "message": display,
                 "percent": str(percent),
             },
         }

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -103,7 +103,7 @@
             }
         },
         "progress": {
-            "discovery": "Discovery in progress…"
+            "discovery": "{message}"
         },
         "abort": {
             "not_loaded": "The Nikobus integration is not loaded. Please reload the integration and try again."

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -103,7 +103,7 @@
             }
         },
         "progress": {
-            "discovery": "Découverte en cours…"
+            "discovery": "{message}"
         },
         "abort": {
             "not_loaded": "L'intégration Nikobus n'est pas chargée. Veuillez la recharger puis réessayer."

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -103,7 +103,7 @@
             }
         },
         "progress": {
-            "discovery": "Ontdekking bezig…"
+            "discovery": "{message}"
         },
         "abort": {
             "not_loaded": "De Nikobus-integratie is niet geladen. Herlaad de integratie en probeer het opnieuw."


### PR DESCRIPTION
## Summary

- Show live discovery progress in the options flow spinner dialog

HA's `async_show_progress` displays the `progress.<action>` translation string (not the step description). The previous string was a static `"Discovery in progress…"` with no placeholders, so the live status never showed. Now:

- `progress.discovery = "{message}"` in en/fr/nl translations
- `_progress_step` builds a combined `message (percent%)` display string

Result: the spinner dialog now shows live status like:
- `PC Link inventory: 47/92 registers, 3 device(s) found (51%)`
- `Scanning module C9A5 (3/6) — 47%`

## Test plan

- [ ] Options flow → Discover modules & buttons → spinner shows live register counter and percent
- [ ] Options flow → Scan all modules for button links → spinner shows current module and per-module percent

https://claude.ai/code/session_01KXy4CgkcVVqS8SAkFF7JEA