### PR TITLE
Consume nikobus-connect 0.3.0 Option-A button schema

### DIFF
--- a/custom_components/nikobus/binary_sensor.py
+++ b/custom_components/nikobus/binary_sensor.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 
 from .button import register_wall_button_devices
-from .const import DOMAIN, EVENT_BUTTON_PRESSED, HUB_IDENTIFIER
+from .const import DOMAIN, EVENT_BUTTON_PRESSED
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity
 
@@ -33,64 +33,71 @@ async def async_setup_entry(
     coordinator: NikobusDataCoordinator = entry.runtime_data
 
     buttons = (coordinator.dict_button_data or {}).get("nikobus_button", {})
-    discovered = {
-        addr: data for addr, data in buttons.items()
-        if isinstance(data, dict) and data.get("linked_button")
-    }
-    register_wall_button_devices(hass, entry, discovered)
+    register_wall_button_devices(hass, entry, buttons)
 
-    async_add_entities(
-        NikobusButtonBinarySensor(
-            coordinator=coordinator,
-            address=address,
-            description=f"Button {address}",
-        )
-        for address in discovered
-    )
+    entities: list[NikobusButtonBinarySensor] = []
+    for physical_addr, phys in buttons.items():
+        if not isinstance(phys, dict):
+            continue
+        for key_label, op_point in (phys.get("operation_points") or {}).items():
+            if not isinstance(op_point, dict):
+                continue
+            bus_addr = op_point.get("bus_address")
+            if not bus_addr:
+                continue
+            entities.append(
+                NikobusButtonBinarySensor(coordinator, physical_addr, key_label, op_point)
+            )
+    async_add_entities(entities)
 
 
 class NikobusButtonBinarySensor(NikobusEntity, BinarySensorEntity):
-    """Binary sensor representing a physical Nikobus button press."""
+    """Binary sensor representing a physical Nikobus button press.
+
+    One entity per ``(physical_address, key_label)`` pair; grouped under the
+    physical-button device in the registry.
+    """
 
     _attr_entity_registry_enabled_default = False
 
     def __init__(
         self,
         coordinator: NikobusDataCoordinator,
-        address: str,
-        description: str,
+        physical_address: str,
+        key_label: str,
+        op_point: dict[str, Any],
     ) -> None:
         """Initialize the button binary sensor."""
-        wall_info = coordinator.get_wall_button_info(address)
-        via_device = (DOMAIN, wall_info["address"]) if wall_info else (DOMAIN, HUB_IDENTIFIER)
+        bus_addr = op_point["bus_address"]
+        self._physical_address = physical_address
+        self._key_label = key_label
         super().__init__(
             coordinator=coordinator,
-            address=address,
-            name=description,
+            address=bus_addr,
+            name=f"Button {key_label}",
             model="Physical Button",
-            via_device=via_device,
+            via_device=(DOMAIN, physical_address),
         )
-        self._address = address
-        self._attr_name = description
-        self._attr_unique_id = f"{DOMAIN}_button_{address}"
-        self._wall_button = wall_info
+        self._address = bus_addr
+        self._attr_unique_id = f"{DOMAIN}_button_{bus_addr}"
 
         self._attr_is_on = False
         self._reset_timer_cancel: CALLBACK_TYPE | None = None
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Expose wall-button parent info and linked module outputs."""
+        """Expose physical-button parent info and linked module outputs."""
         parent_attrs = super().extra_state_attributes or {}
         attrs: dict[str, Any] = {
             **parent_attrs,
             "linked_outputs": self.coordinator.get_button_linked_outputs(self._address),
+            "wall_button_address": self._physical_address,
+            "wall_button_key": self._key_label,
         }
-        if self._wall_button:
-            attrs["wall_button_address"] = self._wall_button.get("address")
-            attrs["wall_button_model"] = self._wall_button.get("model")
-            attrs["wall_button_type"] = self._wall_button.get("type")
-            attrs["wall_button_key"] = self._wall_button.get("key")
+        wall_info = self.coordinator.get_wall_button_info(self._address)
+        if wall_info:
+            attrs["wall_button_model"] = wall_info.get("model")
+            attrs["wall_button_type"] = wall_info.get("type")
         return attrs
 
     @property

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -34,20 +34,30 @@ async def async_setup_entry(
     ]
 
     buttons = (coordinator.dict_button_data or {}).get("nikobus_button", {})
-    # Only discovered buttons (those with at least one linked_button entry)
-    # become HA entities. Hand-added virtual entries are intentionally ignored —
-    # fire them from scripts/automations via ``nikobus.send_button_press``.
-    discovered = {
-        addr: data for addr, data in buttons.items()
-        if isinstance(data, dict) and data.get("linked_button")
-    }
-    register_wall_button_devices(hass, entry, discovered)
-    entities.extend(
-        NikobusButtonEntity(coordinator, addr, data)
-        for addr, data in discovered.items()
-    )
+    register_wall_button_devices(hass, entry, buttons)
+    entities.extend(_iter_button_entities(coordinator, buttons))
 
     async_add_entities(entities)
+
+
+def _iter_button_entities(
+    coordinator: NikobusDataCoordinator,
+    buttons: dict[str, Any],
+):
+    """Yield one NikobusButtonEntity per discovered operation point."""
+    for physical_addr, phys in buttons.items():
+        if not isinstance(phys, dict):
+            continue
+        op_points = phys.get("operation_points") or {}
+        if not isinstance(op_points, dict):
+            continue
+        for key_label, op_point in op_points.items():
+            if not isinstance(op_point, dict):
+                continue
+            bus_addr = op_point.get("bus_address")
+            if not bus_addr:
+                continue
+            yield NikobusButtonEntity(coordinator, physical_addr, key_label, op_point)
 
 
 def register_wall_button_devices(
@@ -55,36 +65,28 @@ def register_wall_button_devices(
     entry: NikobusConfigEntry,
     buttons: dict[str, Any],
 ) -> None:
-    """Register one device per physical wall button (linked_button address).
+    """Register one device per physical wall button (top-level address).
 
-    Groups the 1..N software buttons of a keypad/IR remote under a single
-    parent device in the device registry. The default name is taken straight
-    from the discovery metadata (``{type} ({address})``) so it is identical
-    for every user; HA preserves any user rename via ``name_by_user`` across
-    reloads. Idempotent: safe to call from multiple platforms.
+    Groups the N operation-points of a keypad/IR remote under a single parent
+    device in the device registry. The default name is taken straight from
+    the discovery metadata (``{type} ({address})``) so it is identical for
+    every installation; HA preserves any user rename via ``name_by_user``
+    across reloads. Idempotent: safe to call from multiple platforms.
     """
     device_registry = dr.async_get(hass)
-    seen: set[str] = set()
-    for data in buttons.values():
-        if not isinstance(data, dict):
+    for physical_addr, phys in buttons.items():
+        if not isinstance(phys, dict):
             continue
-        for info in data.get("linked_button") or []:
-            if not isinstance(info, dict):
-                continue
-            address = info.get("address")
-            if not address or address in seen:
-                continue
-            seen.add(address)
-            type_str = str(info.get("type") or info.get("model") or "Wall Button")
-            model = str(info.get("model") or info.get("type") or "Wall Button")
-            device_registry.async_get_or_create(
-                config_entry_id=entry.entry_id,
-                identifiers={(DOMAIN, address)},
-                manufacturer=BRAND,
-                name=f"{type_str} ({address})",
-                model=model,
-                via_device=(DOMAIN, HUB_IDENTIFIER),
-            )
+        type_str = str(phys.get("type") or phys.get("model") or "Wall Button")
+        model = str(phys.get("model") or phys.get("type") or "Wall Button")
+        device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, physical_addr)},
+            manufacturer=BRAND,
+            name=f"{type_str} ({physical_addr})",
+            model=model,
+            via_device=(DOMAIN, HUB_IDENTIFIER),
+        )
 
 
 def _hub_device_info() -> dr.DeviceInfo:
@@ -135,44 +137,48 @@ class NikobusModuleScanButton(ButtonEntity):
 
 
 class NikobusButtonEntity(NikobusEntity, ButtonEntity):
-    """Representation of a Nikobus UI button (Software trigger)."""
+    """Representation of a Nikobus operation-point (software trigger).
+
+    One entity per ``(physical_address, key_label)`` pair; grouped under the
+    physical-button device in the registry.
+    """
 
     def __init__(
         self,
         coordinator: NikobusDataCoordinator,
-        address: str,
-        data: dict[str, Any]
+        physical_address: str,
+        key_label: str,
+        op_point: dict[str, Any],
     ) -> None:
         """Initialize the button entity."""
-
-        wall_info = coordinator.get_wall_button_info(address)
-        via_device = (DOMAIN, wall_info["address"]) if wall_info else (DOMAIN, HUB_IDENTIFIER)
-        name = f"Button {address}"
+        bus_addr = op_point["bus_address"]
+        self._physical_address = physical_address
+        self._key_label = key_label
 
         super().__init__(
             coordinator=coordinator,
-            address=address,
-            name=name,
+            address=bus_addr,
+            name=f"Button {key_label}",
             model="Push Button",
-            via_device=via_device,
+            via_device=(DOMAIN, physical_address),
         )
 
-        self._attr_unique_id = f"{DOMAIN}_push_button_{address}"
-        self._wall_button = wall_info
+        self._attr_unique_id = f"{DOMAIN}_push_button_{bus_addr}"
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Expose wall-button parent info and linked module outputs."""
+        """Expose physical-button parent info and linked module outputs."""
         parent_attrs = super().extra_state_attributes or {}
         attrs: dict[str, Any] = {
             **parent_attrs,
             "linked_outputs": self.coordinator.get_button_linked_outputs(self._address),
+            "wall_button_address": self._physical_address,
+            "wall_button_key": self._key_label,
         }
-        if self._wall_button:
-            attrs["wall_button_address"] = self._wall_button.get("address")
-            attrs["wall_button_model"] = self._wall_button.get("model")
-            attrs["wall_button_type"] = self._wall_button.get("type")
-            attrs["wall_button_key"] = self._wall_button.get("key")
+        wall_info = self.coordinator.get_wall_button_info(self._address)
+        if wall_info:
+            attrs["wall_button_model"] = wall_info.get("model")
+            attrs["wall_button_type"] = wall_info.get("type")
         return attrs
 
     async def async_press(self) -> None:

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from nikobus_connect import NikobusAPI, NikobusCommandHandler, NikobusConnect, NikobusEventListener
-from nikobus_connect.discovery import NikobusDiscovery, InventoryQueryType
+from nikobus_connect.discovery import NikobusDiscovery, InventoryQueryType, find_operation_point
 from nikobus_connect.exceptions import NikobusConnectionError, NikobusDataError, NikobusError
 
 from .const import (
@@ -651,45 +651,53 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
 
         Called by nikobus-connect decoders to derive the push-button (bus)
         address from the physical device address found in module firmware.
-        Looks up ``linked_button[].address`` across all button entries.
+        Looks up the top-level ``channels`` field on the physical entry
+        (schema v2).
         """
         normalized = (button_address or "").upper()
-        for button in (self.dict_button_data or {}).get("nikobus_button", {}).values():
-            for info in button.get("linked_button") or []:
-                if isinstance(info, dict) and (info.get("address") or "").upper() == normalized:
-                    ch = info.get("channels")
-                    if isinstance(ch, int) and ch > 0:
-                        return ch
+        phys = (self.dict_button_data or {}).get("nikobus_button", {}).get(normalized)
+        if isinstance(phys, dict):
+            ch = phys.get("channels")
+            if isinstance(ch, int) and ch > 0:
+                return ch
         return None
 
     # ------------------------------------------------------------------
     # Discovery link helpers (wall button parents + controlled_by index)
     # ------------------------------------------------------------------
 
-    def get_wall_button_info(self, button_address: str) -> dict[str, Any] | None:
-        """Return the physical wall-button record a software button belongs to.
+    def get_wall_button_info(self, bus_address: str) -> dict[str, Any] | None:
+        """Return the physical-button record a soft button (bus address) belongs to.
 
-        Reads the first entry of ``linked_button`` for the given software
-        button address. Returns ``None`` if the button has never been discovered.
+        Shape: ``{type, model, address, channels, key}``. Returns ``None`` when
+        the bus address is not part of any discovered physical button.
         """
-        button = (self.dict_button_data or {}).get("nikobus_button", {}).get(button_address)
-        if not isinstance(button, dict):
+        hit = find_operation_point(self.dict_button_data, bus_address)
+        if hit is None:
             return None
-        for info in button.get("linked_button") or []:
-            if isinstance(info, dict) and info.get("address"):
-                return info
-        return None
+        physical_addr, key_label, _op_point = hit
+        phys = (self.dict_button_data or {}).get("nikobus_button", {}).get(physical_addr)
+        if not isinstance(phys, dict):
+            return None
+        return {
+            "type": phys.get("type"),
+            "model": phys.get("model"),
+            "address": physical_addr,
+            "channels": phys.get("channels"),
+            "key": key_label,
+        }
 
-    def get_button_linked_outputs(self, button_address: str) -> list[dict[str, Any]]:
-        """Return flattened output links for a software button.
+    def get_button_linked_outputs(self, bus_address: str) -> list[dict[str, Any]]:
+        """Return flattened output links for a soft button (bus address).
 
         Each item: ``{module_address, channel, mode, t1, t2}``.
         """
-        button = (self.dict_button_data or {}).get("nikobus_button", {}).get(button_address)
-        if not isinstance(button, dict):
+        hit = find_operation_point(self.dict_button_data, bus_address)
+        if hit is None:
             return []
+        _physical_addr, _key_label, op_point = hit
         flattened: list[dict[str, Any]] = []
-        for link in button.get("linked_modules") or []:
+        for link in op_point.get("linked_modules") or []:
             if not isinstance(link, dict):
                 continue
             module_address = link.get("module_address")
@@ -709,38 +717,39 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         """Build a (module_address_upper, channel) -> list[button record] index."""
         index: dict[tuple[str, int], list[dict[str, Any]]] = {}
         buttons = (self.dict_button_data or {}).get("nikobus_button", {})
-        for soft_addr, button in buttons.items():
-            if not isinstance(button, dict):
+        for physical_addr, phys in buttons.items():
+            if not isinstance(phys, dict):
                 continue
-            description = button.get("description") or f"Button {soft_addr}"
-            wall_info = next(
-                (i for i in (button.get("linked_button") or []) if isinstance(i, dict)),
-                None,
-            )
-            wall_addr = (wall_info or {}).get("address") if wall_info else None
-            wall_key = (wall_info or {}).get("key") if wall_info else None
-            for link in button.get("linked_modules") or []:
-                if not isinstance(link, dict):
+            op_points = phys.get("operation_points") or {}
+            if not isinstance(op_points, dict):
+                continue
+            for key_label, op_point in op_points.items():
+                if not isinstance(op_point, dict):
                     continue
-                module_address = link.get("module_address")
-                if not module_address:
-                    continue
-                module_key = str(module_address).upper()
-                for out in link.get("outputs") or []:
-                    if not isinstance(out, dict):
+                bus_addr = op_point.get("bus_address") or ""
+                description = op_point.get("description") or f"Button {bus_addr}"
+                for link in op_point.get("linked_modules") or []:
+                    if not isinstance(link, dict):
                         continue
-                    channel = out.get("channel")
-                    if not isinstance(channel, int):
+                    module_address = link.get("module_address")
+                    if not module_address:
                         continue
-                    index.setdefault((module_key, channel), []).append({
-                        "button_address": soft_addr,
-                        "description": description,
-                        "mode": out.get("mode"),
-                        "t1": out.get("t1"),
-                        "t2": out.get("t2"),
-                        "wall_button_address": wall_addr,
-                        "wall_button_key": wall_key,
-                    })
+                    module_key = str(module_address).upper()
+                    for out in link.get("outputs") or []:
+                        if not isinstance(out, dict):
+                            continue
+                        channel = out.get("channel")
+                        if not isinstance(channel, int):
+                            continue
+                        index.setdefault((module_key, channel), []).append({
+                            "bus_address": bus_addr,
+                            "description": description,
+                            "mode": out.get("mode"),
+                            "t1": out.get("t1"),
+                            "t2": out.get("t2"),
+                            "wall_button_address": physical_addr,
+                            "wall_button_key": key_label,
+                        })
         return index
 
     def get_controlled_by(self, module_address: str, channel: int) -> list[dict[str, Any]]:
@@ -923,9 +932,15 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         for specs in routing.values():
             for spec in specs:
                 known.add(build_unique_id(spec.domain, spec.kind, spec.address, spec.channel))
-        for addr in self.dict_button_data.get("nikobus_button", {}):
-            known.add(f"{DOMAIN}_button_{addr}")
-            known.add(f"{DOMAIN}_push_button_{addr}")
+        for phys in self.dict_button_data.get("nikobus_button", {}).values():
+            if not isinstance(phys, dict):
+                continue
+            for op_point in (phys.get("operation_points") or {}).values():
+                if not isinstance(op_point, dict):
+                    continue
+                if bus_addr := op_point.get("bus_address"):
+                    known.add(f"{DOMAIN}_button_{bus_addr}")
+                    known.add(f"{DOMAIN}_push_button_{bus_addr}")
         for scene in self.dict_scene_data.get("scene", []):
             if sid := scene.get("id"):
                 known.add(f"{DOMAIN}_scene_{sid}")

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect==0.2.0"
+    "nikobus-connect==0.3.0"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }

--- a/custom_components/nikobus/nkbactuator.py
+++ b/custom_components/nikobus/nkbactuator.py
@@ -12,6 +12,8 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.core import HomeAssistant
+from nikobus_connect.discovery import find_operation_point
+
 from .const import (
     BUTTON_TIMER_THRESHOLDS,
     DIMMER_DELAY,
@@ -178,20 +180,21 @@ class NikobusActuator:
 
     async def button_discovery(self, address: str, press_context: dict[str, Any] | None = None) -> None:
         """Identify impacted modules and trigger targeted refreshes."""
-        button_data = self._dict_button_data.get("nikobus_button", {}).get(address)
-        if button_data:
-            await self.process_button_modules(button_data, address, press_context)
-        else:
+        hit = find_operation_point(self._dict_button_data, address)
+        if hit is None:
             _LOGGER.debug("Press from unknown button %s — run discovery to populate it", address)
+            return
+        _physical_addr, _key_label, op_point = hit
+        await self.process_button_modules(op_point, address, press_context)
 
-    def _derive_impacted_modules(self, button_data: dict[str, Any]) -> list[tuple[str, str]]:
-        """Return the unique (module_address, group) pairs this button affects.
+    def _derive_impacted_modules(self, op_point: dict[str, Any]) -> list[tuple[str, str]]:
+        """Return the unique (module_address, group) pairs this op-point affects.
 
         Derived from ``linked_modules`` — channels 1-6 live in feedback group 1,
         7-12 in group 2.
         """
         seen: set[tuple[str, str]] = set()
-        for link in button_data.get("linked_modules") or []:
+        for link in op_point.get("linked_modules") or []:
             if not isinstance(link, dict):
                 continue
             module_address = (link.get("module_address") or "").upper()
@@ -207,11 +210,11 @@ class NikobusActuator:
                 seen.add((module_address, group))
         return list(seen)
 
-    async def process_button_modules(self, button_data: dict[str, Any], button_address: str, press_context: dict[str, Any] | None) -> None:
-        """Refresh states for specific modules impacted by this button."""
+    async def process_button_modules(self, op_point: dict[str, Any], button_address: str, press_context: dict[str, Any] | None) -> None:
+        """Refresh states for specific modules impacted by this op-point."""
         press_id = (press_context or {}).get("press_id") or f"{button_address}-{uuid.uuid4().hex[:8]}"
 
-        impacted = self._derive_impacted_modules(button_data)
+        impacted = self._derive_impacted_modules(op_point)
         _LOGGER.debug("[%s] Processing button %s: %d modules impacted", press_id, button_address, len(impacted))
 
         for addr, group in impacted:
@@ -328,8 +331,11 @@ class NikobusActuator:
 
     def _derive_button_context(self, address: str) -> tuple[str | None, int | None]:
         """Determine the primary (module_address, channel) link from discovery."""
-        button_data = self._dict_button_data.get("nikobus_button", {}).get(address, {})
-        for link in button_data.get("linked_modules") or []:
+        hit = find_operation_point(self._dict_button_data, address)
+        if hit is None:
+            return (None, None)
+        _physical_addr, _key_label, op_point = hit
+        for link in op_point.get("linked_modules") or []:
             if not isinstance(link, dict):
                 continue
             module_addr = link.get("module_address")

--- a/custom_components/nikobus/nkbstorage.py
+++ b/custom_components/nikobus/nkbstorage.py
@@ -1,33 +1,59 @@
 """HA-native persistence for Nikobus discovery data.
 
-Replaces the legacy ``config/nikobus_button_config.json`` file with a
-versioned store under ``.storage/``. The on-disk shape is:
+Storage schema (v2, nikobus-connect ≥ 0.3.0):
 
     {
         "nikobus_button": {
-            "<address>": {
+            "<physical_address>": {
+                "type": str,
+                "model": str,
+                "channels": int,
                 "description": str,
-                "address": str,
-                "linked_button": [...],
-                "linked_modules": [...],
+                "operation_points": {
+                    "1A": {
+                        "bus_address": str,
+                        "description": str,
+                        "linked_modules": [
+                            {"module_address": str, "outputs": [...]},
+                            ...
+                        ],
+                    },
+                    "1B": {...},
+                    ...
+                },
             },
             ...
         }
     }
 
-The nikobus-connect discovery engine mutates the in-memory dict directly
-and invokes ``async_save()`` whenever its state changes.
+The nikobus-connect discovery engine owns the dict and mutates it in place;
+the integration calls ``async_save()`` through the callback it hands the
+library.
+
+Schema v1 (nikobus-connect 0.2.x) keyed buttons by bus address with a
+flat ``linked_button`` / ``linked_modules`` structure. v1 is unreadable
+by the new code — the library removed the migration helper — so any v1
+file found on disk is dropped with a warning and the user must re-run
+discovery. See nikobus-connect#14 for the clean break rationale.
 """
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
 
+_LOGGER = logging.getLogger(__name__)
+
 BUTTON_STORAGE_KEY = "nikobus.buttons"
-BUTTON_STORAGE_VERSION = 1
+BUTTON_STORAGE_VERSION = 2
+
+
+def _looks_like_v1_entry(entry: Any) -> bool:
+    """Return True if ``entry`` matches the v1 shape (has linked_button key)."""
+    return isinstance(entry, dict) and "linked_button" in entry
 
 
 class NikobusButtonStorage:
@@ -40,12 +66,24 @@ class NikobusButtonStorage:
         self._data: dict[str, Any] = {"nikobus_button": {}}
 
     async def async_load(self) -> dict[str, Any]:
-        """Load persisted data, returning a live mutable dict."""
+        """Load persisted data, returning a live mutable dict.
+
+        Drops any v1-shaped payload with a warning — users re-run discovery
+        to repopulate on the new schema.
+        """
         loaded = await self._store.async_load()
-        if isinstance(loaded, dict) and "nikobus_button" in loaded:
-            self._data = loaded
-            if not isinstance(self._data["nikobus_button"], dict):
-                self._data["nikobus_button"] = {}
+        if isinstance(loaded, dict) and isinstance(loaded.get("nikobus_button"), dict):
+            buttons = loaded["nikobus_button"]
+            if any(_looks_like_v1_entry(entry) for entry in buttons.values()):
+                _LOGGER.warning(
+                    "Dropping v1 Nikobus button store (legacy schema). "
+                    "Run 'Discover modules & buttons' + 'Scan all module links' "
+                    "from the Nikobus Bridge device to repopulate."
+                )
+                self._data = {"nikobus_button": {}}
+                await self._store.async_save(self._data)
+            else:
+                self._data = loaded
         else:
             self._data = {"nikobus_button": {}}
         return self._data


### PR DESCRIPTION
## Summary

Pairs with **nikobus-connect PR #14** (Option-A button schema). The library reshapes the button store: top-level keys are now physical-button addresses, and each physical record nests its operation points under `operation_points`, keyed by label (`1A`/`1B`/…) and each carrying its own `bus_address` + `linked_modules`. The old flat shape (top-level by bus address with `linked_button` + `linked_modules` arrays) is dropped with no migration helper.

## What this PR does

- **`nkbstorage.py`** — bumps `BUTTON_STORAGE_VERSION` to 2. On load, any payload with a legacy `linked_button` key is logged at WARNING level, overwritten with an empty v2 skeleton and re-saved. Users re-run the two Bridge discovery buttons to repopulate. No importer on either side — clean break.
- **`nkbactuator.py`** — press-event routing uses `find_operation_point(dict_button_data, bus_address)` from the library. `_derive_impacted_modules` / `_derive_button_context` now take op-point dicts directly. Unknown addresses still fall through to the existing debug log (refresh-all fallback can be added later if needed).
- **`button.py` + `binary_sensor.py`** — iterate `{physical_addr: {operation_points: {key_label: op_point}}}`, creating one entity per op-point. Entities are grouped under the physical-button device (via_device) which in turn lives under the Nikobus Bridge. `register_wall_button_devices` now just walks the top-level dict; no more `linked_button` array chasing.
- **`coordinator.py`** — `get_wall_button_info(bus_address)`, `get_button_linked_outputs(bus_address)`, and `_build_controlled_by_index` rewritten against the nested shape. Imports `find_operation_point` from `nikobus_connect.discovery`. `get_known_entity_unique_ids` collects bus addresses by walking `operation_points`, so stale-entity cleanup still targets the right unique_ids.
- **`manifest.json`** — pins `nikobus-connect==0.3.0`.

## Attribute changes on button entities

Every soft-button / binary-sensor entity already exposes:

- `wall_button_address` — now the **physical** address (was the same; still correct).
- `wall_button_key` — new, the op-point label (`1A`/`1B`/…).
- `wall_button_model`, `wall_button_type` — unchanged.
- `linked_outputs` — unchanged shape.

The `controlled_by` attribute on light/cover/switch entities gains a `bus_address` field (replacing the old `button_address` key) and keeps `wall_button_address` / `wall_button_key`.

## Test plan

- [ ] After merging this **and** the library release (`nikobus-connect 0.3.0`), pull in HA, then **full HA restart** (not reload).
- [ ] Inspect `.storage/nikobus.buttons` — legacy payload is wiped with a warning line in the log.
- [ ] Run **Discover modules & buttons** + **Scan all module links** from the Nikobus Bridge device.
- [ ] Confirm entities appear grouped under their physical device with names `Button 1A` / `Button 1B` / … and attributes `wall_button_address` + `wall_button_key` populated.
- [ ] Press a physical button on the bus — `nikobus_button_pressed` fires; if the op-point has linked modules, the impacted module group refreshes.
- [ ] `nikobus.send_button_press { address: <bus_addr> }` still routes via `find_operation_point` and refreshes correctly.

## Notes for reviewers

- Tests under `tests/` don't seed button data with the old shape, so none needed updating here. `test_inventory_parsing.py:105` monkey-patches `nikobus_connect.discovery.discovery.merge_linked_modules`; if 0.3.0 renames that symbol, the library session should update the fixture.
- No lookup site required a helper beyond `find_operation_point`; the reverse direction (physical → bus) is always a direct dict walk.

## Requires

- `nikobus-connect==0.3.0` on PyPI with `find_operation_point` exported from `nikobus_connect.discovery`.
- See fdebrus/nikobus-connect#14 for the library side.

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2