### PR TITLE
Accurate module-scan progress counter and longer reload delay

### DIFF
--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -386,7 +386,11 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
         hass = self.hass
 
         async def _delayed_reload() -> None:
-            await asyncio.sleep(1.0)
+            # Wait long enough for HA to render the abort dialog and for
+            # the user to dismiss it before the reload tears down the
+            # options flow (which would otherwise show "Invalid flow
+            # specified").
+            await asyncio.sleep(3.0)
             try:
                 await hass.config_entries.async_reload(entry_id)
             except Exception as err:  # pragma: no cover - defensive

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -105,6 +105,8 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self._discovery_auto_reload: bool = True
         self._discovery_progress_task: asyncio.Task | None = None
         self._discovery_module_order: list[str] = []
+        self._module_scan_frame_count: int = 0
+        self._module_scan_last_index: int = -1
         self._stopping: bool = False
         self._reconnect_task: asyncio.Task | None = None
         self._last_connected: datetime | None = None
@@ -280,6 +282,13 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             return
         if self.inventory_query_type == InventoryQueryType.MODULE:
             await self.nikobus_discovery.parse_module_inventory_response(message)
+            # Count this response frame toward the per-module progress.
+            # Each register query produces one frame, so frame count ≈
+            # register count. The poller resets this on module transition.
+            self._module_scan_frame_count = min(
+                self.discovery_registers_total or 240,
+                self._module_scan_frame_count + 1,
+            )
             self._update_module_scan_progress()
             return
 
@@ -325,12 +334,13 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             )
 
     def _update_module_scan_progress(self) -> None:
-        """Poll the discovery library + command queue for live progress.
+        """Refresh the module-scan progress state for the UI.
 
-        Uses the pre-captured ``_discovery_module_order`` list together with
-        the library's remaining-queue length to determine the current module
-        index (and its address). Per-register progress comes from the
-        command handler's pending-command queue size.
+        Uses the pre-captured ``_discovery_module_order`` list together
+        with the library's remaining-queue length to determine the current
+        module. Per-module register progress is a monotonic counter of the
+        response frames we have received for the current module (reset on
+        module transition).
         """
         disc = self.nikobus_discovery
         if disc is None:
@@ -345,16 +355,18 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             return
 
         queue_list = getattr(disc, "_register_scan_queue", None)
-        if isinstance(queue_list, list):
-            remaining = len(queue_list)
-        else:
-            remaining = 0
+        remaining = len(queue_list) if isinstance(queue_list, list) else 0
 
         # How many modules have been POPPED so far (including the current one).
         popped = total - remaining
         current_index_0 = max(0, popped - 1)  # 0-based index of current module
         current_index_1 = min(current_index_0 + 1, total)  # 1-based display
         self.discovery_modules_done = current_index_0
+
+        # Reset per-module frame counter when we advance to a new module.
+        if current_index_0 != self._module_scan_last_index:
+            self._module_scan_last_index = current_index_0
+            self._module_scan_frame_count = 0
 
         if self._discovery_module_order and current_index_0 < len(
             self._discovery_module_order
@@ -363,7 +375,6 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 current_index_0
             ]
         else:
-            # Fallback to library attribute if available.
             lib_current = (
                 getattr(disc, "_module_address", None)
                 or self.discovery_module_address
@@ -371,13 +382,10 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             if lib_current:
                 self.discovery_current_module = lib_current
 
-        # Per-register progress from the command handler's queue size.
-        cmd_handler = self.nikobus_command
-        queue = getattr(cmd_handler, "_command_queue", None) if cmd_handler else None
-        if queue is not None and hasattr(queue, "qsize"):
-            qsize = queue.qsize()
-            done = max(0, self.discovery_registers_total - qsize)
-            self.discovery_registers_done = min(self.discovery_registers_total, done)
+        self.discovery_registers_done = min(
+            self.discovery_registers_total,
+            self._module_scan_frame_count,
+        )
 
         if self.discovery_current_module:
             self._update_discovery_state(
@@ -903,6 +911,8 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
 
         self._discovery_auto_reload = auto_reload
         self._discovery_finished_event.clear()
+        self._module_scan_frame_count = 0
+        self._module_scan_last_index = -1
         self._update_discovery_state(
             phase=DISCOVERY_PHASE_MODULE_SCAN,
             message=message,

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -107,6 +107,8 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self._discovery_module_order: list[str] = []
         self._module_scan_frame_count: int = 0
         self._module_scan_last_index: int = -1
+        # Monkey-patch state for counting commands sent during discovery
+        self._original_send_command = None
         self._stopping: bool = False
         self._reconnect_task: asyncio.Task | None = None
         self._last_connected: datetime | None = None
@@ -282,13 +284,8 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             return
         if self.inventory_query_type == InventoryQueryType.MODULE:
             await self.nikobus_discovery.parse_module_inventory_response(message)
-            # Count this response frame toward the per-module progress.
-            # Each register query produces one frame, so frame count ≈
-            # register count. The poller resets this on module transition.
-            self._module_scan_frame_count = min(
-                self.discovery_registers_total or 240,
-                self._module_scan_frame_count + 1,
-            )
+            # Per-command progress is counted by the wrapped _send_command
+            # (see _install_command_counter); we just refresh the UI state.
             self._update_module_scan_progress()
             return
 
@@ -397,6 +394,39 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             )
         else:
             async_dispatcher_send(self.hass, SIGNAL_DISCOVERY_STATE)
+
+    def _install_command_counter(self) -> None:
+        """Wrap the command handler's _send_command to count discovery commands.
+
+        Every inventory register query results in exactly one _send_command
+        invocation (for commands without an address, i.e., fire-and-forget).
+        Wrapping that method gives us a reliable per-command counter that
+        doesn't depend on bus frame batching.
+        """
+        handler = self.nikobus_command
+        if handler is None or self._original_send_command is not None:
+            return
+        original = handler._send_command
+        self._original_send_command = original
+
+        async def _counting_send_command(*args, **kwargs):
+            result = await original(*args, **kwargs)
+            if self.discovery_running and self.inventory_query_type == InventoryQueryType.MODULE:
+                self._module_scan_frame_count = min(
+                    self.discovery_registers_total or 240,
+                    self._module_scan_frame_count + 1,
+                )
+            return result
+
+        handler._send_command = _counting_send_command
+
+    def _uninstall_command_counter(self) -> None:
+        """Restore the original _send_command method."""
+        handler = self.nikobus_command
+        if handler is None or self._original_send_command is None:
+            return
+        handler._send_command = self._original_send_command
+        self._original_send_command = None
 
     def _start_progress_poller(self) -> None:
         """Start a background task that polls progress once per second."""
@@ -759,6 +789,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         """Signal discovery completion; optionally reload the config entry."""
         self.discovery_running = False
         self._stop_progress_poller()
+        self._uninstall_command_counter()
         self._update_discovery_state(
             phase=DISCOVERY_PHASE_FINISHED,
             message="Discovery finished",
@@ -913,6 +944,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self._discovery_finished_event.clear()
         self._module_scan_frame_count = 0
         self._module_scan_last_index = -1
+        self._install_command_counter()
         self._update_discovery_state(
             phase=DISCOVERY_PHASE_MODULE_SCAN,
             message=message,
@@ -931,6 +963,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             await self._discovery_finished_event.wait()
         except Exception as err:
             self._stop_progress_poller()
+            self._uninstall_command_counter()
             self._update_discovery_state(
                 phase=DISCOVERY_PHASE_ERROR,
                 message=f"Module scan failed: {err}",


### PR DESCRIPTION
## Summary

Two fixes for the module-scan progress display.

### 1. Accurate per-register counter (1:1 with commands sent)

The previous counter was based on discovery response frames, but the bus batches 2-3 register responses into a single `$2E` frame. For densely-populated modules the counter never reached 240 and got stuck around 140-180.

Fix: monkey-patch the command handler's `_send_command` method to increment the counter each time a command is actually sent on the bus. Inventory register queries are fire-and-forget commands (no address, no answer), so `_send_command` is invoked exactly once per register query — giving a reliable 1:1 counter regardless of how the bus batches responses into frames.

The wrapper is installed in `start_module_scan()` and uninstalled in `_handle_discovery_finished()` and the error paths.

### 2. Fix "Invalid flow specified" at scan end

The 1-second reload delay from PR #270 was not enough — HA still tore down the options flow before the user dismissed the abort dialog. Bumped the delay to 3 seconds.

## Test plan

- [ ] Run module scan → counter advances 0→240 smoothly for every module, regardless of how many buttons are programmed
- [ ] When scan completes, the "Discovery finished" dialog appears and can be dismissed without "Invalid flow specified"

https://claude.ai/code/session_01KXy4CgkcVVqS8SAkFF7JEA