### PR TITLE
Preserve wall-button parents during orphan cleanup

### DIFF
--- a/custom_components/nikobus/__init__.py
+++ b/custom_components/nikobus/__init__.py
@@ -139,17 +139,25 @@ async def _async_cleanup_orphan_entities(
         if entity.unique_id not in valid_entity_ids:
             ent_reg.async_remove(entity.entity_id)
 
-    # Remove orphan devices (except the hub)
+    # Remove orphan devices (except the hub). A device is kept when it either
+    # has at least one entity of its own OR acts as the ``via_device`` parent
+    # of another device in this entry (e.g. a physical wall button that groups
+    # its soft-button children but has no entity of its own).
     hub_identifier = (DOMAIN, HUB_IDENTIFIER)
     devices_with_entities = {
         entity.device_id for entity in ent_reg.entities.values()
         if entity.config_entry_id == entry.entry_id and entity.device_id
     }
+    via_parent_ids = {
+        device.via_device_id for device in dev_reg.devices.values()
+        if device.via_device_id and entry.entry_id in device.config_entries
+    }
 
     for device in list(dev_reg.devices.values()):
         if entry.entry_id in device.config_entries and hub_identifier not in device.identifiers:
-            if device.id not in devices_with_entities:
-                dev_reg.async_remove_device(device.id)
+            if device.id in devices_with_entities or device.id in via_parent_ids:
+                continue
+            dev_reg.async_remove_device(device.id)
 
 async def async_unload_entry(hass: HomeAssistant, entry: NikobusConfigEntry) -> bool:
     """Unload the integration and stop background tasks."""


### PR DESCRIPTION
## Summary

Follow-up to #275 / #276. The `_async_cleanup_orphan_entities` routine in `__init__.py` removed any device with no entities attached on every setup. The wall-button parent devices introduced in #275 intentionally carry no entities — they exist purely to group soft-button children via `via_device` — so they were getting wiped immediately after being registered, which is why `BT_FF_Bathroom_Light` (and its siblings) never appeared in the UI.

The cleanup now also spares any device that is referenced as `via_device_id` by another device in the same config entry, so grouping parents survive.

## Test plan

- [ ] Full HA restart after pulling this in.
- [ ] Settings → Devices & Services → Nikobus: confirm wall-button parents (e.g. `BT_FF_Bathroom_Light`, `BT_GF_Living_Sofa`) appear alongside their soft-button children.
- [ ] Soft buttons remain grouped under their wall-button parent (visible from a soft-button's device page).

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2