### PR TITLE
Discovery progress: use dynamic register_total instead of hardcoded 0xFF

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -466,11 +466,22 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 )
             elif sub_phase == DISCOVERY_SUB_PHASE_REGISTER_SCAN:
                 if module_address:
+                    # Library supplies ``register_total`` (a count starting
+                    # at register 0x10). Show the actual upper bound rather
+                    # than the legacy hard-coded 0xFF — some modules scan
+                    # much narrower ranges, and the early-stop heuristic
+                    # revises ``register_total`` downward once it fires.
+                    # Fall back to 0xFF only when the library did not send
+                    # a register_total (older lib versions / pre-scan tick).
+                    if register_total:
+                        top_register = 0x10 + register_total - 1
+                    else:
+                        top_register = 0xFF
                     message = (
                         f"Scanning module {module_address} "
                         f"({module_index}/{module_total}) — "
-                        f"register 0x{int(register or 0):02X} of 0xFF "
-                        f"({decoded_records} records)"
+                        f"register 0x{int(register or 0):02X} of "
+                        f"0x{top_register:02X} ({decoded_records} records)"
                     )
                 else:
                     message = f"Scanning modules ({module_index}/{module_total})"


### PR DESCRIPTION
## Summary

The register-scan status line on the Bridge device (e.g.
`Scanning module 0E6C (2/10) — register 0x87 of 0xFF (145 records)`)
hardcoded the upper bound as `0xFF`. That's the maximum *planned*
register for a full 240-register scan, not the actual upper bound of
the current module — and nikobus-connect now emits `register_total`
dynamically via `on_progress`, revising it downward when the
early-stop heuristic fires (3 consecutive empty blocks).

The coordinator was already reading `register_total` for the
progress-percent calculation (`coordinator.py:1032-1036`) and the
sensor's `registers_total` attribute, but the textual status line
kept the legacy hardcoded bound. This PR threads the dynamic value
into the format so it matches reality:

- When the library reports `register_total = 200`, the line reads
  `… register 0x87 of 0xC8 (…)` (top = 0x10 + 200 − 1 = 0xC8).
- When no total is reported yet (older lib versions / the very first
  tick before the count has been set), the legacy `0xFF` fallback
  kicks in — no regression for those cases.

## Test plan

- [ ] Run **Discover modules & buttons** from the Bridge device and
      watch the Discovery Status sensor. The "of 0x__" portion of
      the per-register line should reflect the actual upper bound
      reported by the library, and should drop (if the early-stop
      heuristic kicks in) toward the end of each module's scan.
- [ ] Confirm no regression when the library doesn't report a
      register_total (old installs): line still renders `of 0xFF`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_