### PR TITLE
Gate module scan on prior PC Link inventory

### DIFF
--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -9,9 +9,10 @@ from homeassistant.components.button import ButtonEntity
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import BRAND, DOMAIN, HUB_IDENTIFIER
+from .const import BRAND, DOMAIN, HUB_IDENTIFIER, SIGNAL_DISCOVERY_STATE
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity
 
@@ -118,7 +119,13 @@ class NikobusPcLinkInventoryButton(ButtonEntity):
 
 
 class NikobusModuleScanButton(ButtonEntity):
-    """Bridge button that starts a full module scan for button links."""
+    """Bridge button that starts a full module scan for button links.
+
+    Greyed out in the UI until at least one output-capable module is
+    known — the scan walks the list of known modules, so it has nothing
+    to do before a PC Link inventory (or legacy-file migration) has
+    populated storage.
+    """
 
     _attr_has_entity_name = True
     _attr_translation_key = "scan_all_module_links"
@@ -129,6 +136,23 @@ class NikobusModuleScanButton(ButtonEntity):
         self._coordinator = coordinator
         self._attr_unique_id = f"{DOMAIN}_module_scan_button"
         self._attr_device_info = _hub_device_info()
+
+    @property
+    def available(self) -> bool:
+        return self._coordinator.has_known_output_modules
+
+    async def async_added_to_hass(self) -> None:
+        """Re-render availability whenever discovery state changes."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, SIGNAL_DISCOVERY_STATE, self._handle_discovery_update
+            )
+        )
+
+    @callback
+    def _handle_discovery_update(self) -> None:
+        self.async_write_ha_state()
 
     async def async_press(self) -> None:
         """Scan all output modules for button links."""

--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -395,6 +395,14 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
         if coordinator is None:
             return self.async_abort(reason="not_loaded")
 
+        # Gate: the module scan walks the list of known output modules.
+        # Without a prior PC Link inventory (or a legacy-file migration)
+        # that list is empty and the scan has nothing to do. Steer the
+        # user to run the inventory first instead of silently finishing
+        # with zero records.
+        if self._discovery_task is None and not coordinator.has_known_output_modules:
+            return self.async_abort(reason="no_modules")
+
         if self._discovery_task is None:
             self._discovery_kind = "module_scan"
             self._discovery_task = self.hass.async_create_task(

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -616,6 +616,20 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         channels = hit[1].get("channels")
         return len(channels) if isinstance(channels, list) else 0
 
+    @property
+    def has_known_output_modules(self) -> bool:
+        """True if at least one output-capable module is known.
+
+        Gates the full module scan: without any known output modules the
+        scan has nothing to walk. A PC Link inventory (or a migration
+        from the legacy config file) must run first to populate storage.
+        """
+        return any(
+            isinstance(mods, dict) and mods
+            for m_type, mods in self.dict_module_data.items()
+            if m_type in MODULE_TYPES
+        )
+
     def get_module_type(self, module_id: str) -> str | None:
         """Return the hardware type of the specified module."""
         hit = find_module(self.module_storage.data, module_id)
@@ -1171,7 +1185,12 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                         str(addr).upper() for addr in modules.keys()
                     )
             total = len(self._discovery_module_order)
-            message = f"Scanning {total} modules…" if total else "Scanning modules…"
+            if total == 0:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="no_modules_known",
+                )
+            message = f"Scanning {total} modules…"
 
         self._discovery_auto_reload = auto_reload
         self._discovery_finished_event.clear()

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -119,6 +119,9 @@
         },
         "no_loaded_entry": {
             "message": "No loaded Nikobus integration found. Set one up before calling this action."
+        },
+        "no_modules_known": {
+            "message": "No Nikobus modules are configured yet. Run a PC-Link inventory discovery first, then retry the module scan."
         }
     },
     "options": {

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -100,7 +100,8 @@
         "abort": {
             "not_loaded": "L'intégration Nikobus n'est pas chargée. Veuillez la recharger puis réessayer.",
             "discovery_done": "Découverte terminée. L'intégration est en cours de rechargement, les nouvelles entités apparaîtront sous peu.",
-            "discovery_error": "Échec de la découverte : {error}"
+            "discovery_error": "Échec de la découverte : {error}",
+            "no_modules": "Aucun module Nikobus n'est encore configuré. Lancez d'abord un inventaire PC-Link."
         }
     },
     "entity": {
@@ -164,6 +165,9 @@
         },
         "no_loaded_entry": {
             "message": "Aucune intégration Nikobus chargée. Configurez-en une avant d'appeler cette action."
+        },
+        "no_modules_known": {
+            "message": "Aucun module Nikobus n'est encore configuré. Lancez d'abord un inventaire PC-Link, puis relancez le scan des modules."
         }
     }
 }

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -100,7 +100,8 @@
         "abort": {
             "not_loaded": "De Nikobus-integratie is niet geladen. Herlaad de integratie en probeer het opnieuw.",
             "discovery_done": "Ontdekking voltooid. De integratie wordt herladen; nieuwe entiteiten verschijnen zo dadelijk.",
-            "discovery_error": "Ontdekking mislukt: {error}"
+            "discovery_error": "Ontdekking mislukt: {error}",
+            "no_modules": "Er zijn nog geen Nikobus-modules geconfigureerd. Voer eerst een PC-Link-inventaris uit."
         }
     },
     "entity": {
@@ -164,6 +165,9 @@
         },
         "no_loaded_entry": {
             "message": "Geen geladen Nikobus-integratie gevonden. Stel er één in voordat u deze actie aanroept."
+        },
+        "no_modules_known": {
+            "message": "Er zijn nog geen Nikobus-modules geconfigureerd. Voer eerst een PC-Link-inventaris uit en probeer dan opnieuw modules te scannen."
         }
     }
 }


### PR DESCRIPTION
## Summary

Prevents users from kicking off a full module scan before a PC Link
inventory (or legacy-file migration) has populated the list of known
output modules. Without that list the scan does zero work, but the
library returns "Discovery finished" anyway, which reads as "nothing
to discover" and leads users to stop rather than run the inventory
that would actually populate their setup.

Three guards — cheap to maintain, each catches a different entry
point:

- **Coordinator** — `start_module_scan(module_address=None)` raises
  `HomeAssistantError(translation_key="no_modules_known")` when no
  output modules are known. Covers bus-level callers: scripts,
  services, the UI button, and the options flow task.

- **Options flow** — `async_step_discovery_modules` pre-checks
  `coordinator.has_known_output_modules` before creating the
  background task and aborts with `reason="no_modules"` (translation
  already existed in `options.abort`). The user sees a clear message
  pointing them at the PC Link inventory item in the same menu.

- **Module-scan button** — `NikobusModuleScanButton` now has a
  reactive `available` property tied to
  `coordinator.has_known_output_modules`. The button greys out in
  the device UI until an inventory has run. Subscribes to
  `SIGNAL_DISCOVERY_STATE` to re-render when discovery completes.

Single-module scans (`start_module_scan(module_address="...")`)
remain unguarded — if the user already knows a module address and
wants to rescan it, storage state doesn't matter.

Translation additions:
- `exceptions.no_modules_known` in `en.json`, `fr.json`, `nl.json`.
- `options.abort.no_modules` added to `fr.json` and `nl.json` (was
  English-only).

## Test plan

- [ ] Fresh install (or after clearing `.storage/nikobus.modules`):
      confirm the **Scan all module links** button on the Nikobus
      Bridge device is greyed out, and that the "Scan all modules
      for button links" menu item in the options flow aborts with
      the "No Nikobus modules are configured yet" message.
- [ ] Run **Discover modules & buttons** (PC Link inventory) to
      populate modules. Confirm the scan button becomes available
      and the options-flow menu item proceeds to the progress
      spinner.
- [ ] After an inventory, trigger a scan via the bus service
      (`nikobus.query_module_inventory` with an explicit
      `module_address`) — should still work (single-module path
      isn't gated).