### PR TITLE
Discovery progress: drop 1-second poll task, use real task as progress_task

### DIFF
--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -452,21 +452,40 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
     async def _progress_step(
         self, step_id: str
     ) -> config_entries.FlowResult:
-        """Poll the background discovery task and show a progress spinner.
+        """Show a progress spinner until the discovery task completes.
 
-        HA only re-runs the flow step when the ``progress_task`` completes.
-        To refresh the displayed progress during a long-running discovery, we
-        pass a short "poll" task (sleep 1s) as the ``progress_task``. HA
-        re-runs the step when that poll task completes, which lets us read
-        the latest coordinator state and return a new spinner with updated
-        description placeholders. Meanwhile the real discovery task runs
-        independently; once it finishes, the next invocation transitions to
-        the done/error step.
+        Passes the real discovery task itself as ``progress_task`` so
+        HA re-runs this step exactly once — when the task finishes —
+        and we transition to the terminal step. No intermediate
+        re-renders while the scan is running.
+
+        The earlier implementation created a fresh 1-second
+        ``asyncio.sleep`` task as ``progress_task`` on every call to
+        refresh the dialog text mid-scan. On long scans that piled
+        up hundreds of short-lived tasks and a handful of race
+        windows: a poll task could fire after we'd already returned
+        ``PROGRESS_DONE``, HA would re-enter a flow whose state had
+        moved on, and the frontend rendered "Invalid flow specified"
+        even when nothing crashed server-side. See the prior attempts
+        in #288 (fire-and-forget reload) and #294 (abort instead of
+        create_entry) — both were real fixes but missed this layer.
+
+        The trade-off is that the progress-dialog description is
+        static for the duration of the scan. Live per-register detail
+        is surfaced via the **Discovery Status** and **Discovery
+        Progress** sensors on the Nikobus Bridge device, which are
+        what the user should watch during a long scan.
         """
         coordinator = self._coordinator()
         task = self._discovery_task
 
-        if task is not None and task.done():
+        if task is None:
+            # The caller always creates the task before we get here; treat
+            # a missing task as an error rather than spinning forever.
+            _LOGGER.error("Discovery progress step reached without a task")
+            return self.async_show_progress_done(next_step_id="discovery_error")
+
+        if task.done():
             self._discovery_task = None
             try:
                 task.result()
@@ -483,9 +502,6 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
         percent = coordinator.discovery_progress_percent if coordinator else 0
         display = raw_message or "Starting…"
 
-        # Short poll task so HA re-runs this step every 1s to refresh the UI.
-        poll_task = self.hass.async_create_task(asyncio.sleep(1))
-
         kwargs: dict[str, Any] = {
             "step_id": step_id,
             "progress_action": "discovery",
@@ -495,7 +511,7 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
             },
         }
         try:
-            return self.async_show_progress(progress_task=poll_task, **kwargs)
+            return self.async_show_progress(progress_task=task, **kwargs)
         except TypeError:
             # Older HA without progress_task support — fall back to plain call.
             return self.async_show_progress(**kwargs)


### PR DESCRIPTION
## Summary

Third (and hopefully final) pass on *"Invalid flow specified"* after
discovery completes from the options flow.

### What the previous attempts fixed — and missed

- **#288** made the options update listener fire-and-forget so the
  reload no longer blocked the flow-close HTTP response. Real fix,
  but partial.
- **#294** switched the terminal step from `async_create_entry` to
  `async_abort` so the flow closes with a single response and no
  options-listener involvement at all. Real fix, but still partial.

Both were necessary. Neither was sufficient: the error still
reproduced on some installs.

### Remaining culprit

`_progress_step` created a fresh `asyncio.sleep(1)` task on every
call and passed *that* as `progress_task`, so HA would re-run the
step every second to refresh the dialog text. On a 10-minute module
scan that's ~600 poll tasks and 600 re-runs. When the real discovery
task finishes, the next invocation returns `PROGRESS_DONE` — but a
pending poll task can still fire after that, causing HA to re-enter
a flow whose state has already moved on. The frontend then sees a
flow_id that no longer has the expected shape and renders the
generic *"Invalid flow specified"* error. Nothing crashes
server-side, which is why grepping the HA log for
`"Invalid flow specified"` (from the earlier debugging session)
never turned up a Python traceback.

### The fix

Drop the poll task entirely. Pass the **real discovery Future** as
`progress_task`. HA re-runs the step exactly once, when discovery
completes. No accumulated throwaways, no race window.

```python
# Before:
poll_task = self.hass.async_create_task(asyncio.sleep(1))
return self.async_show_progress(progress_task=poll_task, ...)

# After:
return self.async_show_progress(progress_task=task, ...)
# (``task`` is the already-running discovery coroutine)
```

### Trade-off

The description text inside the progress dialog is now **static** for
the scan's duration. Live per-register detail stays available on the
**Nikobus Bridge** device's *Discovery Status* and *Discovery
Progress* sensors, which were already the richer view — the dialog
placeholders could only carry the first-tick snapshot of the text
anyway, never a ticking counter.

Also guards against the edge case where `_progress_step` is reached
without a discovery task in flight (shouldn't happen, but fail
loudly to the error step rather than spinning forever).

## Test plan

- [ ] Run **Configure → Discover modules & buttons** through to
      completion. Confirm the dialog closes with the *"Discovery
      finished…"* abort message and no *"Invalid flow specified"*.
- [ ] Same for **Configure → Scan all modules for button links**.
- [ ] Confirm the Nikobus Bridge device's **Discovery Status**
      sensor ticks through the live per-register message during
      the scan (that's where the detail now lives).
- [ ] Error path: force a discovery failure (e.g. disconnect the
      PC-Link mid-scan) and confirm the flow transitions to the
      error step cleanly instead of "Invalid flow specified".

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_