### PR TITLE
Fix options-flow bugs and add temporary IR trace log

### DIFF
--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -475,7 +475,7 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
         options = [
             {
                 "value": addr,
-                "label": self._module_label(addr, entry),
+                "label": _module_label(addr, entry),
             }
             for addr, entry in sorted(
                 modules.items(),

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -295,6 +295,11 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
 
     async def _event_callback(self, message: str) -> None:
         """Route non-feedback bus events (buttons, ACKs, discovery frames)."""
+        _LOGGER.debug(
+            "Nikobus press frame: %s  (raw bytes hex: %s)",
+            message,
+            message.encode().hex(),
+        )
         if message.startswith("#N"):
             # Extract the 6-char address after the "#N" prefix
             if self.nikobus_actuator and len(message) >= 8:

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -33,15 +33,15 @@
             "reconfigure": {
                 "data": {
                     "connection_string": "Connection (serial port or IP:port)",
-                    "has_feedbackmodule": "[%key:component::nikobus::config::step::hardware::data::has_feedbackmodule%]",
-                    "prior_gen3": "[%key:component::nikobus::config::step::hardware::data::prior_gen3%]",
-                    "refresh_interval": "[%key:component::nikobus::config::step::polling::data::refresh_interval%]"
+                    "has_feedbackmodule": "Feedback Module (05-207) installed and connected via PC-Link",
+                    "prior_gen3": "PC-Link is older than Gen 3",
+                    "refresh_interval": "Polling interval (seconds)"
                 },
                 "data_description": {
                     "connection_string": "Serial device path or TCP address of the PC-Link bridge",
-                    "has_feedbackmodule": "[%key:component::nikobus::config::step::hardware::data_description::has_feedbackmodule%]",
-                    "prior_gen3": "[%key:component::nikobus::config::step::hardware::data_description::prior_gen3%]",
-                    "refresh_interval": "[%key:component::nikobus::config::step::polling::data_description::refresh_interval%]"
+                    "has_feedbackmodule": "When enabled, the Feedback Module pushes state changes automatically — no polling needed.",
+                    "prior_gen3": "Enables compatibility tweaks for first and second-generation PC-Link hardware.",
+                    "refresh_interval": "How often to read module states from the bus (60–3600 s). Lower values mean faster updates but more bus traffic."
                 },
                 "description": "Update the connection string or hardware settings. The connection will be re-tested.",
                 "title": "Reconfigure Nikobus"
@@ -147,12 +147,12 @@
             },
             "hardware": {
                 "data": {
-                    "has_feedbackmodule": "[%key:component::nikobus::config::step::hardware::data::has_feedbackmodule%]",
-                    "prior_gen3": "[%key:component::nikobus::config::step::hardware::data::prior_gen3%]"
+                    "has_feedbackmodule": "Feedback Module (05-207) installed and connected via PC-Link",
+                    "prior_gen3": "PC-Link is older than Gen 3"
                 },
                 "data_description": {
-                    "has_feedbackmodule": "[%key:component::nikobus::config::step::hardware::data_description::has_feedbackmodule%]",
-                    "prior_gen3": "[%key:component::nikobus::config::step::hardware::data_description::prior_gen3%]"
+                    "has_feedbackmodule": "When enabled, the Feedback Module pushes state changes automatically — no polling needed.",
+                    "prior_gen3": "Enables compatibility tweaks for first and second-generation PC-Link hardware."
                 },
                 "description": "Update your hardware settings. The integration will reload automatically.",
                 "title": "Hardware Configuration"
@@ -169,7 +169,7 @@
             },
             "polling": {
                 "data": {
-                    "refresh_interval": "[%key:component::nikobus::config::step::polling::data::refresh_interval%]"
+                    "refresh_interval": "Polling interval (seconds)"
                 },
                 "data_description": {
                     "refresh_interval": "How often to read module states from the bus (60–3600 s)."


### PR DESCRIPTION
## Summary

Three independent changes stacked on one branch. The two bug fixes are
user-visible regressions worth shipping now; the trace log is
short-lived observability for an in-flight library investigation.

- **`4af5beb` — Fix `AttributeError` in "Customize a module" step.**
  `async_step_configure_modules` called `_module_label` as
  `self._module_label`, but it's a module-level helper (sibling of
  `_module_type_order`, which the same list comprehension already
  calls correctly without `self`). Strip the `self.` prefix so the
  module picker renders instead of erroring out with
  `AttributeError: 'NikobusOptionsFlow' object has no attribute
  '_module_label'`.

- **`919d7f5` — Inline `[%key:component::nikobus::...%]` references
  in `en.json`.** HA resolves those references at build time when
  generating `translations/*.json` from `strings.json`. Custom
  integrations that ship `translations/` directly without a
  `strings.json` source skip that step, so the references rendered
  as literal placeholders in the UI (e.g. the Hardware Configuration
  dialog showed
  `[%key:component::nikobus::config::step::hardware::data::has_feedbackmodule%]`
  instead of the English label). Replaced 11 intra-component
  references across `config.reconfigure`, `options.hardware`, and
  `options.polling` with their literal strings. HA-core
  `[%key:common::...%]` references are kept — those resolve at
  runtime against the shared translation store. `fr.json` and
  `nl.json` already used literals and needed no change.

- **`5e5d1b7` — Log raw bus frames on the event-callback path
  (temporary).** Single `_LOGGER.debug` at the top of
  `NikobusDataCoordinator._event_callback`, before prefix routing,
  so any frame shape surfaces — not just `#N<6-hex>`. Used to
  capture the on-wire format of an IR remote press so
  `nikobus-connect` can ship IR-op-point `bus_address` population
  in a follow-up patch. Gated at DEBUG; no runtime behavior change.
  Will be reverted once the library work lands.

## Test plan

- [ ] Open **Settings → Devices & services → Nikobus → Configure →
      Customize a module**. Confirm the module picker renders with
      labels like "Switch Module — 0E6C — …" instead of erroring.
- [ ] Open **Configure → Change hardware settings**. Confirm both
      checkbox labels render in English ("Feedback Module (05-207)
      installed and connected via PC-Link" / "PC-Link is older than
      Gen 3") instead of `[%key:...%]` placeholders. Same check in
      the initial-setup Hardware step and the Reconfigure flow.
- [ ] Set `logger.logs.custom_components.nikobus.coordinator: debug`,
      press a physical wall button, confirm a
      `Nikobus press frame: #N... (raw bytes hex: ...)` line appears.
      Same check with an IR remote press — the captured frame is the
      raw material the library needs for the follow-up.
- [ ] Confirm no behavior change in light/switch/cover entities —
      none of these changes touch the runtime routing path.