### PR TITLE
Qualify IR op-point device name with receiver address

### DIFF
--- a/custom_components/nikobus/binary_sensor.py
+++ b/custom_components/nikobus/binary_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 
-from .button import register_wall_button_devices
+from .button import op_point_display_name, register_wall_button_devices
 from .const import DOMAIN, EVENT_BUTTON_PRESSED
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity
@@ -71,7 +71,7 @@ class NikobusButtonBinarySensor(NikobusEntity, BinarySensorEntity):
         bus_addr = op_point["bus_address"]
         self._physical_address = physical_address
         self._key_label = key_label
-        name = op_point.get("description") or f"Push button {key_label}"
+        name = op_point_display_name(physical_address, key_label, op_point)
         super().__init__(
             coordinator=coordinator,
             address=bus_addr,

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -98,6 +98,24 @@ def _hub_device_info() -> dr.DeviceInfo:
     )
 
 
+def op_point_display_name(
+    physical_address: str, key_label: str, op_point: dict[str, Any]
+) -> str:
+    """Build a UI-visible name for an op-point's device entry.
+
+    IR op-points (storage keys starting with ``IR:``) get the receiver's
+    bus address appended so the same IR code registered on different
+    receivers remains distinguishable in the device list — the
+    library-generated description ("IR code 30A #I30A") is identical for
+    every receiver that learned the same code. Wall keys keep the
+    library description verbatim; it already carries the channel label.
+    """
+    if key_label.startswith("IR:"):
+        ir_code = key_label[len("IR:"):]
+        return f"IR {ir_code} on {physical_address}"
+    return op_point.get("description") or f"Push button {key_label}"
+
+
 class NikobusPcLinkInventoryButton(ButtonEntity):
     """Bridge button that starts a PC Link inventory discovery."""
 
@@ -155,7 +173,7 @@ class NikobusButtonEntity(NikobusEntity, ButtonEntity):
         self._physical_address = physical_address
         self._key_label = key_label
 
-        name = op_point.get("description") or f"Push button {key_label}"
+        name = op_point_display_name(physical_address, key_label, op_point)
 
         super().__init__(
             coordinator=coordinator,


### PR DESCRIPTION
## Summary

The library generates IR op-point descriptions as `"IR code X #IX"` —
identical for every receiver that learned the same code. When two
receivers share an IR code (common with scene remotes mapped onto
multiple rooms), the HA device list shows several entries with that
same label and no visible way to tell them apart.

Unique IDs are already safe: each IR op-point has its own
`bus_address` computed from the nibble-shift rule in nikobus-connect,
so entity registration and routing already distinguish them. This PR
only changes the visible **device name** by appending the receiver's
bus address:

  `IR 30A on 0D1C80`
  `IR 30A on 0D1C40`

Wall-key op-points keep the library description verbatim; that text
already carries the channel label and doesn't collide.

Introduces one shared helper (`op_point_display_name`) in `button.py`
so `binary_sensor.py` reuses the same logic — the twin binary sensor
inherits the qualified name automatically.

## Test plan

- [ ] Reload the integration on an install that has IR receivers with
      overlapping codes. Confirm the device list shows
      `IR <code> on <receiver_address>` instead of the ambiguous
      `IR code <code> #I<code>`.
- [ ] Confirm non-IR (wall-key) op-points are unchanged — their label
      still reads e.g. "Push button 1C" or whatever custom description
      the library provided.
- [ ] Confirm entity unique IDs didn't change: no new-entity
      duplicates, no orphaned entities after reload. (Unique IDs are
      built from `bus_address`, not from the device name.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_