### PR TITLE
Discovery flow UX: live spinner, accurate progress, skip success dialog

### DIFF
--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -327,7 +327,7 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
 
         HA only re-runs the flow step when the ``progress_task`` completes.
         To refresh the displayed progress during a long-running discovery, we
-        pass a short "poll" task (sleep 5s) as the ``progress_task``. HA
+        pass a short "poll" task (sleep 1s) as the ``progress_task``. HA
         re-runs the step when that poll task completes, which lets us read
         the latest coordinator state and return a new spinner with updated
         description placeholders. Meanwhile the real discovery task runs
@@ -354,8 +354,8 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
         percent = coordinator.discovery_progress_percent if coordinator else 0
         display = f"{raw_message or 'Starting…'} ({percent}%)"
 
-        # Short poll task so HA re-runs this step every 5s to refresh the UI.
-        poll_task = self.hass.async_create_task(asyncio.sleep(5))
+        # Short poll task so HA re-runs this step every 1s to refresh the UI.
+        poll_task = self.hass.async_create_task(asyncio.sleep(1))
 
         kwargs: dict[str, Any] = {
             "step_id": step_id,

--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -327,7 +327,7 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
 
         HA only re-runs the flow step when the ``progress_task`` completes.
         To refresh the displayed progress during a long-running discovery, we
-        pass a short "poll" task (sleep 0.5s) as the ``progress_task``. HA
+        pass a short "poll" task (sleep 5s) as the ``progress_task``. HA
         re-runs the step when that poll task completes, which lets us read
         the latest coordinator state and return a new spinner with updated
         description placeholders. Meanwhile the real discovery task runs
@@ -354,8 +354,8 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
         percent = coordinator.discovery_progress_percent if coordinator else 0
         display = f"{raw_message or 'Starting…'} ({percent}%)"
 
-        # Short poll task so HA re-runs this step ~every 0.5s to refresh the UI.
-        poll_task = self.hass.async_create_task(asyncio.sleep(0.5))
+        # Short poll task so HA re-runs this step every 5s to refresh the UI.
+        poll_task = self.hass.async_create_task(asyncio.sleep(5))
 
         kwargs: dict[str, Any] = {
             "step_id": step_id,

--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -352,7 +352,7 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
             else "Discovery in progress…"
         )
         percent = coordinator.discovery_progress_percent if coordinator else 0
-        display = f"{raw_message or 'Starting…'} ({percent}%)"
+        display = raw_message or "Starting…"
 
         # Short poll task so HA re-runs this step every 1s to refresh the UI.
         poll_task = self.hass.async_create_task(asyncio.sleep(1))

--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -374,33 +374,29 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
     async def async_step_discovery_done(
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.FlowResult:
-        """Final step after a successful discovery."""
-        coordinator = self._coordinator()
-        msg = (
-            coordinator.discovery_status_message
-            if coordinator
-            else "Discovery finished."
+        """Close the flow after a successful discovery and reload the entry.
+
+        We use ``async_abort`` rather than ``async_create_entry`` so HA does
+        not show the generic "Options successfully saved" dialog — nothing
+        actually changed in the options. The reload is scheduled manually
+        so the newly-discovered entities appear.
+        """
+        self.hass.async_create_task(
+            self.hass.config_entries.async_reload(self._entry.entry_id)
         )
-        return self.async_show_form(
-            step_id="discovery_done",
-            data_schema=vol.Schema({}),
-            description_placeholders={"message": msg},
-            last_step=True,
-        ) if user_input is None else self.async_create_entry(data=self._options)
+        return self.async_abort(reason="discovery_done")
 
     async def async_step_discovery_error(
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.FlowResult:
-        """Shown when a discovery task raised an exception."""
+        """Close the flow after a failed discovery, surfacing the error."""
         coordinator = self._coordinator()
         err = (
             coordinator.discovery_last_error
             if coordinator
             else "Unknown error"
         ) or "Unknown error"
-        return self.async_show_form(
-            step_id="discovery_error",
-            data_schema=vol.Schema({}),
+        return self.async_abort(
+            reason="discovery_error",
             description_placeholders={"error": err},
-            last_step=True,
-        ) if user_input is None else self.async_create_entry(data=self._options)
+        )

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -103,6 +103,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self._discovery_finished_event: asyncio.Event = asyncio.Event()
         self._discovery_finished_event.set()  # idle = already set
         self._discovery_auto_reload: bool = True
+        self._discovery_progress_task: asyncio.Task | None = None
         self._stopping: bool = False
         self._reconnect_task: asyncio.Task | None = None
         self._last_connected: datetime | None = None
@@ -323,45 +324,91 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             )
 
     def _update_module_scan_progress(self) -> None:
-        """Update progress counters based on the discovery library's internal state."""
+        """Poll the discovery library + command queue for live progress.
+
+        Uses the command queue size (commands remaining) for fine-grained
+        per-register progress rather than counting response frames, because
+        the library batches multiple chunks per frame.
+        """
         disc = self.nikobus_discovery
         if disc is None:
             return
 
-        # Current module being scanned
+        # --- Current module & module counter tracking ------------------
         current = getattr(disc, "_module_address", None) or self.discovery_module_address
         if current and current != self.discovery_current_module:
-            # Module changed → increment the done counter, reset register counter.
             if self.discovery_current_module is not None:
                 self.discovery_modules_done += 1
             self.discovery_current_module = current
             self.discovery_registers_done = 0
-            self.discovery_registers_total = 240  # command range 0x10-0xFF
+            self.discovery_registers_total = 240  # 0x10-0xFF
 
-        # Queue size tells us remaining modules when using "ALL"
-        queue = getattr(disc, "_register_scan_queue", None)
-        if isinstance(queue, list):
-            # modules_total should reflect the initial total; only set once
-            if self.discovery_modules_total == 0:
-                self.discovery_modules_total = (
-                    self.discovery_modules_done + 1 + len(queue)
-                )
+        # Fallback default for the register total before any module is known.
+        if self.discovery_registers_total == 0:
+            self.discovery_registers_total = 240
 
-        self.discovery_registers_done = min(
-            self.discovery_registers_total,
-            self.discovery_registers_done + 1,
-        )
+        # modules_total: set once from the initial queue depth
+        queue_list = getattr(disc, "_register_scan_queue", None)
+        if isinstance(queue_list, list) and self.discovery_modules_total == 0:
+            self.discovery_modules_total = (
+                self.discovery_modules_done + 1 + len(queue_list)
+            )
+
+        # --- Per-register progress from the command queue --------------
+        cmd_handler = self.nikobus_command
+        queue = getattr(cmd_handler, "_command_queue", None) if cmd_handler else None
+        if queue is not None and hasattr(queue, "qsize"):
+            remaining = queue.qsize()
+            done = max(0, self.discovery_registers_total - remaining)
+            self.discovery_registers_done = min(self.discovery_registers_total, done)
 
         if self.discovery_current_module:
             pct = self.discovery_progress_percent
             self._update_discovery_state(
                 message=(
                     f"Scanning module {self.discovery_current_module} "
-                    f"({self.discovery_modules_done + 1}/{self.discovery_modules_total or '?'}) — {pct}%"
+                    f"({self.discovery_modules_done + 1}/"
+                    f"{self.discovery_modules_total or '?'}) — "
+                    f"{self.discovery_registers_done}/{self.discovery_registers_total}"
                 ),
             )
         else:
             async_dispatcher_send(self.hass, SIGNAL_DISCOVERY_STATE)
+
+    def _start_progress_poller(self) -> None:
+        """Start a background task that polls progress once per second."""
+        if self._discovery_progress_task and not self._discovery_progress_task.done():
+            return
+        self._discovery_progress_task = self.hass.async_create_task(
+            self._progress_poll_loop()
+        )
+
+    def _stop_progress_poller(self) -> None:
+        """Cancel the background progress poller."""
+        task = self._discovery_progress_task
+        self._discovery_progress_task = None
+        if task and not task.done():
+            task.cancel()
+
+    async def _progress_poll_loop(self) -> None:
+        """Periodically refresh module-scan progress so the UI sees updates.
+
+        Frame callbacks alone are not enough to drive live updates because
+        the library buffers multiple chunks per frame and empty registers
+        don't always produce a frame. This loop re-reads the command queue
+        every second and publishes a fresh state message.
+        """
+        try:
+            while self.discovery_running:
+                if self.inventory_query_type == InventoryQueryType.MODULE:
+                    self._update_module_scan_progress()
+                else:
+                    async_dispatcher_send(self.hass, SIGNAL_DISCOVERY_STATE)
+                await asyncio.sleep(1.0)
+        except asyncio.CancelledError:
+            return
+        except Exception as err:  # pragma: no cover - defensive
+            _LOGGER.debug("Discovery progress poller error: %s", err)
 
     @staticmethod
     def _is_empty_inventory_block(message: str) -> bool:
@@ -688,6 +735,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
     async def _handle_discovery_finished(self) -> None:
         """Signal discovery completion; optionally reload the config entry."""
         self.discovery_running = False
+        self._stop_progress_poller()
         self._update_discovery_state(
             phase=DISCOVERY_PHASE_FINISHED,
             message="Discovery finished",
@@ -790,12 +838,14 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             registers_total=92,
             error=None,
         )
+        self._start_progress_poller()
         try:
             await self.nikobus_discovery.start_inventory_discovery()
             # The library returns after queueing commands; wait for the
             # on_discovery_finished callback to actually fire.
             await self._discovery_finished_event.wait()
         except Exception as err:
+            self._stop_progress_poller()
             self._update_discovery_state(
                 phase=DISCOVERY_PHASE_ERROR,
                 message=f"PC Link inventory failed: {err}",
@@ -843,12 +893,14 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             registers_total=0,
             error=None,
         )
+        self._start_progress_poller()
         try:
             await self.nikobus_discovery.query_module_inventory(target)
             # The library returns after queueing commands; wait for the
             # on_discovery_finished callback to actually fire.
             await self._discovery_finished_event.wait()
         except Exception as err:
+            self._stop_progress_poller()
             self._update_discovery_state(
                 phase=DISCOVERY_PHASE_ERROR,
                 message=f"Module scan failed: {err}",

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -326,35 +326,40 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
     def _update_module_scan_progress(self) -> None:
         """Poll the discovery library + command queue for live progress.
 
-        Uses the command queue size (commands remaining) for fine-grained
-        per-register progress rather than counting response frames, because
-        the library batches multiple chunks per frame.
+        Derives progress from the library's remaining-queue length and the
+        command handler's pending-command queue. Avoids incremental counters
+        that can drift out of sync when modules transition.
         """
         disc = self.nikobus_discovery
         if disc is None:
             return
 
-        # --- Current module & module counter tracking ------------------
-        current = getattr(disc, "_module_address", None) or self.discovery_module_address
-        if current and current != self.discovery_current_module:
-            if self.discovery_current_module is not None:
-                self.discovery_modules_done += 1
-            self.discovery_current_module = current
-            self.discovery_registers_done = 0
+        if self.discovery_registers_total == 0:
             self.discovery_registers_total = 240  # 0x10-0xFF
 
-        # Fallback default for the register total before any module is known.
-        if self.discovery_registers_total == 0:
-            self.discovery_registers_total = 240
+        current = getattr(disc, "_module_address", None) or self.discovery_module_address
+        if current:
+            self.discovery_current_module = current
 
-        # modules_total: set once from the initial queue depth
+        # Derive modules_done from the library's scan queue:
+        #   remaining_after_current = len(_register_scan_queue)
+        #   modules_done = modules_total - remaining_after_current - 1
+        # When discovery_modules_total wasn't set by start_module_scan(),
+        # infer it once from the initial queue snapshot.
         queue_list = getattr(disc, "_register_scan_queue", None)
-        if isinstance(queue_list, list) and self.discovery_modules_total == 0:
-            self.discovery_modules_total = (
-                self.discovery_modules_done + 1 + len(queue_list)
-            )
+        if isinstance(queue_list, list):
+            if self.discovery_modules_total == 0:
+                self.discovery_modules_total = len(queue_list) + (1 if current else 0)
+            if self.discovery_modules_total:
+                self.discovery_modules_done = max(
+                    0,
+                    min(
+                        self.discovery_modules_total - 1,
+                        self.discovery_modules_total - len(queue_list) - 1,
+                    ),
+                )
 
-        # --- Per-register progress from the command queue --------------
+        # Per-register progress from the command handler's queue size.
         cmd_handler = self.nikobus_command
         queue = getattr(cmd_handler, "_command_queue", None) if cmd_handler else None
         if queue is not None and hasattr(queue, "qsize"):
@@ -362,13 +367,14 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             done = max(0, self.discovery_registers_total - remaining)
             self.discovery_registers_done = min(self.discovery_registers_total, done)
 
-        if self.discovery_current_module:
-            pct = self.discovery_progress_percent
+        if self.discovery_current_module and self.discovery_modules_total:
+            current_index = min(
+                self.discovery_modules_done + 1, self.discovery_modules_total
+            )
             self._update_discovery_state(
                 message=(
                     f"Scanning module {self.discovery_current_module} "
-                    f"({self.discovery_modules_done + 1}/"
-                    f"{self.discovery_modules_total or '?'}) — "
+                    f"({current_index}/{self.discovery_modules_total}) — "
                     f"{self.discovery_registers_done}/{self.discovery_registers_total}"
                 ),
             )

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -92,21 +92,15 @@
             "discovery_modules": {
                 "title": "Module Scan",
                 "description": "Scanning each output module for button links.\n\n**Progress:** {percent}%\n\n{message}"
-            },
-            "discovery_done": {
-                "title": "Discovery finished",
-                "description": "{message}\n\nThe integration will reload and newly-discovered entities will appear shortly."
-            },
-            "discovery_error": {
-                "title": "Discovery failed",
-                "description": "The discovery scan could not complete:\n\n**{error}**\n\nCheck the Home Assistant logs for details."
             }
         },
         "progress": {
             "discovery": "{message}"
         },
         "abort": {
-            "not_loaded": "The Nikobus integration is not loaded. Please reload the integration and try again."
+            "not_loaded": "The Nikobus integration is not loaded. Please reload the integration and try again.",
+            "discovery_done": "Discovery finished. The integration is reloading and the newly-discovered entities will appear shortly.",
+            "discovery_error": "Discovery failed: {error}"
         }
     },
     "entity": {

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -92,21 +92,15 @@
             "discovery_modules": {
                 "title": "Scan des modules",
                 "description": "Analyse de chaque module de sortie pour récupérer les liens de boutons.\n\n**Progression :** {percent}%\n\n{message}"
-            },
-            "discovery_done": {
-                "title": "Découverte terminée",
-                "description": "{message}\n\nL'intégration va être rechargée, les nouvelles entités apparaîtront sous peu."
-            },
-            "discovery_error": {
-                "title": "Échec de la découverte",
-                "description": "Le scan de découverte n'a pas pu aboutir :\n\n**{error}**\n\nConsultez les journaux Home Assistant pour plus de détails."
             }
         },
         "progress": {
             "discovery": "{message}"
         },
         "abort": {
-            "not_loaded": "L'intégration Nikobus n'est pas chargée. Veuillez la recharger puis réessayer."
+            "not_loaded": "L'intégration Nikobus n'est pas chargée. Veuillez la recharger puis réessayer.",
+            "discovery_done": "Découverte terminée. L'intégration est en cours de rechargement, les nouvelles entités apparaîtront sous peu.",
+            "discovery_error": "Échec de la découverte : {error}"
         }
     },
     "entity": {

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -92,21 +92,15 @@
             "discovery_modules": {
                 "title": "Modules scannen",
                 "description": "Elk uitgangsmodule wordt gescand op knoppenkoppelingen.\n\n**Voortgang:** {percent}%\n\n{message}"
-            },
-            "discovery_done": {
-                "title": "Ontdekking voltooid",
-                "description": "{message}\n\nDe integratie wordt opnieuw geladen; nieuwe entiteiten verschijnen zo dadelijk."
-            },
-            "discovery_error": {
-                "title": "Ontdekking mislukt",
-                "description": "De ontdekkingsscan kon niet worden voltooid:\n\n**{error}**\n\nControleer de Home Assistant-logboeken voor details."
             }
         },
         "progress": {
             "discovery": "{message}"
         },
         "abort": {
-            "not_loaded": "De Nikobus-integratie is niet geladen. Herlaad de integratie en probeer het opnieuw."
+            "not_loaded": "De Nikobus-integratie is niet geladen. Herlaad de integratie en probeer het opnieuw.",
+            "discovery_done": "Ontdekking voltooid. De integratie wordt herladen; nieuwe entiteiten verschijnen zo dadelijk.",
+            "discovery_error": "Ontdekking mislukt: {error}"
         }
     },
     "entity": {


### PR DESCRIPTION
## Summary

Multiple UX fixes for the discovery options flow from PR #265.

### 1. Refresh spinner every 1 second
HA only re-runs a flow step when the `progress_task` completes. Passing the long-running discovery task meant the spinner stayed frozen at 0% for the entire scan. Use a 1s `asyncio.sleep` task instead, so HA re-runs the step ~once per second with fresh state.

### 2. Accurate module-scan progress via command queue
- Progress was counted per response frame, but the library batches multiple chunks per frame, so counts drifted. Now reads the command handler's `_command_queue.qsize()` to compute `registers_done = total - remaining` — accurate regardless of framing.
- Added a background poller task that runs every 1s during active discovery and refreshes progress via the dispatcher signal. Needed because empty registers may not produce frames.

### 3. Fix module counter overflow (`7/6`)
`modules_done` was tracked by incrementing on module transitions, which could overshoot. Now derived from the library's `_register_scan_queue` length and clamped to `[0, total-1]`. The displayed index `min(done+1, total)` can never exceed total.

### 4. Remove duplicate percent display
`_progress_step` was appending `(percent%)` to the already-formatted status message, producing `... — 99% (99%)`. Removed the redundant suffix — the message already carries `N/total` register counts.

### 5. Skip "Options successfully saved" dialog
`async_create_entry` in an options flow always displays HA's generic success dialog, which added a pointless extra click. Use `async_abort` with custom reasons `discovery_done` / `discovery_error` instead. The flow closes immediately with a proper completion or error message, and the config entry reload is scheduled manually.

## Test plan

- [ ] Options flow → Scan all modules → spinner refreshes every second with live `Scanning module C9A5 (1/6) — 47/240` message
- [ ] Module counter stops at `6/6`, never overflows to `7/6`
- [ ] No duplicate percent in the progress message
- [ ] When scan completes, the flow closes directly (no "Options successfully saved" dialog) and newly-discovered entities appear after reload

https://claude.ai/code/session_01KXy4CgkcVVqS8SAkFF7JEA