### PR TITLE
Options flow: rename channel entity_type "none" → "default"; add "disabled"

### DIFF
--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -37,11 +37,42 @@ from nikobus_connect.discovery import find_module
 _LOGGER = logging.getLogger(__name__)
 
 # Module hardware capabilities: which HA entity types each module type can back.
+#
+# Per-module dropdown choices in the "Customize a module" options flow:
+#
+#   - "default"  — use the module's natural entity type (switch, light, or
+#                  cover depending on the module). Stored as absent
+#                  ``entity_type`` on the channel; the router's
+#                  ``_resolve_entity_type`` falls through to the hardware
+#                  default.
+#   - a concrete override (``switch`` / ``light`` / ``cover``) — only listed
+#     when the hardware can actually back that entity type.
+#   - "disabled" — skip the channel entirely (no HA entity created). Checked
+#                  in ``router.py`` alongside the legacy ``not_in_use``
+#                  description-prefix convention.
 _MODULE_ENTITY_TYPES: dict[str, list[str]] = {
-    "switch_module": ["switch", "light", "none"],
-    "dimmer_module": ["light", "none"],
-    "roller_module": ["cover", "switch", "light", "none"],
+    "switch_module": ["default", "light", "disabled"],
+    "dimmer_module": ["default", "disabled"],
+    "roller_module": ["default", "switch", "light", "disabled"],
 }
+
+# The implicit default entity type a channel resolves to when no explicit
+# override is stored — kept in sync with ``router._resolve_entity_type``.
+_MODULE_DEFAULT_ENTITY_TYPE: dict[str, str] = {
+    "switch_module": "switch",
+    "dimmer_module": "light",
+    "roller_module": "cover",
+}
+
+
+def _entity_type_label(module_type: str, value: str) -> str:
+    """Human-readable label for an entity-type dropdown value."""
+    if value == "default":
+        resolved = _MODULE_DEFAULT_ENTITY_TYPE.get(module_type, "switch")
+        return f"Default ({resolved})"
+    if value == "disabled":
+        return "Disabled (hide channel)"
+    return value.capitalize()
 
 _HEX_RE = re.compile(r"^[0-9A-Fa-f]{6}$")
 
@@ -606,9 +637,13 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
                 errors["base"] = "invalid_hex_address"
             else:
                 entity_type = user_input.get("entity_type")
-                if entity_type and entity_type != "none":
+                if entity_type and entity_type != "default":
+                    # "disabled" and concrete overrides ("switch" / "light" /
+                    # "cover") are stored verbatim on the channel.
                     channel["entity_type"] = entity_type
                 else:
+                    # "default" — drop the override so the router falls
+                    # through to the hardware default.
                     channel.pop("entity_type", None)
 
                 channel["description"] = (
@@ -629,10 +664,15 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
                 self._edit_channel_index = None
                 return await self.async_step_edit_module()
 
-        allowed = _MODULE_ENTITY_TYPES.get(module_type, ["switch", "light", "none"])
-        current_entity_type = channel.get("entity_type") or "none"
+        allowed = _MODULE_ENTITY_TYPES.get(module_type, ["default", "light", "disabled"])
+        # Absent entity_type on the channel resolves to the default at runtime,
+        # so present it that way in the dropdown too. Any pre-existing value
+        # that no longer appears in the module's allowed list (e.g. a roller
+        # channel stored as "switch" that is no longer offered) falls back to
+        # "default" rather than silently sticking on an off-list value.
+        current_entity_type = channel.get("entity_type") or "default"
         if current_entity_type not in allowed:
-            current_entity_type = allowed[0]
+            current_entity_type = "default"
 
         schema_dict: dict[Any, Any] = {
             vol.Required(
@@ -640,7 +680,10 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
                 default=current_entity_type,
             ): SelectSelector(
                 SelectSelectorConfig(
-                    options=[{"value": v, "label": v.capitalize()} for v in allowed],
+                    options=[
+                        {"value": v, "label": _entity_type_label(module_type, v)}
+                        for v in allowed
+                    ],
                     mode=SelectSelectorMode.DROPDOWN,
                 )
             ),

--- a/custom_components/nikobus/router.py
+++ b/custom_components/nikobus/router.py
@@ -113,8 +113,15 @@ def build_routing(
                     )
                     continue
                 channel_description = channel_info.get("description", "")
-                
-                # Skip channels explicitly marked as unused
+
+                # Skip channels explicitly marked as unused.
+                #   * ``entity_type: "disabled"`` — set from the "Customize a
+                #     module" options flow to hide a channel.
+                #   * ``description`` prefixed with ``not_in_use`` — the
+                #     legacy convention from hand-edited config files; still
+                #     honoured for backwards compatibility.
+                if channel_info.get("entity_type") == "disabled":
+                    continue
                 if channel_description.startswith("not_in_use"):
                     continue
 


### PR DESCRIPTION
## Summary

The **Customize a module → pick channel** options flow offered `"none"`
as an entity_type choice, which read like *"hide the channel"* to users
but actually meant *"use the module's hardware default"* — the save
path just dropped the key entirely, and the router's
`_resolve_entity_type` fell through to the default
(switch / light / cover). Meanwhile the real "hide this channel"
mechanism — prefixing the description with `not_in_use` — was never
surfaced in the UI, so users who actually wanted to skip a channel had
no in-app way to do it.

This PR realigns the labels with the behaviour and closes the UI gap:

- **`"default"`** replaces `"none"` as the selector value and is shown
  in the dropdown as *"Default (switch)"* / *"Default (light)"* /
  *"Default (cover)"* so the effective entity type is unambiguous per
  module. Still stored as an absent `entity_type` on the channel → no
  data migration needed; existing installs just see a relabelled
  dropdown.

- **`"disabled"`** is a new selector value that stores
  `entity_type: "disabled"` on the channel. The router now skips
  channels where `entity_type == "disabled"` **in addition to** the
  legacy `not_in_use`-prefix description check, so hand-edited configs
  from earlier releases keep working.

- Dropdown labels are built per `module_type` via a new
  `_entity_type_label(module_type, value)` helper — the fixed strings
  stay in the Python source for now (no translation-file churn).

- Off-list pre-existing values (e.g. a roller channel stored as a
  value that's no longer offered, or a legacy `"none"`) fall back to
  `"default"` in the dropdown rather than silently sticking on an
  invisible value.

## Per-module dropdown contents after this change

| Module type | Dropdown options |
| --- | --- |
| `switch_module` | Default (switch) / Light / Disabled |
| `dimmer_module` | Default (light) / Disabled |
| `roller_module` | Default (cover) / Switch / Light / Disabled |

## Test plan

- [ ] Open **Configure → Customize a module → pick module → pick
      channel**. Confirm the entity-type dropdown shows the new
      labels per module type.
- [ ] Select **Default (…)** on a channel that previously had an
      override, save, reload. Confirm the override is removed from
      storage and the entity switches back to the hardware default.
- [ ] Select **Disabled** on a channel, save, reload. Confirm the
      entity disappears from HA. Flip back to **Default**, reload,
      confirm it reappears.
- [ ] Legacy: set a channel description to `not_in_use Something`
      (pre-2.0 style). Confirm the channel still skips entity
      creation after this PR.
- [ ] Open an install that had `entity_type: "none"` manually stored
      (or was persisted under an earlier buggy save). The dropdown
      should render it as **Default (…)** rather than an empty entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_