### PR TITLE
Name wall-button devices from common child prefix

### DIFF
--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+import re
+from os.path import commonprefix
 from typing import Any
 
 from homeassistant.components.button import ButtonEntity
@@ -52,27 +54,76 @@ def register_wall_button_devices(
     multiple platforms.
     """
     device_registry = dr.async_get(hass)
-    seen: set[str] = set()
+
+    # Pass 1: bucket soft-button descriptions by wall-button address.
+    grouped: dict[str, dict[str, Any]] = {}
     for data in buttons.values():
         if not isinstance(data, dict):
             continue
+        desc = str(data.get("description", "") or "")
         for info in data.get("linked_button") or []:
             if not isinstance(info, dict):
                 continue
             address = info.get("address")
-            if not address or address in seen:
+            if not address:
                 continue
-            seen.add(address)
-            model = info.get("model") or info.get("type") or "Wall Button"
-            name = info.get("type") or f"Wall Button {address}"
-            device_registry.async_get_or_create(
-                config_entry_id=entry.entry_id,
-                identifiers={(DOMAIN, address)},
-                manufacturer=BRAND,
-                name=name,
-                model=model,
-                via_device=(DOMAIN, HUB_IDENTIFIER),
-            )
+            bucket = grouped.setdefault(address, {"info": info, "children": []})
+            if desc:
+                bucket["children"].append(desc)
+
+    # Pass 2: register each wall-button device with a unique, meaningful name.
+    for address, bucket in grouped.items():
+        info = bucket["info"]
+        model = info.get("model") or info.get("type") or "Wall Button"
+        name = _wall_button_display_name(info, bucket["children"])
+        device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, address)},
+            manufacturer=BRAND,
+            name=name,
+            model=model,
+            via_device=(DOMAIN, HUB_IDENTIFIER),
+        )
+
+
+def _wall_button_display_name(info: dict[str, Any], child_descriptions: list[str]) -> str:
+    """Derive a unique, human-friendly name for a wall-button parent device.
+
+    Uses the longest common prefix of the soft-button descriptions so a keypad
+    whose children are ``BT_GF_Living_Sofa_Wall_Light_Up`` / ``…_Down`` /
+    ``…_Shutter_Open`` / ``…_Close`` is named ``BT_GF_Living_Sofa``. Falls back
+    to ``{type} ({address})`` when no useful prefix exists.
+    """
+    address = str(info.get("address") or "")
+    type_str = str(info.get("type") or info.get("model") or "Wall Button")
+
+    # Drop placeholder descriptions Nikobus auto-generates for unknown buttons:
+    # "DISCOVERED - Nikobus Button #NABCDEF", "Button with 8 Operation Points #NABCDEF",
+    # "Feedback Button with 4 Operation Points #NABCDEF", etc.
+    meaningful = [
+        d for d in child_descriptions
+        if d
+        and not d.startswith("DISCOVERED")
+        and "UndefinedType" not in d
+        and not re.search(r"#N[0-9A-Fa-f]+$", d)
+    ]
+    if len(meaningful) == 1:
+        return meaningful[0]
+    if len(meaningful) >= 2:
+        prefix = commonprefix(meaningful)
+        # If the common prefix stops mid-word ("BT_FF_Office_Light_O" from
+        # "…_On" / "…_Off"), trim back to the last natural separator.
+        if prefix and prefix[-1] not in " _-·/":
+            idx = max(prefix.rfind("_"), prefix.rfind("-"), prefix.rfind(" "))
+            if idx >= 3:
+                prefix = prefix[:idx]
+        prefix = prefix.rstrip(" _-·/")
+        # Require at least a couple of semantic chunks to avoid meaningless
+        # single-letter prefixes like "B" across unrelated buttons.
+        if prefix.count("_") >= 2 or len(prefix) >= 8:
+            return prefix
+
+    return f"{type_str} ({address})" if address else type_str
 
 
 def _hub_device_info() -> dr.DeviceInfo:


### PR DESCRIPTION
## Summary

Follow-up to #275. The wall-button parent devices were all named after their generic type ("IR Button with 4 Operation Points", "Button with 4 Operation Points", …), so every keypad looked identical in the UI.

Now the name is derived from the **longest common prefix of the child soft-button descriptions**, trimmed back to a natural word boundary, with auto-generated placeholders (`DISCOVERED - …`, `Button with 8 Operation Points #N…`) filtered out. Falls back to `{type} ({address})` when no useful prefix exists.

Against the real config posted in #275, this yields:

| Address | Name |
|---|---|
| `0D1C80` | `BT_GF_Living_Sofa` |
| `1CA840` | `BT_GF_Garage` |
| `0FFEC0` | `BT_GF_FamilyRoom` |
| `1DF256` | `BT_HF_Bedroom_Left` |
| `1DF1E0` | `BT_HF_Bedroom_Right` |
| `17F2F8` | `BT_HF_Toilet_Light` |
| `1E1EC8` | `BT_FF_Office_Light` |
| `10152B` | `Feedback Button with 4 Operation Points (10152B)` |
| `2E58F6` | `RF Transmitter (2E58F6)` |

## Test plan

- [ ] Reload the integration and check Settings → Devices & Services → Nikobus — each keypad now has a distinct, meaningful name and groups its soft buttons underneath.
- [ ] Keypads that only have auto-generated child descriptions fall back to `{type} ({address})` and remain unique.

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2