### PR TITLE
Storage-version revert + use library op-point description as entity name

### DIFF
--- a/custom_components/nikobus/binary_sensor.py
+++ b/custom_components/nikobus/binary_sensor.py
@@ -71,10 +71,11 @@ class NikobusButtonBinarySensor(NikobusEntity, BinarySensorEntity):
         bus_addr = op_point["bus_address"]
         self._physical_address = physical_address
         self._key_label = key_label
+        name = op_point.get("description") or f"Push button {key_label}"
         super().__init__(
             coordinator=coordinator,
             address=bus_addr,
-            name=f"Button {key_label}",
+            name=name,
             model="Physical Button",
             via_device=(DOMAIN, physical_address),
         )

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -155,10 +155,12 @@ class NikobusButtonEntity(NikobusEntity, ButtonEntity):
         self._physical_address = physical_address
         self._key_label = key_label
 
+        name = op_point.get("description") or f"Push button {key_label}"
+
         super().__init__(
             coordinator=coordinator,
             address=bus_addr,
-            name=f"Button {key_label}",
+            name=name,
             model="Push Button",
             via_device=(DOMAIN, physical_address),
         )

--- a/custom_components/nikobus/nkbstorage.py
+++ b/custom_components/nikobus/nkbstorage.py
@@ -1,6 +1,6 @@
 """HA-native persistence for Nikobus discovery data.
 
-Storage schema (v2, nikobus-connect ≥ 0.3.0):
+Storage schema (nikobus-connect ≥ 0.3.0):
 
     {
         "nikobus_button": {
@@ -29,31 +29,17 @@ Storage schema (v2, nikobus-connect ≥ 0.3.0):
 The nikobus-connect discovery engine owns the dict and mutates it in place;
 the integration calls ``async_save()`` through the callback it hands the
 library.
-
-Schema v1 (nikobus-connect 0.2.x) keyed buttons by bus address with a
-flat ``linked_button`` / ``linked_modules`` structure. v1 is unreadable
-by the new code — the library removed the migration helper — so any v1
-file found on disk is dropped with a warning and the user must re-run
-discovery. See nikobus-connect#14 for the clean break rationale.
 """
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
 
-_LOGGER = logging.getLogger(__name__)
-
 BUTTON_STORAGE_KEY = "nikobus.buttons"
-BUTTON_STORAGE_VERSION = 2
-
-
-def _looks_like_v1_entry(entry: Any) -> bool:
-    """Return True if ``entry`` matches the v1 shape (has linked_button key)."""
-    return isinstance(entry, dict) and "linked_button" in entry
+BUTTON_STORAGE_VERSION = 1
 
 
 class NikobusButtonStorage:
@@ -66,24 +52,10 @@ class NikobusButtonStorage:
         self._data: dict[str, Any] = {"nikobus_button": {}}
 
     async def async_load(self) -> dict[str, Any]:
-        """Load persisted data, returning a live mutable dict.
-
-        Drops any v1-shaped payload with a warning — users re-run discovery
-        to repopulate on the new schema.
-        """
+        """Load persisted data, returning a live mutable dict."""
         loaded = await self._store.async_load()
         if isinstance(loaded, dict) and isinstance(loaded.get("nikobus_button"), dict):
-            buttons = loaded["nikobus_button"]
-            if any(_looks_like_v1_entry(entry) for entry in buttons.values()):
-                _LOGGER.warning(
-                    "Dropping v1 Nikobus button store (legacy schema). "
-                    "Run 'Discover modules & buttons' + 'Scan all module links' "
-                    "from the Nikobus Bridge device to repopulate."
-                )
-                self._data = {"nikobus_button": {}}
-                await self._store.async_save(self._data)
-            else:
-                self._data = loaded
+            self._data = loaded
         else:
             self._data = {"nikobus_button": {}}
         return self._data


### PR DESCRIPTION
## Summary

Two follow-ups on top of #280:

### 1. Keep button storage at version 1

Reverts the `BUTTON_STORAGE_VERSION` bump. HA's `Store` treats a major-version mismatch as fatal and calls `_async_migrate_func`, which raises `NotImplementedError` when not overridden — breaking integration startup for anyone who had a pre-release v1 file on disk. Since there are no stable downstream users yet, the cleanest fix is to keep the version at `1` with no migration hook. Pre-release files with the old shape are silently ignored on load (no `operation_points` → zero entities registered) until the user re-runs discovery with the 0.3.0 library, which rewrites the store in the new shape.

### 2. Use library-provided op-point description as entity name

Library 0.3.0 writes unique per-op-point descriptions into `operation_points[key_label].description` (e.g. `"Push button 1A #N8177CE"`). The integration was overwriting that with a generic `"Button {key_label}"` label, so every physical button's "Connected devices" list rendered four identical-looking rows instead of the bus-address-tagged names.

Both `NikobusButtonEntity` and `NikobusButtonBinarySensor` now read `op_point.get("description")` and fall back to `f"Push button {key_label}"` only if the description is missing. `unique_id` stays keyed on `bus_address` — stable across this fix, no registry churn.

## Test plan

- [ ] HA startup succeeds even with a stale pre-release `.storage/nikobus.buttons` on disk (no `NotImplementedError`).
- [ ] After re-running discovery with `nikobus-connect==0.3.0`, the physical-button device page's "Connected devices" list shows entries like `Push button 1A #N8177CE` instead of `Button 1A`.

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2