### PR TITLE
Surface button/module discovery links in the device registry

### DIFF
--- a/custom_components/nikobus/binary_sensor.py
+++ b/custom_components/nikobus/binary_sensor.py
@@ -11,7 +11,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 
-from .const import DOMAIN, EVENT_BUTTON_PRESSED
+from .button import register_wall_button_devices
+from .const import DOMAIN, EVENT_BUTTON_PRESSED, HUB_IDENTIFIER
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity
 
@@ -33,6 +34,7 @@ async def async_setup_entry(
         return
 
     buttons = coordinator.dict_button_data.get("nikobus_button", {})
+    register_wall_button_devices(hass, entry, buttons)
 
     async_add_entities(
         NikobusButtonBinarySensor(
@@ -54,18 +56,37 @@ class NikobusButtonBinarySensor(NikobusEntity, BinarySensorEntity):
         description: str,
     ) -> None:
         """Initialize the button binary sensor."""
+        wall_info = coordinator.get_wall_button_info(address)
+        via_device = (DOMAIN, wall_info["address"]) if wall_info else (DOMAIN, HUB_IDENTIFIER)
         super().__init__(
             coordinator=coordinator,
             address=address,
             name=description,
             model="Physical Button",
+            via_device=via_device,
         )
         self._address = address
         self._attr_name = description
         self._attr_unique_id = f"{DOMAIN}_button_{address}"
-        
+        self._wall_button = wall_info
+
         self._attr_is_on = False
         self._reset_timer_cancel: Any | None = None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose wall-button parent info and linked module outputs."""
+        parent_attrs = super().extra_state_attributes or {}
+        attrs: dict[str, Any] = {
+            **parent_attrs,
+            "linked_outputs": self.coordinator.get_button_linked_outputs(self._address),
+        }
+        if self._wall_button:
+            attrs["wall_button_address"] = self._wall_button.get("address")
+            attrs["wall_button_model"] = self._wall_button.get("model")
+            attrs["wall_button_type"] = self._wall_button.get("type")
+            attrs["wall_button_key"] = self._wall_button.get("key")
+        return attrs
 
     @property
     def state(self) -> str:

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -31,12 +31,48 @@ async def async_setup_entry(
 
     if coordinator.dict_button_data:
         buttons = coordinator.dict_button_data.get("nikobus_button", {})
+        register_wall_button_devices(hass, entry, buttons)
         entities.extend(
             NikobusButtonEntity(coordinator, addr, data)
             for addr, data in buttons.items()
         )
 
     async_add_entities(entities)
+
+
+def register_wall_button_devices(
+    hass: HomeAssistant,
+    entry: NikobusConfigEntry,
+    buttons: dict[str, Any],
+) -> None:
+    """Register one device per physical wall button (linked_button address).
+
+    Groups the 1..N software buttons of a keypad/IR remote under a single
+    parent device in the device registry. Idempotent: safe to call from
+    multiple platforms.
+    """
+    device_registry = dr.async_get(hass)
+    seen: set[str] = set()
+    for data in buttons.values():
+        if not isinstance(data, dict):
+            continue
+        for info in data.get("linked_button") or []:
+            if not isinstance(info, dict):
+                continue
+            address = info.get("address")
+            if not address or address in seen:
+                continue
+            seen.add(address)
+            model = info.get("model") or info.get("type") or "Wall Button"
+            name = info.get("type") or f"Wall Button {address}"
+            device_registry.async_get_or_create(
+                config_entry_id=entry.entry_id,
+                identifiers={(DOMAIN, address)},
+                manufacturer=BRAND,
+                name=name,
+                model=model,
+                via_device=(DOMAIN, HUB_IDENTIFIER),
+            )
 
 
 def _hub_device_info() -> dr.DeviceInfo:
@@ -90,26 +126,46 @@ class NikobusButtonEntity(NikobusEntity, ButtonEntity):
     """Representation of a Nikobus UI button (Software trigger)."""
 
     def __init__(
-        self, 
-        coordinator: NikobusDataCoordinator, 
-        address: str, 
+        self,
+        coordinator: NikobusDataCoordinator,
+        address: str,
         data: dict[str, Any]
     ) -> None:
         """Initialize the button entity."""
-        
+
         raw_desc = str(data.get("description", ""))
         name = raw_desc if raw_desc and "UndefinedType" not in raw_desc else f"Button {address}"
 
+        wall_info = coordinator.get_wall_button_info(address)
+        via_device = (DOMAIN, wall_info["address"]) if wall_info else (DOMAIN, HUB_IDENTIFIER)
+
         super().__init__(
-            coordinator=coordinator, 
-            address=address, 
-            name=name, 
-            model="Push Button"
+            coordinator=coordinator,
+            address=address,
+            name=name,
+            model="Push Button",
+            via_device=via_device,
         )
-        
+
         # Unique ID for the Home Assistant entity registry
         self._attr_unique_id = f"{DOMAIN}_push_button_{address}"
         self._operation_time = data.get("operation_time")
+        self._wall_button = wall_info
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose wall-button parent info and linked module outputs."""
+        parent_attrs = super().extra_state_attributes or {}
+        attrs: dict[str, Any] = {
+            **parent_attrs,
+            "linked_outputs": self.coordinator.get_button_linked_outputs(self._address),
+        }
+        if self._wall_button:
+            attrs["wall_button_address"] = self._wall_button.get("address")
+            attrs["wall_button_model"] = self._wall_button.get("model")
+            attrs["wall_button_type"] = self._wall_button.get("type")
+            attrs["wall_button_key"] = self._wall_button.get("key")
+        return attrs
 
     async def async_press(self) -> None:
         """Execute the button press command on the Nikobus bus."""

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -83,6 +83,9 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self.dict_button_data: dict[str, Any] = {}
         self.dict_scene_data: dict[str, Any] = {}
 
+        # Lazy cache: (module_address_upper, channel) -> [button records that trigger it]
+        self._controlled_by_index: dict[tuple[str, int], list[dict[str, Any]]] | None = None
+
         self.nikobus_actuator: NikobusActuator | None = None
         self.nikobus_listener: NikobusEventListener | None = None
         self.nikobus_command: NikobusCommandHandler | None = None
@@ -623,6 +626,99 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                     if isinstance(ch, int) and ch > 0:
                         return ch
         return None
+
+    # ------------------------------------------------------------------
+    # Discovery link helpers (wall button parents + controlled_by index)
+    # ------------------------------------------------------------------
+
+    def get_wall_button_info(self, button_address: str) -> dict[str, Any] | None:
+        """Return the physical wall-button record a software button belongs to.
+
+        Reads the first entry of ``linked_button`` for the given software
+        button address. Returns ``None`` if the button has never been discovered.
+        """
+        button = (self.dict_button_data or {}).get("nikobus_button", {}).get(button_address)
+        if not isinstance(button, dict):
+            return None
+        for info in button.get("linked_button") or []:
+            if isinstance(info, dict) and info.get("address"):
+                return info
+        return None
+
+    def get_button_linked_outputs(self, button_address: str) -> list[dict[str, Any]]:
+        """Return flattened output links for a software button.
+
+        Each item: ``{module_address, channel, mode, t1, t2}``.
+        """
+        button = (self.dict_button_data or {}).get("nikobus_button", {}).get(button_address)
+        if not isinstance(button, dict):
+            return []
+        flattened: list[dict[str, Any]] = []
+        for link in button.get("linked_modules") or []:
+            if not isinstance(link, dict):
+                continue
+            module_address = link.get("module_address")
+            for out in link.get("outputs") or []:
+                if not isinstance(out, dict):
+                    continue
+                flattened.append({
+                    "module_address": module_address,
+                    "channel": out.get("channel"),
+                    "mode": out.get("mode"),
+                    "t1": out.get("t1"),
+                    "t2": out.get("t2"),
+                })
+        return flattened
+
+    def _build_controlled_by_index(self) -> dict[tuple[str, int], list[dict[str, Any]]]:
+        """Build a (module_address_upper, channel) -> list[button record] index."""
+        index: dict[tuple[str, int], list[dict[str, Any]]] = {}
+        buttons = (self.dict_button_data or {}).get("nikobus_button", {})
+        for soft_addr, button in buttons.items():
+            if not isinstance(button, dict):
+                continue
+            description = button.get("description") or f"Button {soft_addr}"
+            wall_info = next(
+                (i for i in (button.get("linked_button") or []) if isinstance(i, dict)),
+                None,
+            )
+            wall_addr = (wall_info or {}).get("address") if wall_info else None
+            wall_key = (wall_info or {}).get("key") if wall_info else None
+            for link in button.get("linked_modules") or []:
+                if not isinstance(link, dict):
+                    continue
+                module_address = link.get("module_address")
+                if not module_address:
+                    continue
+                module_key = str(module_address).upper()
+                for out in link.get("outputs") or []:
+                    if not isinstance(out, dict):
+                        continue
+                    channel = out.get("channel")
+                    if not isinstance(channel, int):
+                        continue
+                    index.setdefault((module_key, channel), []).append({
+                        "button_address": soft_addr,
+                        "description": description,
+                        "mode": out.get("mode"),
+                        "t1": out.get("t1"),
+                        "t2": out.get("t2"),
+                        "wall_button_address": wall_addr,
+                        "wall_button_key": wall_key,
+                    })
+        return index
+
+    def get_controlled_by(self, module_address: str, channel: int) -> list[dict[str, Any]]:
+        """Return the buttons that trigger a given ``(module_address, channel)``."""
+        if self._controlled_by_index is None:
+            self._controlled_by_index = self._build_controlled_by_index()
+        return self._controlled_by_index.get(
+            (str(module_address).upper(), int(channel)), []
+        )
+
+    def invalidate_controlled_by_index(self) -> None:
+        """Drop the cached controlled-by index — call after discovery updates."""
+        self._controlled_by_index = None
 
     def get_cover_operation_time(
         self, module_id: str, channel: int, direction: str = "up", default: float = 30.0

--- a/custom_components/nikobus/cover.py
+++ b/custom_components/nikobus/cover.py
@@ -205,6 +205,7 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
             "operation_time_up": self._calculator.time_up,
             "operation_time_down": self._calculator.time_down,
             "movement_source": self._movement_source,
+            "controlled_by": self.coordinator.get_controlled_by(self._address, self._channel),
         }
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/nikobus/entity.py
+++ b/custom_components/nikobus/entity.py
@@ -24,6 +24,7 @@ class NikobusEntity(CoordinatorEntity[NikobusDataCoordinator]):
         address: str,
         name: str,
         model: str,
+        via_device: tuple[str, str] | None = None,
     ) -> None:
         """Initialize the entity with shared device information."""
         super().__init__(coordinator)
@@ -32,12 +33,15 @@ class NikobusEntity(CoordinatorEntity[NikobusDataCoordinator]):
         self._device_model = model
 
         # Platinum Architecture: Groups channels under a single physical device.
-        self._attr_device_info = dr.DeviceInfo(
+        device_info = dr.DeviceInfo(
             identifiers={(DOMAIN, self._address)},
             name=self._device_name,
             manufacturer=BRAND,
             model=self._device_model,
         )
+        if via_device is not None:
+            device_info["via_device"] = via_device
+        self._attr_device_info = device_info
 
     @property
     def available(self) -> bool:

--- a/custom_components/nikobus/light.py
+++ b/custom_components/nikobus/light.py
@@ -97,6 +97,7 @@ class NikobusBaseLight(NikobusEntity, LightEntity, RestoreEntity):
             "channel_description": self._channel_description,
             "module_description": self._module_description,
             "module_model": self._module_model,
+            "controlled_by": self.coordinator.get_controlled_by(self._address, self._channel),
         }
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/nikobus/switch.py
+++ b/custom_components/nikobus/switch.py
@@ -90,6 +90,7 @@ class NikobusBaseSwitch(NikobusEntity, SwitchEntity, RestoreEntity):
             "channel_description": self._channel_description,
             "module_description": self._module_description,
             "module_model": self._module_model,
+            "controlled_by": self.coordinator.get_controlled_by(self._address, self._channel),
         }
 
     async def async_added_to_hass(self) -> None:


### PR DESCRIPTION
## Summary

Turns the `linked_button` / `linked_modules` fields produced by discovery into something the HA UI can actually show:

- **Wall-button parent device.** Register one device per physical keypad/IR button (`linked_button.address`) and attach each software button to it via `via_device`. The 4 soft buttons of an 05-348 now appear nested under a single "IR Button with 4 Operation Points" device, itself nested under the Nikobus Bridge.
- **Button attributes.** Software button + physical binary-sensor entities expose `linked_outputs` (flattened module / channel / mode / t1 / t2) and `wall_button_*` metadata.
- **controlled_by back-link.** Light, cover, and switch entities gain a `controlled_by` attribute listing every button (with description, mode, timers, parent wall-button) that triggers that specific `(module_address, channel)`.
- **Coordinator helpers.** New `get_wall_button_info`, `get_button_linked_outputs`, `get_controlled_by` (with lazy reverse index) centralise the lookups. The cache rebuilds naturally when the config entry reloads after discovery.

## Test plan

- [ ] Run a PC Link inventory + module scan, then check the Devices view: soft buttons should be grouped under their physical wall button, and the wall buttons under the bridge.
- [ ] Open a button entity — confirm `linked_outputs`, `wall_button_model`, `wall_button_type`, `wall_button_key` attributes are populated.
- [ ] Open a light/cover/switch entity — confirm `controlled_by` lists the buttons that trigger it (with mode + t1/t2 + wall button parent).
- [ ] Undiscovered buttons (no `linked_button`) still appear under the bridge as before and don't crash.
- [ ] Re-run discovery and reload the entry — attributes reflect the updated links.

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2