### PR TITLE
scene: share the longest stop deadline across every roller in a scene

### DIFF
--- a/custom_components/nikobus/scene.py
+++ b/custom_components/nikobus/scene.py
@@ -153,9 +153,24 @@ class NikobusSceneEntity(NikobusEntity, Scene):
                     module_task["delay"] = max(module_task["delay"], op_time + 3.0)
 
         # 3. Commit updates to hardware
+        # All rollers in the scene share the same stop deadline: the
+        # longest per-channel ``op_time + 3 s`` across every impacted
+        # cover, regardless of which module it sits on. This gives each
+        # cover the most generous buffer the scene asks for, which
+        # absorbs bus contention when several modules are commanded
+        # back to back. The previous per-module max meant a cover with
+        # the longest op_time on a busy bus could see its stop fire
+        # before the motor reached the end-stop — manifesting as a
+        # cover that froze at e.g. 86 % when the same scene worked
+        # cleanly when triggered manually on an idle bus.
+        global_delay = max(
+            (info["delay"] for info in roller_tasks.values()),
+            default=0.0,
+        )
+
         for module_id, final_state in module_updates.items():
             await self._apply_module_state(module_id, final_state)
-            
+
             # 4. Schedule roller release if needed
             if module_id in roller_tasks:
                 task_info = roller_tasks[module_id]
@@ -163,7 +178,7 @@ class NikobusSceneEntity(NikobusEntity, Scene):
                 self._module_tokens[module_id] = token
                 task = self.hass.async_create_task(
                     self._delayed_roller_stop(
-                        module_id, final_state, task_info["indexes"], task_info["delay"], token
+                        module_id, final_state, task_info["indexes"], global_delay, token
                     )
                 )
                 self._roller_stop_tasks.append(task)


### PR DESCRIPTION
## Summary

Fixes the symptom where a Nikobus scene with multiple rollers
across multiple modules sometimes leaves one cover frozen short of
its end-stop (typical report: stops at ~86 % of a 37 s travel)
when the same scene works cleanly under manual activation.

### Root cause

`scene.async_activate` previously sized the scheduled roller stop
**per module**: each module commanded by the scene got its own
sleep, equal to `max(op_time + 3 s)` across the channels of *that
module only*. With:

```
ch4 / ch5 / ch6 of 8CF5 (open)  +  ch1 of 8B9C (open)
```

8CF5 was scheduled to stop at `max(ch4, ch5, ch6) + 3`, and 8B9C
independently at `ch1 + 3`. Both deadlines were measured from the
single scene-activation timestamp.

That works on an idle bus. On a contended bus (automation that
also drives LEDs / fires several scenes back-to-back / sits behind
the discovery command queue), the OPEN command for one module
lands a few seconds after activation. The schedule clock keeps
ticking from activation time, the 3-second buffer can't absorb
realistic contention, and the cover with the longest `op_time` on
the busiest module gets clipped — e.g. relay only runs 32 s before
the stop arrives, leaving a 37 s cover at ≈ 86 %.

### Fix

Compute the global max delay across every channel in the scene
once, after the input loop, and use that single deadline for every
module's stop task. The longest cover in the scene donates its
buffer to every other cover.

```python
global_delay = max(
    (info["delay"] for info in roller_tasks.values()),
    default=0.0,
)
# … then pass `global_delay` to every _delayed_roller_stop call.
```

Behaviour unchanged for single-roller scenes (per-module max and
global max are equal).

### Trade-off

A shorter cover sharing the scene with a longer one now sees its
relay held for a few extra seconds after physically reaching the
end-stop. Common Nikobus shutter hardware already tolerates this —
the previous per-channel `+ 3 s` already produces the same
behaviour for shorter siblings on the same module — and the trade
is favourable: a worst-case slightly longer end-stop dwell vs. a
worst-case mid-travel freeze.

## Test plan

- [ ] User-reported scene (`scene_open_kitchen_4_5_and_office_shutters`)
      activated from an automation. Confirm channel 4 of `8CF5`
      reaches 100 % instead of stopping at ~86 %.
- [ ] Single-roller scene: behaviour unchanged.
- [ ] Multi-roller scene from a manually-pressed scene entity:
      still works as before.
- [ ] Closing variant of the same scene (`state: "close"`):
      mirror behaviour with `operation_time_down`, no regressions.

## Follow-up worth considering (not in this PR)

The deeper issue is that the stop sleep is anchored to scene
activation, not to the moment the OPEN command actually finished
landing on the bus. Stamping the start *after*
`await self.coordinator.api.set_output_states_for_module(...)`
returns would absorb arbitrary contention and let us drop the
shared-max workaround. Worth a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_