### PR TITLE
Fix first-tick counter reset and replace abort with async_create_entry

### DIFF
--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -374,30 +374,18 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
     async def async_step_discovery_done(
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.FlowResult:
-        """Close the flow after a successful discovery and reload the entry.
+        """Finalize the flow after a successful discovery.
 
-        We use ``async_abort`` rather than ``async_create_entry`` so HA does
-        not show the generic "Options successfully saved" dialog — nothing
-        actually changed in the options. The reload is scheduled with a
-        short delay so HA can render the abort result before the flow is
-        torn down by the reload.
+        Use ``async_create_entry`` with empty options so HA closes the
+        flow cleanly via its standard success dialog. The coordinator's
+        auto-reload (triggered by the options update listener) picks up
+        the newly-discovered entities. This avoids the "Invalid flow
+        specified" error that async_abort + manual reload can cause.
         """
-        entry_id = self._entry.entry_id
-        hass = self.hass
-
-        async def _delayed_reload() -> None:
-            # Wait long enough for HA to render the abort dialog and for
-            # the user to dismiss it before the reload tears down the
-            # options flow (which would otherwise show "Invalid flow
-            # specified").
-            await asyncio.sleep(3.0)
-            try:
-                await hass.config_entries.async_reload(entry_id)
-            except Exception as err:  # pragma: no cover - defensive
-                _LOGGER.debug("Failed to reload entry after discovery: %s", err)
-
-        hass.async_create_task(_delayed_reload())
-        return self.async_abort(reason="discovery_done")
+        # Merge back the existing options so the update listener fires
+        # even if self._options is empty.
+        merged = {**self._entry.options, **self._options}
+        return self.async_create_entry(title="", data=merged)
 
     async def async_step_discovery_error(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -404,21 +404,30 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         doesn't depend on bus frame batching.
         """
         handler = self.nikobus_command
-        if handler is None or self._original_send_command is not None:
+        if handler is None:
+            _LOGGER.debug("Command counter install skipped: no handler")
+            return
+        if self._original_send_command is not None:
+            _LOGGER.debug("Command counter install skipped: already installed")
             return
         original = handler._send_command
         self._original_send_command = original
+        coordinator = self  # closure reference
 
         async def _counting_send_command(*args, **kwargs):
             result = await original(*args, **kwargs)
-            if self.discovery_running and self.inventory_query_type == InventoryQueryType.MODULE:
-                self._module_scan_frame_count = min(
-                    self.discovery_registers_total or 240,
-                    self._module_scan_frame_count + 1,
+            if (
+                coordinator.discovery_running
+                and coordinator.inventory_query_type == InventoryQueryType.MODULE
+            ):
+                coordinator._module_scan_frame_count = min(
+                    coordinator.discovery_registers_total or 240,
+                    coordinator._module_scan_frame_count + 1,
                 )
             return result
 
         handler._send_command = _counting_send_command
+        _LOGGER.debug("Command counter installed on handler %s", handler)
 
     def _uninstall_command_counter(self) -> None:
         """Restore the original _send_command method."""
@@ -943,7 +952,9 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self._discovery_auto_reload = auto_reload
         self._discovery_finished_event.clear()
         self._module_scan_frame_count = 0
-        self._module_scan_last_index = -1
+        # Initialize to 0 so the first poll tick (current_index_0 == 0)
+        # does not reset the counter and discard the initial increments.
+        self._module_scan_last_index = 0
         self._install_command_counter()
         self._update_discovery_state(
             phase=DISCOVERY_PHASE_MODULE_SCAN,


### PR DESCRIPTION
## Summary

Two final fixes for the module-scan progress flow.

### 1. Fix first-tick counter reset wiping initial increments

`start_module_scan` initialized `_module_scan_last_index` to `-1`. On the first poll tick the current module index is `0`, so the mismatch triggered the reset-on-module-change logic and zeroed the counter, discarding commands already processed by the wrapped `_send_command`. Initialize to `0` so the first tick is a no-op.

Also added debug logging for the command counter install/skip paths.

### 2. Use async_create_entry to finalize the discovery flow

`async_abort` followed by a delayed manual reload was unreliable — any reload tears down the config entry's options flow, causing HA to return `Invalid flow specified` when the frontend polled or the user dismissed the abort dialog. Even bumping the delay didn't help because the timing depends on user interaction.

Switched back to `async_create_entry`, HA's blessed way to finish an options flow: persists options, triggers the update listener (which reloads via `_async_options_updated`), and shows HA's standard success dialog. Minor UX cost (extra "Success" click) but the flow closes cleanly and the integration reloads reliably.

## Test plan

- [ ] Run module scan → counter advances smoothly from 0 to 240 for every module
- [ ] When scan completes, "Options successfully saved" dialog appears and closes cleanly (no "Invalid flow specified")
- [ ] After closing the dialog, newly-discovered entities are visible

https://claude.ai/code/session_01KXy4CgkcVVqS8SAkFF7JEA