### PR TITLE
Options flow: localize entity_type dropdown labels (en/fr/nl)

### DIFF
--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -57,22 +57,9 @@ _MODULE_ENTITY_TYPES: dict[str, list[str]] = {
 }
 
 # The implicit default entity type a channel resolves to when no explicit
-# override is stored — kept in sync with ``router._resolve_entity_type``.
-_MODULE_DEFAULT_ENTITY_TYPE: dict[str, str] = {
-    "switch_module": "switch",
-    "dimmer_module": "light",
-    "roller_module": "cover",
-}
-
-
-def _entity_type_label(module_type: str, value: str) -> str:
-    """Human-readable label for an entity-type dropdown value."""
-    if value == "default":
-        resolved = _MODULE_DEFAULT_ENTITY_TYPE.get(module_type, "switch")
-        return f"Default ({resolved})"
-    if value == "disabled":
-        return "Disabled (hide channel)"
-    return value.capitalize()
+# override is stored — declared in router._resolve_entity_type. The
+# translations/*.json selector.entity_type_<module_type>.options.default
+# labels ("Default (switch)" / …) document the mapping to the user.
 
 _HEX_RE = re.compile(r"^[0-9A-Fa-f]{6}$")
 
@@ -687,11 +674,13 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
                 default=current_entity_type,
             ): SelectSelector(
                 SelectSelectorConfig(
-                    options=[
-                        {"value": v, "label": _entity_type_label(module_type, v)}
-                        for v in allowed
-                    ],
+                    options=list(allowed),
                     mode=SelectSelectorMode.DROPDOWN,
+                    # Labels come from translations/*.json under
+                    # selector.entity_type_<module_type>.options.<value>.
+                    # One key per module_type so the "Default (…)" suffix
+                    # can name the module's hardware-default entity type.
+                    translation_key=f"entity_type_{module_type}",
                 )
             ),
             vol.Optional(

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -197,7 +197,7 @@
             },
             "edit_channel": {
                 "title": "Module {address} — channel {channel}",
-                "description": "Configure how this channel appears in Home Assistant. Set `entity_type` to `none` to hide the channel entirely.",
+                "description": "Configure how this channel appears in Home Assistant. Pick **Disabled (hide channel)** in the Entity type dropdown to skip creating an entity for this channel.",
                 "data": {
                     "entity_type": "Entity type",
                     "description": "Channel description",

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -220,5 +220,28 @@
             },
             "name": "Query module inventory"
         }
+    },
+    "selector": {
+        "entity_type_switch_module": {
+            "options": {
+                "default": "Default (switch)",
+                "light": "Light",
+                "disabled": "Disabled (hide channel)"
+            }
+        },
+        "entity_type_dimmer_module": {
+            "options": {
+                "default": "Default (light)",
+                "disabled": "Disabled (hide channel)"
+            }
+        },
+        "entity_type_roller_module": {
+            "options": {
+                "default": "Default (cover)",
+                "switch": "Switch",
+                "light": "Light",
+                "disabled": "Disabled (hide channel)"
+            }
+        }
     }
 }

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -107,7 +107,7 @@
             },
             "edit_channel": {
                 "title": "Module {address} — canal {channel}",
-                "description": "Configurez l'apparence de ce canal dans Home Assistant. Sélectionnez **Disabled (hide channel)** dans la liste Type d'entité pour ne pas créer d'entité pour ce canal.",
+                "description": "Configurez l'apparence de ce canal dans Home Assistant. Sélectionnez **Désactivé (masquer le canal)** dans la liste Type d'entité pour ne pas créer d'entité pour ce canal.",
                 "data": {
                     "entity_type": "Type d'entité",
                     "description": "Description du canal",
@@ -196,6 +196,29 @@
         },
         "no_modules_known": {
             "message": "Aucun module Nikobus n'est encore configuré. Lancez d'abord un inventaire PC-Link, puis relancez le scan des modules."
+        }
+    },
+    "selector": {
+        "entity_type_switch_module": {
+            "options": {
+                "default": "Par défaut (interrupteur)",
+                "light": "Lumière",
+                "disabled": "Désactivé (masquer le canal)"
+            }
+        },
+        "entity_type_dimmer_module": {
+            "options": {
+                "default": "Par défaut (lumière)",
+                "disabled": "Désactivé (masquer le canal)"
+            }
+        },
+        "entity_type_roller_module": {
+            "options": {
+                "default": "Par défaut (volet)",
+                "switch": "Interrupteur",
+                "light": "Lumière",
+                "disabled": "Désactivé (masquer le canal)"
+            }
         }
     }
 }

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -59,6 +59,7 @@
                 "description": "Que souhaitez-vous faire ?",
                 "menu_options": {
                     "hardware": "Modifier la configuration matérielle",
+                    "configure_modules": "Personnaliser un module (description, type d'entité, déclencheurs LED, temps de course)",
                     "discovery_pc_link": "Découvrir les modules et boutons (inventaire PC Link)",
                     "discovery_modules": "Scanner tous les modules pour les liens de boutons"
                 }
@@ -88,6 +89,33 @@
             "discovery_pc_link": {
                 "title": "Inventaire PC Link",
                 "description": "Analyse du registre PC Link pour trouver les modules et boutons.\n\n**Progression :** {percent}%\n\n{message}"
+            },
+            "configure_modules": {
+                "title": "Personnaliser un module Nikobus",
+                "description": "Choisissez un module à modifier. Les champs issus de la découverte (modèle, adresse, nombre de canaux) restent en lecture seule ; seuls les champs utilisateur (descriptions, types d'entité, déclencheurs LED, temps de course) peuvent être modifiés ici.",
+                "data": {
+                    "module": "Module"
+                }
+            },
+            "edit_module": {
+                "title": "Module {address} ({module_type})",
+                "description": "Modèle : {model}. Modifiez la description du module ou choisissez un canal à personnaliser.",
+                "data": {
+                    "description": "Description du module",
+                    "channel": "Canal"
+                }
+            },
+            "edit_channel": {
+                "title": "Module {address} — canal {channel}",
+                "description": "Configurez l'apparence de ce canal dans Home Assistant. Sélectionnez **Disabled (hide channel)** dans la liste Type d'entité pour ne pas créer d'entité pour ce canal.",
+                "data": {
+                    "entity_type": "Type d'entité",
+                    "description": "Description du canal",
+                    "led_on": "Déclencheur LED allumée (adresse bus 6-hex, optionnel)",
+                    "led_off": "Déclencheur LED éteinte (adresse bus 6-hex, optionnel)",
+                    "operation_time_up": "Temps de course à l'ouverture (secondes)",
+                    "operation_time_down": "Temps de course à la fermeture (secondes)"
+                }
             },
             "discovery_modules": {
                 "title": "Scan des modules",

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -59,6 +59,7 @@
                 "description": "Wat wilt u doen?",
                 "menu_options": {
                     "hardware": "Hardware-instellingen wijzigen",
+                    "configure_modules": "Module aanpassen (beschrijving, entiteitstype, LED-triggers, looptijd)",
                     "discovery_pc_link": "Modules en knoppen ontdekken (PC Link-inventaris)",
                     "discovery_modules": "Alle modules scannen voor knoppenkoppelingen"
                 }
@@ -88,6 +89,33 @@
             "discovery_pc_link": {
                 "title": "PC Link-inventaris",
                 "description": "Het PC Link-register wordt gescand op modules en knoppen.\n\n**Voortgang:** {percent}%\n\n{message}"
+            },
+            "configure_modules": {
+                "title": "Een Nikobus-module aanpassen",
+                "description": "Kies een module om te bewerken. Velden uit de ontdekking (model, adres, aantal kanalen) blijven alleen-lezen; alleen gebruikersvelden (beschrijvingen, entiteitstypes, LED-triggers, looptijden) kunnen hier worden gewijzigd.",
+                "data": {
+                    "module": "Module"
+                }
+            },
+            "edit_module": {
+                "title": "Module {address} ({module_type})",
+                "description": "Model: {model}. Bewerk de beschrijving van de module of kies een kanaal om aan te passen.",
+                "data": {
+                    "description": "Modulebeschrijving",
+                    "channel": "Kanaal"
+                }
+            },
+            "edit_channel": {
+                "title": "Module {address} — kanaal {channel}",
+                "description": "Stel in hoe dit kanaal in Home Assistant verschijnt. Kies **Disabled (hide channel)** in de entiteitstype-keuzelijst om geen entiteit voor dit kanaal aan te maken.",
+                "data": {
+                    "entity_type": "Entiteitstype",
+                    "description": "Kanaalbeschrijving",
+                    "led_on": "LED-aan trigger (6-hex busadres, optioneel)",
+                    "led_off": "LED-uit trigger (6-hex busadres, optioneel)",
+                    "operation_time_up": "Looptijd omhoog (seconden)",
+                    "operation_time_down": "Looptijd omlaag (seconden)"
+                }
             },
             "discovery_modules": {
                 "title": "Modules scannen",

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -107,7 +107,7 @@
             },
             "edit_channel": {
                 "title": "Module {address} — kanaal {channel}",
-                "description": "Stel in hoe dit kanaal in Home Assistant verschijnt. Kies **Disabled (hide channel)** in de entiteitstype-keuzelijst om geen entiteit voor dit kanaal aan te maken.",
+                "description": "Stel in hoe dit kanaal in Home Assistant verschijnt. Kies **Uitgeschakeld (kanaal verbergen)** in de entiteitstype-keuzelijst om geen entiteit voor dit kanaal aan te maken.",
                 "data": {
                     "entity_type": "Entiteitstype",
                     "description": "Kanaalbeschrijving",
@@ -196,6 +196,29 @@
         },
         "no_modules_known": {
             "message": "Er zijn nog geen Nikobus-modules geconfigureerd. Voer eerst een PC-Link-inventaris uit en probeer dan opnieuw modules te scannen."
+        }
+    },
+    "selector": {
+        "entity_type_switch_module": {
+            "options": {
+                "default": "Standaard (schakelaar)",
+                "light": "Lamp",
+                "disabled": "Uitgeschakeld (kanaal verbergen)"
+            }
+        },
+        "entity_type_dimmer_module": {
+            "options": {
+                "default": "Standaard (lamp)",
+                "disabled": "Uitgeschakeld (kanaal verbergen)"
+            }
+        },
+        "entity_type_roller_module": {
+            "options": {
+                "default": "Standaard (rolluik)",
+                "switch": "Schakelaar",
+                "light": "Lamp",
+                "disabled": "Uitgeschakeld (kanaal verbergen)"
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #297. Stacked on top of `claude/edit-channel-description-fix`.

The **entity_type** dropdown in *Customize a module → pick channel*
built its labels in Python via `_entity_type_label`, so the values
stayed English ("Default (switch)" / "Disabled (hide channel)" / …)
regardless of the user's locale.

Move the label construction into `translations/*.json` under a new
top-level `selector` block, one key per `module_type` so the
"Default (…)" suffix can still name the module's hardware-default
entity type:

```json
"selector": {
    "entity_type_switch_module": { "options": { "default": "Default (switch)", "light": "Light", "disabled": "Disabled (hide channel)" } },
    "entity_type_dimmer_module": { "options": { "default": "Default (light)", "disabled": "Disabled (hide channel)" } },
    "entity_type_roller_module": { "options": { "default": "Default (cover)", "switch": "Switch", "light": "Light", "disabled": "Disabled (hide channel)" } }
}
```

`config_flow.py` points the `SelectSelector` at
`translation_key=f"entity_type_{module_type}"` and passes plain
string options. HA resolves the labels from the loaded translations
at render time.

The `edit_channel` step description in fr/nl now quotes the
localized "Disabled" label (*Désactivé (masquer le canal)* /
*Uitgeschakeld (kanaal verbergen)*) so the prompt text and the
dropdown option match once the translation system kicks in.

## Dropdown labels per locale (after this PR)

| Module | en | fr | nl |
| --- | --- | --- | --- |
| `switch_module` | Default (switch) / Light / Disabled (hide channel) | Par défaut (interrupteur) / Lumière / Désactivé (masquer le canal) | Standaard (schakelaar) / Lamp / Uitgeschakeld (kanaal verbergen) |
| `dimmer_module` | Default (light) / Disabled (hide channel) | Par défaut (lumière) / Désactivé (masquer le canal) | Standaard (lamp) / Uitgeschakeld (kanaal verbergen) |
| `roller_module` | Default (cover) / Switch / Light / Disabled (hide channel) | Par défaut (volet) / Interrupteur / Lumière / Désactivé (masquer le canal) | Standaard (rolluik) / Schakelaar / Lamp / Uitgeschakeld (kanaal verbergen) |

## Code cleanup

- `config_flow.py`: drop `_entity_type_label` and the
  `_MODULE_DEFAULT_ENTITY_TYPE` helper dict. Neither is referenced
  from Python anymore — the mapping is documented in the
  translation files and enforced at runtime by
  `router._resolve_entity_type`.

## Test plan

- [ ] Switch HA's locale to French (or Dutch). Open **Configure →
      Customize a module → pick module → pick channel**. Confirm
      the entity-type dropdown renders localized labels.
- [ ] On a `dimmer_module`, confirm only "Default (light)" and
      "Disabled (hide channel)" (in the user's locale) appear —
      no spurious `switch` / `cover` options.
- [ ] Confirm the description text above the dropdown quotes the
      same localized "Disabled" string as the dropdown itself.
- [ ] Pick each label in each locale and submit; confirm the
      correct `entity_type` value is stored on the channel
      (`"default"` → absent, `"disabled"` → explicit, others
      verbatim).

## Dependency

Depends on #297 (branch `claude/edit-channel-description-fix`)
because it modifies the `edit_channel` description strings that PR
introduced into fr.json and nl.json. Merge #297 first, then merge
this.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_