### PR TITLE
Options flow: abort instead of create_entry after discovery

### DIFF
--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -410,8 +410,12 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
 
         if self._discovery_task is None:
             self._discovery_kind = "pc_link"
+            # auto_reload=True: let the coordinator schedule its own
+            # background reload when discovery finishes. The options flow
+            # terminates with async_abort (no update-listener round-trip),
+            # so we can't rely on the listener to kick off a reload here.
             self._discovery_task = self.hass.async_create_task(
-                coordinator.start_pc_link_inventory(auto_reload=False)
+                coordinator.start_pc_link_inventory(auto_reload=True)
             )
 
         return await self._progress_step("discovery_pc_link")
@@ -436,8 +440,11 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
 
         if self._discovery_task is None:
             self._discovery_kind = "module_scan"
+            # auto_reload=True: same rationale as the PC Link step above
+            # — the coordinator handles reload asynchronously once
+            # discovery finishes; the flow terminates via async_abort.
             self._discovery_task = self.hass.async_create_task(
-                coordinator.start_module_scan(auto_reload=False)
+                coordinator.start_module_scan(auto_reload=True)
             )
 
         return await self._progress_step("discovery_modules")
@@ -735,16 +742,25 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
     ) -> config_entries.FlowResult:
         """Finalize the flow after a successful discovery.
 
-        Use ``async_create_entry`` with empty options so HA closes the
-        flow cleanly via its standard success dialog. The coordinator's
-        auto-reload (triggered by the options update listener) picks up
-        the newly-discovered entities. This avoids the "Invalid flow
-        specified" error that async_abort + manual reload can cause.
+        Abort with the ``discovery_done`` reason so HA closes the flow
+        via a plain terminal response — no options persistence, no
+        update listener invocation, no awaiting of the reload.
+
+        Entity refresh is delegated to the coordinator:
+        ``_handle_discovery_finished`` schedules the config-entry reload
+        via ``hass.async_create_task`` (see ``coordinator.py``), so it
+        runs independently of the flow lifecycle. This keeps the
+        flow-close HTTP response fast enough for the frontend to render
+        the success dialog instead of falling back to its generic
+        "Invalid flow specified" error.
+
+        (The previous ``async_create_entry`` version kept the flow
+        dependent on the options update listener, which — even after
+        it was made fire-and-forget in #288 — was still entangled with
+        the ``async_show_progress_done → next_step → create_entry``
+        hand-off on the flow-manager side.)
         """
-        # Merge back the existing options so the update listener fires
-        # even if self._options is empty.
-        merged = {**self.config_entry.options, **self._options}
-        return self.async_create_entry(title="", data=merged)
+        return self.async_abort(reason="discovery_done")
 
     async def async_step_discovery_error(
         self, user_input: dict[str, Any] | None = None


### PR DESCRIPTION
## Summary

Second shot at the "Invalid flow specified" that appears after a
discovery completes from the options flow. #288 made the update
listener fire-and-forget, which removed the obvious
await-reload-in-listener bottleneck — but the error still reproduces
on some installs, so the terminal-step shape itself is the remaining
culprit.

### What's changing

The discovery paths don't actually change options
(`self._options` is empty on both `async_step_discovery_pc_link` and
`async_step_discovery_modules`), so `async_create_entry` was
semantically wrong: it engaged the update-listener machinery for a
flow that had nothing to persist. That kept an observable window
open on the flow-manager side where the flow could disappear before
the frontend's follow-up call landed — and the frontend renders that
as "Invalid flow specified".

Switch `async_step_discovery_done` to `async_abort(reason="discovery_done")`.
The abort message is already in all three translation files:

> "Discovery finished. The integration is reloading and the
> newly-discovered entities will appear shortly."

Reload responsibility moves to the coordinator:

- `start_pc_link_inventory(auto_reload=True)` and
  `start_module_scan(auto_reload=True)` in both option steps.
- `_handle_discovery_finished` already schedules
  `hass.async_create_task(async_reload(entry_id))` when
  `auto_reload=True`. That's the existing path used by the Bridge
  device's discovery buttons — no behaviour change there.

Net: the flow-close HTTP response is now a single terminal abort,
with no options persistence, no update-listener invocation, no
awaiting of anything. The reload runs independently of the flow
lifecycle.

## Test plan

- [ ] Run **Configure → Discover modules & buttons** to completion.
      Confirm the dialog closes with the "Discovery finished. The
      integration is reloading…" message and the newly-discovered
      entities appear a moment later.
- [ ] Same check for **Configure → Scan all modules for button
      links** (runs with existing modules).
- [ ] Bridge-device **Discover modules & buttons** button (the
      non-flow path) still works — this PR only touches the options
      flow; the button path already used `auto_reload=True`.
- [ ] Reconfigure via **Configure → Change hardware settings** still
      triggers a reload after a settings change (that path uses
      `async_update_reload_and_abort` and is unaffected).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_