### PR TITLE
Fix "Invalid flow specified" after discovery from options flow

### DIFF
--- a/custom_components/nikobus/__init__.py
+++ b/custom_components/nikobus/__init__.py
@@ -178,8 +178,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: NikobusConfigEntry) -> b
 
 
 async def _async_options_updated(hass: HomeAssistant, entry: NikobusConfigEntry) -> None:
-    """Reload the integration when the user changes options."""
-    await hass.config_entries.async_reload(entry.entry_id)
+    """Reload the integration when the user changes options.
+
+    Scheduled as a background task rather than awaited, because HA awaits
+    update listeners before closing the options flow and responding to
+    the frontend. A reload triggered by the discovery options flow is
+    slow (unload + re-forward setup to every platform, rebuilding
+    entities for every freshly-discovered module/button); awaiting it
+    here causes the flow-close HTTP request to time out, which the UI
+    renders as a generic "Invalid flow specified" error. Firing the
+    reload as a task lets the flow finalize immediately; entities
+    refresh when the reload completes in the background.
+    """
+    hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
 
 
 def _register_hub_device(hass: HomeAssistant, entry: NikobusConfigEntry) -> None:


### PR DESCRIPTION
## Summary

Closes the "Invalid flow specified" error the options discovery flow
renders after a successful scan.

Root cause is a flow-close ↔ reload race: HA awaits options update
listeners before responding to the frontend's flow-close request. The
listener in this integration awaits `async_reload(entry_id)`, which
for a discovery-triggered reload is slow (unload the coordinator,
forward setup to every platform, rebuild entities for every freshly-
discovered module/button). The frontend HTTP request times out before
the reload finishes and the UI renders its generic "Invalid flow
specified" fallback. Nothing crashes server-side — that's why
`grep "Invalid flow specified"` returns nothing in the HA log.

Fix is a one-line change: schedule the reload via
`hass.async_create_task(...)` instead of awaiting it. The listener
returns immediately, the flow finalizes, the frontend closes the
dialog, and the reload runs asynchronously. Entities appear a beat
later when the reload completes.

This also resolves the historical "async_abort + manual reload" race
referenced in `config_flow.py` — the earlier workaround (switching
to `async_create_entry`) didn't fix it because both paths block on
the same awaited reload. The current attempt (`async_create_entry`)
can now stay in place; this PR just unblocks the listener.

## Test plan

- [ ] Open **Configure → Discover modules & buttons** (or **Scan all
      modules for button links**). Wait for the progress spinner to
      reach the early-stop / finalize phase. Confirm the dialog
      closes with the success confirmation instead of showing
      "Invalid flow specified".
- [ ] Confirm discovery still results in refreshed entities: the
      newly-discovered modules/buttons appear on the device page
      within a few seconds of the dialog closing.
- [ ] Open **Configure → Change hardware settings**, toggle a flag,
      submit. Confirm the reload still triggers and settings apply
      (the listener still runs — just non-blocking now).