### PR TITLE
Discovery progress UX: live status line + float percent

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -134,7 +134,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         # the library emits via its on_progress callback (0.3.5+).
         self.discovery_phase: str = DISCOVERY_PHASE_IDLE
         self.discovery_sub_phase: str = DISCOVERY_SUB_PHASE_IDLE
-        self.discovery_status_message: str = ""
+        self.discovery_status_message: str = "Idle"
         self.discovery_current_module: str | None = None
         self.discovery_modules_done: int = 0
         self.discovery_modules_total: int = 0
@@ -998,18 +998,21 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
     # ------------------------------------------------------------------
 
     @property
-    def discovery_progress_percent(self) -> int:
+    def discovery_progress_percent(self) -> float:
         """Overall progress estimate (0-100) across all discovery sub-phases.
 
         Phases are stacked by weight (see const.DISCOVERY_WEIGHT_*):
         inventory → identity → register_scan → finalizing. Within
         register_scan, progress is (completed_modules + partial_current) /
-        total_modules.
+        total_modules. Returned as a float with ~0.1 resolution so the UI
+        can show sub-percent movement — each of the 240 register ticks in
+        a module only advances the bar by a fraction of a percent, so an
+        integer-rounded value looks frozen for tens of seconds at a time.
         """
         if self.discovery_sub_phase in (DISCOVERY_SUB_PHASE_IDLE, DISCOVERY_SUB_PHASE_ERROR):
-            return 0
+            return 0.0
         if self.discovery_sub_phase == DISCOVERY_SUB_PHASE_FINISHED:
-            return 100
+            return 100.0
 
         # Cumulative floor — everything before the current phase is "done".
         floor = 0
@@ -1046,12 +1049,12 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         else:
             # Older libraries may still drive the legacy-phase field only.
             if self.discovery_phase == DISCOVERY_PHASE_PC_LINK:
-                return 10
+                return 10.0
             if self.discovery_phase == DISCOVERY_PHASE_MODULE_SCAN:
-                return 40
-            return 0
+                return 40.0
+            return 0.0
 
-        return min(99, int(floor + phase_frac * phase_weight))
+        return min(99.9, round(floor + phase_frac * phase_weight, 1))
 
     def _update_discovery_state(
         self,

--- a/custom_components/nikobus/sensor.py
+++ b/custom_components/nikobus/sensor.py
@@ -14,11 +14,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     BRAND,
-    DISCOVERY_PHASE_ERROR,
-    DISCOVERY_PHASE_FINISHED,
-    DISCOVERY_PHASE_IDLE,
-    DISCOVERY_PHASE_MODULE_SCAN,
-    DISCOVERY_PHASE_PC_LINK,
     DOMAIN,
     HUB_IDENTIFIER,
     SIGNAL_DISCOVERY_STATE,
@@ -110,19 +105,20 @@ class _DiscoverySignalEntity(SensorEntity):
 
 
 class NikobusDiscoveryStatusSensor(_DiscoverySignalEntity):
-    """Text sensor showing the current discovery phase/message."""
+    """Text sensor showing the current discovery status line.
+
+    Reports ``discovery_status_message`` (e.g.
+    ``"Scanning module 0E6C (2/10) — register 0x87 of 0xFF (145 records)"``)
+    as the native value so the user sees per-register progress in real
+    time instead of a coarse enum that sits at ``"module_scan"`` for the
+    entire register-scan phase. The previous enum classification
+    (``idle|pc_link|module_scan|finished|error``) is still exposed as the
+    ``phase`` attribute for automations that grouped on it.
+    """
 
     _attr_has_entity_name = True
     _attr_translation_key = "discovery_status"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_device_class = SensorDeviceClass.ENUM
-    _attr_options = [
-        DISCOVERY_PHASE_IDLE,
-        DISCOVERY_PHASE_PC_LINK,
-        DISCOVERY_PHASE_MODULE_SCAN,
-        DISCOVERY_PHASE_FINISHED,
-        DISCOVERY_PHASE_ERROR,
-    ]
 
     def __init__(self, coordinator: NikobusDataCoordinator) -> None:
         super().__init__(coordinator)
@@ -130,13 +126,13 @@ class NikobusDiscoveryStatusSensor(_DiscoverySignalEntity):
 
     @property
     def native_value(self) -> str:
-        return self._coordinator.discovery_phase
+        return self._coordinator.discovery_status_message
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         c = self._coordinator
         return {
-            "message": c.discovery_status_message,
+            "phase": c.discovery_phase,
             "sub_phase": c.discovery_sub_phase,
             "current_module": c.discovery_current_module,
             "modules_done": c.discovery_modules_done,
@@ -157,11 +153,12 @@ class NikobusDiscoveryProgressSensor(_DiscoverySignalEntity):
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_entity_registry_enabled_default = False
+    _attr_suggested_display_precision = 1
 
     def __init__(self, coordinator: NikobusDataCoordinator) -> None:
         super().__init__(coordinator)
         self._attr_unique_id = f"{DOMAIN}_discovery_progress"
 
     @property
-    def native_value(self) -> int:
+    def native_value(self) -> float:
         return self._coordinator.discovery_progress_percent


### PR DESCRIPTION
## Summary

Makes the "Discovery status" + "Discovery progress" sensors actually
reflect what the integration is doing during a long scan, instead of
sitting at a static state/percent for tens of minutes.

- **Status sensor** now displays the live per-register message
  (e.g. `Scanning module 0E6C (2/10) — register 0x87 of 0xFF (145
  records)`) as its state, updating every ~0.5s. Previously the state
  was a coarse enum fixed to one of 5 values, and the rich message
  was hidden as an attribute. The former enum is preserved as the
  `phase` attribute for any automation that grouped on it.

- **Progress sensor** now returns a float with 0.1 precision (via
  `suggested_display_precision = 1`). With the previous `int(...)`
  cast, ~37 consecutive progress events rounded to the same integer,
  so the bar looked frozen for 20+ seconds between visible ticks —
  longer when register ACKs timed out.

- `discovery_status_message` initializes to `"Idle"` instead of `""`
  so the state isn't blank before the first discovery run.

No runtime behavior change on the bus or in discovery; this is purely
a display-layer improvement.

## Test plan

- [ ] Trigger **Discover modules & buttons** from the options flow or
      the bridge entity page. Confirm the Discovery Status sensor
      ticks through messages like `PC Link inventory: …`,
      `Identifying modules (…)`, `Scanning module 0E6C (2/10) …`
      instead of being stuck at "Scanning modules".
- [ ] During register scan, confirm the Discovery Progress sensor
      displays sub-percent values (e.g. `32.4 %` → `32.7 %` →
      `33.1 %`) rather than holding at an integer for long stretches.
- [ ] Confirm automations that grouped on the old enum can be
      rewritten against `state_attr('sensor.discovery_status',
      'phase')`.