### PR TITLE
Drop nikobus_button_config.json; persist buttons via HA Store

### DIFF
--- a/custom_components/nikobus/__init__.py
+++ b/custom_components/nikobus/__init__.py
@@ -36,6 +36,9 @@ PLATFORMS: Final[list[str]] = [
 ]
 
 SCAN_MODULE_SCHEMA = vol.Schema({vol.Optional("module_address", default=""): cv.string})
+SEND_BUTTON_PRESS_SCHEMA = vol.Schema({
+    vol.Required("address"): cv.string,
+})
 
 async def async_setup_entry(hass: HomeAssistant, entry: NikobusConfigEntry) -> bool:
     """Set up the Nikobus integration (single-instance) without redundant handshakes."""
@@ -84,6 +87,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: NikobusConfigEntry) -> b
             "query_module_inventory",
             handle_module_discovery,
             SCAN_MODULE_SCHEMA,
+        )
+
+    async def handle_send_button_press(call: ServiceCall) -> None:
+        """Fire a Nikobus button-press command on the bus for the given address.
+
+        Useful for virtual / IR-scene entries that are not part of discovery —
+        define them as scripts/automations calling this service.
+        """
+        address = (call.data.get("address", "") or "").strip().upper()
+        if not address:
+            _LOGGER.warning("nikobus.send_button_press called without address")
+            return
+        await coordinator.async_event_handler("ha_button_pressed", {"address": address})
+
+    if not hass.services.has_service(DOMAIN, "send_button_press"):
+        hass.services.async_register(
+            DOMAIN,
+            "send_button_press",
+            handle_send_button_press,
+            SEND_BUTTON_PRESS_SCHEMA,
         )
 
     # 4. Forward setup to platforms FIRST

--- a/custom_components/nikobus/binary_sensor.py
+++ b/custom_components/nikobus/binary_sensor.py
@@ -30,19 +30,20 @@ async def async_setup_entry(
     """Set up Nikobus button sensor entities from a config entry."""
     coordinator: NikobusDataCoordinator = entry.runtime_data
 
-    if not coordinator.dict_button_data:
-        return
-
-    buttons = coordinator.dict_button_data.get("nikobus_button", {})
-    register_wall_button_devices(hass, entry, buttons)
+    buttons = (coordinator.dict_button_data or {}).get("nikobus_button", {})
+    discovered = {
+        addr: data for addr, data in buttons.items()
+        if isinstance(data, dict) and data.get("linked_button")
+    }
+    register_wall_button_devices(hass, entry, discovered)
 
     async_add_entities(
         NikobusButtonBinarySensor(
             coordinator=coordinator,
             address=address,
-            description=data.get("description", f"Button {address}"),
+            description=f"Button {address}",
         )
-        for address, data in buttons.items()
+        for address in discovered
     )
 
 

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -29,13 +29,19 @@ async def async_setup_entry(
         NikobusModuleScanButton(coordinator),
     ]
 
-    if coordinator.dict_button_data:
-        buttons = coordinator.dict_button_data.get("nikobus_button", {})
-        register_wall_button_devices(hass, entry, buttons)
-        entities.extend(
-            NikobusButtonEntity(coordinator, addr, data)
-            for addr, data in buttons.items()
-        )
+    buttons = (coordinator.dict_button_data or {}).get("nikobus_button", {})
+    # Only discovered buttons (those with at least one linked_button entry)
+    # become HA entities. Hand-added virtual entries are intentionally ignored —
+    # fire them from scripts/automations via ``nikobus.send_button_press``.
+    discovered = {
+        addr: data for addr, data in buttons.items()
+        if isinstance(data, dict) and data.get("linked_button")
+    }
+    register_wall_button_devices(hass, entry, discovered)
+    entities.extend(
+        NikobusButtonEntity(coordinator, addr, data)
+        for addr, data in discovered.items()
+    )
 
     async_add_entities(entities)
 
@@ -135,11 +141,9 @@ class NikobusButtonEntity(NikobusEntity, ButtonEntity):
     ) -> None:
         """Initialize the button entity."""
 
-        raw_desc = str(data.get("description", ""))
-        name = raw_desc if raw_desc and "UndefinedType" not in raw_desc else f"Button {address}"
-
         wall_info = coordinator.get_wall_button_info(address)
         via_device = (DOMAIN, wall_info["address"]) if wall_info else (DOMAIN, HUB_IDENTIFIER)
+        name = f"Button {address}"
 
         super().__init__(
             coordinator=coordinator,
@@ -149,9 +153,7 @@ class NikobusButtonEntity(NikobusEntity, ButtonEntity):
             via_device=via_device,
         )
 
-        # Unique ID for the Home Assistant entity registry
         self._attr_unique_id = f"{DOMAIN}_push_button_{address}"
-        self._operation_time = data.get("operation_time")
         self._wall_button = wall_info
 
     @property
@@ -172,11 +174,9 @@ class NikobusButtonEntity(NikobusEntity, ButtonEntity):
     async def async_press(self) -> None:
         """Execute the button press command on the Nikobus bus."""
         _LOGGER.debug("UI Button pressed for address: %s", self._address)
-        
-        await self.coordinator.async_event_handler("ha_button_pressed", {
-            "address": self._address,
-            "operation_time": self._operation_time,
-        })
+        await self.coordinator.async_event_handler(
+            "ha_button_pressed", {"address": self._address}
+        )
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import logging
-import re
-from os.path import commonprefix
 from typing import Any
 
 from homeassistant.components.button import ButtonEntity
@@ -50,80 +48,33 @@ def register_wall_button_devices(
     """Register one device per physical wall button (linked_button address).
 
     Groups the 1..N software buttons of a keypad/IR remote under a single
-    parent device in the device registry. Idempotent: safe to call from
-    multiple platforms.
+    parent device in the device registry. The default name is taken straight
+    from the discovery metadata (``{type} ({address})``) so it is identical
+    for every user; HA preserves any user rename via ``name_by_user`` across
+    reloads. Idempotent: safe to call from multiple platforms.
     """
     device_registry = dr.async_get(hass)
-
-    # Pass 1: bucket soft-button descriptions by wall-button address.
-    grouped: dict[str, dict[str, Any]] = {}
+    seen: set[str] = set()
     for data in buttons.values():
         if not isinstance(data, dict):
             continue
-        desc = str(data.get("description", "") or "")
         for info in data.get("linked_button") or []:
             if not isinstance(info, dict):
                 continue
             address = info.get("address")
-            if not address:
+            if not address or address in seen:
                 continue
-            bucket = grouped.setdefault(address, {"info": info, "children": []})
-            if desc:
-                bucket["children"].append(desc)
-
-    # Pass 2: register each wall-button device with a unique, meaningful name.
-    for address, bucket in grouped.items():
-        info = bucket["info"]
-        model = info.get("model") or info.get("type") or "Wall Button"
-        name = _wall_button_display_name(info, bucket["children"])
-        device_registry.async_get_or_create(
-            config_entry_id=entry.entry_id,
-            identifiers={(DOMAIN, address)},
-            manufacturer=BRAND,
-            name=name,
-            model=model,
-            via_device=(DOMAIN, HUB_IDENTIFIER),
-        )
-
-
-def _wall_button_display_name(info: dict[str, Any], child_descriptions: list[str]) -> str:
-    """Derive a unique, human-friendly name for a wall-button parent device.
-
-    Uses the longest common prefix of the soft-button descriptions so a keypad
-    whose children are ``BT_GF_Living_Sofa_Wall_Light_Up`` / ``…_Down`` /
-    ``…_Shutter_Open`` / ``…_Close`` is named ``BT_GF_Living_Sofa``. Falls back
-    to ``{type} ({address})`` when no useful prefix exists.
-    """
-    address = str(info.get("address") or "")
-    type_str = str(info.get("type") or info.get("model") or "Wall Button")
-
-    # Drop placeholder descriptions Nikobus auto-generates for unknown buttons:
-    # "DISCOVERED - Nikobus Button #NABCDEF", "Button with 8 Operation Points #NABCDEF",
-    # "Feedback Button with 4 Operation Points #NABCDEF", etc.
-    meaningful = [
-        d for d in child_descriptions
-        if d
-        and not d.startswith("DISCOVERED")
-        and "UndefinedType" not in d
-        and not re.search(r"#N[0-9A-Fa-f]+$", d)
-    ]
-    if len(meaningful) == 1:
-        return meaningful[0]
-    if len(meaningful) >= 2:
-        prefix = commonprefix(meaningful)
-        # If the common prefix stops mid-word ("BT_FF_Office_Light_O" from
-        # "…_On" / "…_Off"), trim back to the last natural separator.
-        if prefix and prefix[-1] not in " _-·/":
-            idx = max(prefix.rfind("_"), prefix.rfind("-"), prefix.rfind(" "))
-            if idx >= 3:
-                prefix = prefix[:idx]
-        prefix = prefix.rstrip(" _-·/")
-        # Require at least a couple of semantic chunks to avoid meaningless
-        # single-letter prefixes like "B" across unrelated buttons.
-        if prefix.count("_") >= 2 or len(prefix) >= 8:
-            return prefix
-
-    return f"{type_str} ({address})" if address else type_str
+            seen.add(address)
+            type_str = str(info.get("type") or info.get("model") or "Wall Button")
+            model = str(info.get("model") or info.get("type") or "Wall Button")
+            device_registry.async_get_or_create(
+                config_entry_id=entry.entry_id,
+                identifiers={(DOMAIN, address)},
+                manufacturer=BRAND,
+                name=f"{type_str} ({address})",
+                model=model,
+                via_device=(DOMAIN, HUB_IDENTIFIER),
+            )
 
 
 def _hub_device_info() -> dr.DeviceInfo:

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -37,6 +37,7 @@ from .const import (
 )
 from .nkbactuator import NikobusActuator
 from .nkbconfig import NikobusConfig
+from .nkbstorage import NikobusButtonStorage
 
 # Typed config entry alias used across the integration. A plain alias
 # (instead of PEP 695 `type X = ...`) keeps compatibility with older
@@ -77,10 +78,11 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
 
         self.nikobus_connection = NikobusConnect(self.connection_string)
         self.nikobus_config = NikobusConfig(hass)
+        self.button_storage = NikobusButtonStorage(hass)
         self.api: NikobusAPI | None = None
 
         self.dict_module_data: dict[str, Any] = {}
-        self.dict_button_data: dict[str, Any] = {}
+        self.dict_button_data: dict[str, Any] = {"nikobus_button": {}}
         self.dict_scene_data: dict[str, Any] = {}
 
         # Lazy cache: (module_address_upper, channel) -> [button records that trigger it]
@@ -170,9 +172,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             if discovered_modules:
                 self._merge_discovered_modules(discovered_modules)
 
-            self.dict_button_data = await self.nikobus_config.load_json_data(
-                "nikobus_button_config.json", "button"
-            ) or {"nikobus_button": {}}
+            self.dict_button_data = await self.button_storage.async_load()
             self.dict_scene_data = await self.nikobus_config.load_json_data(
                 "nikobus_scene_config.json", "scene"
             )
@@ -185,6 +185,8 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 self,
                 config_dir=self.hass.config.config_dir,
                 create_task=self.hass.async_create_task,
+                button_data=self.dict_button_data,
+                on_button_save=self.button_storage.async_save,
             )
             self.nikobus_discovery.on_discovery_finished = self._handle_discovery_finished
 

--- a/custom_components/nikobus/cover.py
+++ b/custom_components/nikobus/cover.py
@@ -25,7 +25,6 @@ from .const import (
     DEFAULT_COVER_MOVEMENT_BUFFER,
     DEFAULT_COVER_OPERATION_TIME,
     DOMAIN,
-    EVENT_BUTTON_OPERATION,
     EVENT_BUTTON_PRESSED,
     HUB_IDENTIFIER,
 )
@@ -166,11 +165,6 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
         # that the in-transit position reflects actual elapsed travel time.
         self._last_button_press_monotonic: float | None = None
 
-        # Set by _handle_nikobus_event when EVENT_BUTTON_OPERATION carries a
-        # button-configured operation time (tilt / partial move).  Consumed by
-        # _handle_coordinator_update when starting the corresponding motion.
-        self._last_button_operation_time: float | None = None
-
     @property
     def current_cover_position(self) -> int:
         """Return the current position of the cover (0-100)."""
@@ -216,9 +210,6 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
                 self._position = float(pos)
                 self._calculator.set_position(self._position)
 
-        self.async_on_remove(
-            self.hass.bus.async_listen(EVENT_BUTTON_OPERATION, self._handle_nikobus_event)
-        )
         self.async_on_remove(
             self.hass.bus.async_listen(EVENT_BUTTON_PRESSED, self._handle_button_pressed)
         )
@@ -284,13 +275,7 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
                     detection_latency = age
                 self._last_button_press_monotonic = None
 
-            # Consume any button-configured operation time (e.g. tilt / partial
-            # move) stored by _handle_nikobus_event.  Takes precedence over the
-            # default full-travel run limit.
-            op_time = self._last_button_operation_time
-            self._last_button_operation_time = None
-
-            self._start_motion_logic(direction, limit_time=op_time, detection_latency=detection_latency)
+            self._start_motion_logic(direction, detection_latency=detection_latency)
 
         super()._handle_coordinator_update()
 
@@ -321,24 +306,6 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
             # Cover is moving — this press is a stop command.
             send_stop = (self._movement_source == "ha")
             await self._stop(send_stop=send_stop)
-
-    async def _handle_nikobus_event(self, event: Any) -> None:
-        """Capture button_operation_time from the Nikobus bus event payload.
-
-        EVENT_BUTTON_OPERATION fires before the state buffer is updated, so
-        motion tracking is deferred to _handle_coordinator_update which fires
-        after the buffer is refreshed.  This handler's only job is to store
-        any button-configured operation time (tilt / partial move) so that
-        _handle_coordinator_update can apply it when it starts the motion.
-        """
-        if str(event.data.get("impacted_module_address", "")).upper() != str(self._address).upper():
-            return
-        op_time = event.data.get("button_operation_time")
-        if op_time is not None:
-            try:
-                self._last_button_operation_time = float(op_time)
-            except (TypeError, ValueError):
-                pass
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open cover command."""
@@ -395,7 +362,6 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
     def _start_motion_logic(
         self,
         direction: str,
-        limit_time: float | None = None,
         detection_latency: float = 0.0,
     ) -> None:
         """Initialize the virtual travel tracker."""
@@ -415,15 +381,11 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
         # Sync position immediately so the UI reflects in-transit state.
         self._position = self._calculator.current_position()
 
-        if limit_time is not None:
-            # Button-configured operation time (tilt / partial move).
-            self._current_run_limit = float(limit_time)
-        else:
-            # Full-travel run limit, shortened by already-elapsed detection time.
-            self._current_run_limit = max(
-                DEFAULT_COVER_MOVEMENT_BUFFER,
-                active_op_time - detection_latency + DEFAULT_COVER_MOVEMENT_BUFFER,
-            )
+        # Full-travel run limit, shortened by already-elapsed detection time.
+        self._current_run_limit = max(
+            DEFAULT_COVER_MOVEMENT_BUFFER,
+            active_op_time - detection_latency + DEFAULT_COVER_MOVEMENT_BUFFER,
+        )
 
         self._motion_task = self.hass.async_create_task(self._motion_loop())
         self.async_write_ha_state()

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect==0.1.9"
+    "nikobus-connect==0.2.0"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }

--- a/custom_components/nikobus/nkbactuator.py
+++ b/custom_components/nikobus/nkbactuator.py
@@ -174,38 +174,42 @@ class NikobusActuator:
     async def button_discovery(self, address: str, press_context: Optional[Dict[str, Any]] = None) -> None:
         """Identify impacted modules and trigger targeted refreshes."""
         button_data = self._dict_button_data.get("nikobus_button", {}).get(address)
-
         if button_data:
             await self.process_button_modules(button_data, address, press_context)
         else:
-            # Auto-discovery for unconfigured buttons
-            new_button = {
-                "description": f"DISCOVERED - Nikobus Button #N{address}",
-                "address": address,
-                "impacted_module": [{"address": "", "group": ""}],
-            }
-            self._dict_button_data.setdefault("nikobus_button", {})[address] = new_button
-            try:
-                await self._coordinator.nikobus_config.write_json_data(
-                    "nikobus_button_config.json", "button", self._dict_button_data
-                )
-            except Exception as err:
-                _LOGGER.warning("Failed to persist discovered button %s to config: %s", address, err)
+            _LOGGER.debug("Press from unknown button %s — run discovery to populate it", address)
+
+    def _derive_impacted_modules(self, button_data: Dict[str, Any]) -> list[tuple[str, str]]:
+        """Return the unique (module_address, group) pairs this button affects.
+
+        Derived from ``linked_modules`` — channels 1-6 live in feedback group 1,
+        7-12 in group 2.
+        """
+        seen: set[tuple[str, str]] = set()
+        for link in button_data.get("linked_modules") or []:
+            if not isinstance(link, dict):
+                continue
+            module_address = (link.get("module_address") or "").upper()
+            if not module_address:
+                continue
+            for out in link.get("outputs") or []:
+                if not isinstance(out, dict):
+                    continue
+                channel = out.get("channel")
+                if not isinstance(channel, int):
+                    continue
+                group = "1" if channel <= 6 else "2"
+                seen.add((module_address, group))
+        return list(seen)
 
     async def process_button_modules(self, button_data: Dict[str, Any], button_address: str, press_context: Optional[Dict[str, Any]]) -> None:
         """Refresh states for specific modules impacted by this button."""
-        op_time = float(button_data.get("operation_time", 0))
         press_id = (press_context or {}).get("press_id") or f"{button_address}-{uuid.uuid4().hex[:8]}"
-        
-        impacted_modules = button_data.get("impacted_module", [])
-        
-        _LOGGER.debug("[%s] Processing button %s: %d modules impacted", press_id, button_address, len(impacted_modules))
 
-        for module_info in impacted_modules:
-            addr = (module_info.get("address") or "").upper()
-            group = module_info.get("group", "")
-            if not addr or not group:
-                continue
+        impacted = self._derive_impacted_modules(button_data)
+        _LOGGER.debug("[%s] Processing button %s: %d modules impacted", press_id, button_address, len(impacted))
+
+        for addr, group in impacted:
 
             # Determine if this specific module is a dimmer BEFORE debouncing
             is_dimmer = addr in self._dict_module_data.get("dimmer_module", {})
@@ -227,7 +231,6 @@ class NikobusActuator:
                 duration=(press_context or {}).get("duration_s"),
                 bucket=(press_context or {}).get("bucket"),
                 extra={
-                    "button_operation_time": op_time,
                     "impacted_module_address": addr,
                     "impacted_module_group": group,
                 }
@@ -317,31 +320,22 @@ class NikobusActuator:
         self._hass.bus.async_fire(event_type, payload)
 
     def _derive_button_context(self, address: str) -> Tuple[Optional[str], Optional[int]]:
-        """Determine primary module/channel link for a button from config."""
+        """Determine the primary (module_address, channel) link from discovery."""
         button_data = self._dict_button_data.get("nikobus_button", {}).get(address, {})
-        impacted = button_data.get("impacted_module") or []
-        links = button_data.get("linked_modules") or []
-
-        # Try impacted_module first, skipping empty placeholder entries
-        module_addr = None
-        for entry in impacted:
-            if entry.get("address"):
-                module_addr = entry["address"]
-                break
-
-        channel = None
-
-        # Fall back to linked_modules if no configured impacted_module
-        if not module_addr and links:
-            first_link = links[0]
-            module_addr = first_link.get("module_address")
-            outputs = first_link.get("outputs")
+        for link in button_data.get("linked_modules") or []:
+            if not isinstance(link, dict):
+                continue
+            module_addr = link.get("module_address")
+            if not module_addr:
+                continue
+            channel: Optional[int] = None
+            outputs = link.get("outputs")
             if isinstance(outputs, list) and outputs:
                 ch_val = outputs[0].get("channel")
                 if isinstance(ch_val, int):
                     channel = ch_val
-
-        return (module_addr.upper() if module_addr else None, channel)
+            return (module_addr.upper(), channel)
+        return (None, None)
 
     def _get_bucket(self, duration: float) -> int:
         """Map press duration to a discrete bucket (0-3)."""

--- a/custom_components/nikobus/nkbconfig.py
+++ b/custom_components/nikobus/nkbconfig.py
@@ -11,12 +11,9 @@ from .exceptions import NikobusDataError  # Updated import
 
 _LOGGER = logging.getLogger(__name__)
 _LOAD_TRANSFORMS: Dict[str, str] = {
-    "button": "_transform_button_data",
     "module": "_transform_module_data",
 }
-_WRITE_TRANSFORMS: Dict[str, str] = {
-    "button": "_transform_button_data_for_writing",
-}
+_WRITE_TRANSFORMS: Dict[str, str] = {}
 
 
 class NikobusConfig:
@@ -86,27 +83,6 @@ class NikobusConfig:
             return data
         return getattr(self, transform_name)(data)
 
-    def _transform_button_data(self, data: dict) -> dict:
-        """Transform button data from a list to a dictionary.
-
-        Also migrates legacy field names from nikobus-connect < 0.1.4:
-            discovered_info  → linked_button
-            discovered_links → linked_modules
-        """
-        if "nikobus_button" in data:
-            for button in data["nikobus_button"]:
-                if isinstance(button, dict):
-                    if "discovered_info" in button:
-                        button["linked_button"] = button.pop("discovered_info")
-                    if "discovered_links" in button:
-                        button["linked_modules"] = button.pop("discovered_links")
-            data["nikobus_button"] = {
-                button["address"]: button for button in data["nikobus_button"]
-            }
-        else:
-            _LOGGER.warning("'nikobus_button' key not found in button data")
-        return data
-
     def _transform_module_data(self, data: dict) -> dict:
         """Transform module data from a list to a dictionary."""
         for key in ["switch_module", "dimmer_module", "roller_module", "other_module"]:
@@ -166,12 +142,6 @@ class NikobusConfig:
                 "Run PC-Link inventory discovery to populate it.",
                 file_path,
             )
-        elif data_type == "button":
-            _LOGGER.info(
-                "Button configuration file not found: %s. "
-                "A new file will be created upon discovering the first button.",
-                file_path,
-            )
         else:
             _LOGGER.info(
                 "%s configuration file not found: %s. Skipping.",
@@ -184,7 +154,6 @@ class NikobusConfig:
         """Create an empty skeleton config file so the library can update it later."""
         _EMPTY_SKELETONS = {
             "module": {},
-            "button": {"nikobus_button": []},
             "scene": {},
         }
         skeleton = _EMPTY_SKELETONS.get(data_type, {})
@@ -259,12 +228,3 @@ class NikobusConfig:
         if not transform_name:
             return data
         return getattr(self, transform_name)(data)
-
-    def _transform_button_data_for_writing(self, data: dict) -> dict:
-        """Transform button data from a dictionary back to a list for saving."""
-        button_data_list = []
-        for address, details in data.get("nikobus_button", {}).items():
-            entry = dict(details)
-            entry["address"] = address
-            button_data_list.append(entry)
-        return {"nikobus_button": button_data_list}

--- a/custom_components/nikobus/nkbstorage.py
+++ b/custom_components/nikobus/nkbstorage.py
@@ -1,0 +1,60 @@
+"""HA-native persistence for Nikobus discovery data.
+
+Replaces the legacy ``config/nikobus_button_config.json`` file with a
+versioned store under ``.storage/``. The on-disk shape is:
+
+    {
+        "nikobus_button": {
+            "<address>": {
+                "description": str,
+                "address": str,
+                "linked_button": [...],
+                "linked_modules": [...],
+            },
+            ...
+        }
+    }
+
+The nikobus-connect discovery engine mutates the in-memory dict directly
+and invokes ``async_save()`` whenever its state changes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+BUTTON_STORAGE_KEY = "nikobus.buttons"
+BUTTON_STORAGE_VERSION = 1
+
+
+class NikobusButtonStorage:
+    """Wrap a HA ``Store`` for button discovery data."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        self._store: Store[dict[str, Any]] = Store(
+            hass, BUTTON_STORAGE_VERSION, BUTTON_STORAGE_KEY
+        )
+        self._data: dict[str, Any] = {"nikobus_button": {}}
+
+    async def async_load(self) -> dict[str, Any]:
+        """Load persisted data, returning a live mutable dict."""
+        loaded = await self._store.async_load()
+        if isinstance(loaded, dict) and "nikobus_button" in loaded:
+            self._data = loaded
+            if not isinstance(self._data["nikobus_button"], dict):
+                self._data["nikobus_button"] = {}
+        else:
+            self._data = {"nikobus_button": {}}
+        return self._data
+
+    async def async_save(self) -> None:
+        """Persist the current in-memory dict to storage."""
+        await self._store.async_save(self._data)
+
+    @property
+    def data(self) -> dict[str, Any]:
+        """Return the mutable in-memory dict."""
+        return self._data

--- a/custom_components/nikobus/services.yaml
+++ b/custom_components/nikobus/services.yaml
@@ -5,3 +5,11 @@ query_module_inventory:
       required: false
       selector:
         text:
+
+send_button_press:
+  fields:
+    address:
+      example: "84DFFC"
+      required: true
+      selector:
+        text:


### PR DESCRIPTION
## Summary

Two commits on this branch. **The second one is a breaking change** — requires a coordinated nikobus-connect library release that supports the new storage-adapter interface. See companion prompt in chat for the library-side work.

**User-visible effect:** `nikobus_button_config.json` is no longer read or written. Button discovery data lives in `.storage/nikobus.buttons` (HA's standard versioned store, invisible to hand-editing). Users re-run discovery once after the upgrade; their old hand-edits are dropped on purpose (clean break, no importer).

### Commit 1 — Wall-button device names

Dropped the prefix-based naming from #276 (relied on every user following the same description convention) in favour of the discovery metadata: `{type} ({address})`, e.g. `Button with 2 Operation Points (1E584C)`. Always unique, deterministic, identical for every installation. Users who want a semantic name rename the device in the UI — HA persists that as `name_by_user` across reloads.

### Commit 2 — Remove the JSON config file

- **Storage.** New `NikobusButtonStorage` wraps `homeassistant.helpers.storage.Store` under key `nikobus.buttons`. `coordinator.connect()` loads via the store and hands the library a mutable dict + async save callback (`button_data=`, `on_button_save=` kwargs on `NikobusDiscovery`).
- **Entities.** Only discovered buttons (those with a populated `linked_button`) become HA entities. Virtual / IR-scene entries from the old JSON are gone — fire them from scripts via the new `nikobus.send_button_press(address)` service.
- **Actuator.** Impacted `(module, group)` pairs are derived from `linked_modules` (channels 1-6 → group 1, 7-12 → group 2). `impacted_module` field and the JSON-auto-write for unknown-address presses are gone.
- **`operation_time` removed from the button side.** Dropped from `NikobusButtonEntity`, the `ha_button_pressed` event, the `EVENT_BUTTON_OPERATION` payload, and `cover.py`'s now-unused tilt hook (`_handle_nikobus_event`, `_last_button_operation_time`, `_start_motion_logic(limit_time=…)` all deleted). Cover travel always uses the configured module time. Cover `operation_time_up/down` (in the module config) is untouched.
- **Cleanup.** Removed `_transform_button_data` / `_transform_button_data_for_writing` and the `"button"` data_type from `NikobusConfig`; services.yaml gains `send_button_press`.

## Requires

- `nikobus-connect` library update: `NikobusDiscovery.__init__` must accept `button_data: dict` (mutable, owned by caller) and `on_button_save: Callable[[], Awaitable[None]]`. All button-related file IO inside the library is replaced by mutating the passed dict and invoking `on_button_save()`. Module discovery IO stays as-is for now.
- After merging, bump `manifest.json`'s `requirements` to pin the new library version.

## Test plan

- [ ] Fresh HA restart after upgrade, full discovery run completes. `.storage/nikobus.buttons` is created. `nikobus_button_config.json` is untouched (safe to delete by hand).
- [ ] Wall-button parents appear with names `{type} ({address})`; soft buttons nest under them.
- [ ] Pressing a soft-button entity refreshes the right module groups.
- [ ] `nikobus.send_button_press` service fires a `#N<addr>` on the bus for a virtual address.
- [ ] Hand-added entries in the legacy JSON (e.g. `IR_FamilyRoom_TVLights`) no longer appear as entities — replace with script + service call.
- [ ] Cover travel still completes; physical button presses still drive cover motion via `EVENT_BUTTON_PRESSED`.

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2