### PR TITLE
Options flow: add module_type override in Customize-a-module step

### DIFF
--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -87,6 +87,48 @@ def _module_type_order(module_type: str | None) -> int:
     return _MODULE_TYPE_ORDER.get(module_type or "", 99)
 
 
+# User-overridable module classifications shown in the
+# Customize-a-module step. Mirrors the buckets the router
+# recognises (switch / dimmer / roller). ``other_module`` is
+# included so users with a misclassified non-output module
+# (PC Logic, Feedback, etc.) can park it there until library
+# discovery learns its real type.
+_OVERRIDABLE_MODULE_TYPES: tuple[str, ...] = (
+    "switch_module",
+    "dimmer_module",
+    "roller_module",
+    "other_module",
+)
+
+# Default channel count by module_type — matches the library's
+# inventory defaults (mapping.DEVICE_TYPES). Only used when the
+# user changes ``module_type`` and the existing ``channels`` list
+# is shorter than the new type's expected count: we extend it to
+# the right length with ``not_in_use`` placeholders so the router
+# can build the full set of entities for the new classification.
+# Existing channel entries are preserved verbatim — never
+# truncated, never overwritten.
+_DEFAULT_CHANNELS_BY_TYPE: dict[str, int] = {
+    "switch_module": 12,
+    "dimmer_module": 12,
+    "roller_module": 6,
+    "other_module": 0,
+}
+
+
+def _make_default_channel(module_type: str, index: int) -> dict[str, Any]:
+    """Build a placeholder channel entry for a freshly-padded slot.
+
+    Mirrors ``nikobus_connect.discovery.fileio._default_channel`` so a
+    re-discovery merge doesn't see drift between user-padded entries
+    and library-padded ones.
+    """
+    channel: dict[str, Any] = {"description": f"not_in_use output_{index}"}
+    if module_type == "roller_module":
+        channel["operation_time_up"] = "30"
+    return channel
+
+
 def _module_label(address: str, entry: dict[str, Any]) -> str:
     """Render a user-facing label for the module picker."""
     desc = entry.get("description") or f"Module {address}"
@@ -566,6 +608,36 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
             if new_desc:
                 entry["description"] = new_desc
 
+            # Persist a manual module_type override.
+            #
+            # Discovery normally owns ``module_type`` and re-merges it
+            # from the inventory's ``device_type`` byte every time the
+            # user runs *Discover modules & buttons*. That round-trip
+            # clobbers any UI override done here — by design today (see
+            # ``nikobus_connect.discovery.fileio.merge_module_inventory``
+            # at the line ``existing["module_type"] = module_type``). A
+            # follow-up library change will respect non-`other_module`
+            # values written by the integration; until that lands, this
+            # override survives until the next inventory run, which is
+            # enough to unblock users hitting a misreported device_type
+            # byte (e.g. dimmer self-reported as roller).
+            new_type = (user_input.get("module_type") or "").strip()
+            if new_type and new_type != entry.get("module_type"):
+                entry["module_type"] = new_type
+                expected = _DEFAULT_CHANNELS_BY_TYPE.get(new_type, 0)
+                channels_list = entry.get("channels")
+                if not isinstance(channels_list, list):
+                    channels_list = []
+                # Extend (never truncate) to the new type's default
+                # channel count. Preserves user-edited descriptions /
+                # entity_type / LED triggers / travel times on every
+                # existing slot.
+                while len(channels_list) < expected:
+                    channels_list.append(
+                        _make_default_channel(new_type, len(channels_list) + 1)
+                    )
+                entry["channels"] = channels_list
+
             selected = user_input.get("channel")
             await coordinator._async_on_module_save()
 
@@ -593,6 +665,10 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
         ]
         channel_options.append({"value": "done", "label": "Finish editing"})
 
+        current_type = entry.get("module_type") or "other_module"
+        if current_type not in _OVERRIDABLE_MODULE_TYPES:
+            current_type = "other_module"
+
         return self.async_show_form(
             step_id="edit_module",
             data_schema=vol.Schema({
@@ -600,6 +676,16 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
                     "description",
                     default=entry.get("description") or "",
                 ): TextSelector(TextSelectorConfig()),
+                vol.Required(
+                    "module_type",
+                    default=current_type,
+                ): SelectSelector(
+                    SelectSelectorConfig(
+                        options=list(_OVERRIDABLE_MODULE_TYPES),
+                        mode=SelectSelectorMode.DROPDOWN,
+                        translation_key="module_type",
+                    )
+                ),
                 vol.Required("channel", default="done"): SelectSelector(
                     SelectSelectorConfig(
                         options=channel_options,

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -189,9 +189,10 @@
             },
             "edit_module": {
                 "title": "Module {address} ({module_type})",
-                "description": "Model: {model}. Edit the module description or pick a channel to customize.",
+                "description": "Model: {model}. Edit the module description, override the module type if discovery misclassified it, or pick a channel to customize. Note: re-running *Discover modules & buttons* may overwrite a manual type override until the library learns to respect it.",
                 "data": {
                     "description": "Module description",
+                    "module_type": "Module type",
                     "channel": "Channel"
                 }
             },
@@ -222,6 +223,14 @@
         }
     },
     "selector": {
+        "module_type": {
+            "options": {
+                "switch_module": "Switch module",
+                "dimmer_module": "Dimmer module",
+                "roller_module": "Roller / shutter module",
+                "other_module": "Other (PC Logic / Feedback / unclassified)"
+            }
+        },
         "entity_type_switch_module": {
             "options": {
                 "default": "Default (switch)",

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -99,9 +99,10 @@
             },
             "edit_module": {
                 "title": "Module {address} ({module_type})",
-                "description": "Modèle : {model}. Modifiez la description du module ou choisissez un canal à personnaliser.",
+                "description": "Modèle : {model}. Modifiez la description du module, corrigez le type si la découverte s'est trompée, ou choisissez un canal à personnaliser. Note : relancer *Découvrir les modules et boutons* peut écraser un type forcé manuellement, jusqu'à ce que la bibliothèque apprenne à le respecter.",
                 "data": {
                     "description": "Description du module",
+                    "module_type": "Type de module",
                     "channel": "Canal"
                 }
             },
@@ -199,6 +200,14 @@
         }
     },
     "selector": {
+        "module_type": {
+            "options": {
+                "switch_module": "Module d'interrupteurs",
+                "dimmer_module": "Module variateur",
+                "roller_module": "Module volet / store",
+                "other_module": "Autre (PC Logic / Feedback / non classé)"
+            }
+        },
         "entity_type_switch_module": {
             "options": {
                 "default": "Par défaut (interrupteur)",

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -99,9 +99,10 @@
             },
             "edit_module": {
                 "title": "Module {address} ({module_type})",
-                "description": "Model: {model}. Bewerk de beschrijving van de module of kies een kanaal om aan te passen.",
+                "description": "Model: {model}. Bewerk de beschrijving, corrigeer het moduletype als de ontdekking het verkeerd heeft geclassificeerd, of kies een kanaal om aan te passen. Let op: opnieuw *Modules en knoppen ontdekken* uitvoeren kan een handmatig overschreven type weer wegschrijven totdat de bibliotheek dit respecteert.",
                 "data": {
                     "description": "Modulebeschrijving",
+                    "module_type": "Moduletype",
                     "channel": "Kanaal"
                 }
             },
@@ -199,6 +200,14 @@
         }
     },
     "selector": {
+        "module_type": {
+            "options": {
+                "switch_module": "Schakelmodule",
+                "dimmer_module": "Dimmermodule",
+                "roller_module": "Rolluik / zonweringsmodule",
+                "other_module": "Overig (PC Logic / Feedback / niet geclassificeerd)"
+            }
+        },
         "entity_type_switch_module": {
             "options": {
                 "default": "Standaard (schakelaar)",


### PR DESCRIPTION
## Summary

Adds a **Module type** dropdown to the *Customize a module* options
flow so users can correct a misclassified module without stopping HA
and editing `.storage/nikobus.modules` by hand.

### Why

Discovery occasionally writes the wrong `module_type` for a module —
typically because the inventory frame self-reports a `device_type`
byte that doesn't match the real hardware. Concrete user report:
[#301](https://github.com/fdebrus/Nikobus-HA/issues/301), where a
`05-007-02` dimmer landed in storage as `roller_module` and got
rendered as cover entities instead of lights.

`nikobus_connect.discovery.discovery._resolve_module_type` already
declares coordinator config authoritative *during* a scan, but the
matching merge step
(`nikobus_connect.discovery.fileio.merge_module_inventory`)
unconditionally overwrites `module_type` from the inventory on every
refresh — so any storage-side correction is undone the next time the
user runs *Discover modules & buttons*. That clobber is a follow-up
on the library side. This PR is the integration-side workaround so
affected users aren't blocked.

### What changes

- New required field `module_type` in `async_step_edit_module`.
  Allowed values: `switch_module`, `dimmer_module`, `roller_module`,
  `other_module` (catch-all for PC Logic / Feedback / unclassified
  hardware that doesn't back HA entities).
- On a type change, the entry's `channels` list is **extended (never
  truncated)** to the new type's default channel count
  (12 for switch / dimmer, 6 for roller). Padding uses `not_in_use`
  placeholders — same shape the library writes itself, so a future
  inventory merge sees consistent data.
- Existing channel descriptions, `entity_type` overrides, LED
  triggers, and travel times survive the type flip even if the new
  type's default count is smaller.
- Translation labels under `selector.module_type.options.*` in en /
  fr / nl. The step description picks up a one-line warning that
  re-running *Discover modules & buttons* may overwrite the override
  until the library learns to respect it.

### Doesn't change

- The library merge that does the clobber. Tracked separately.
- Routing logic. The new type takes effect on the next reload via
  the existing `router._resolve_entity_type` path.

## Test plan

- [ ] Open **Configure → Customize a module → pick module**. New
      *Module type* dropdown is present, defaults to the stored
      type. Picking a different type and pressing **Finish editing**
      reloads the integration and rebuilds entities according to the
      new type.
- [ ] Repro of #301: install with a dimmer stored as
      `roller_module`. Use the dropdown to switch to `dimmer_module`.
      Confirm: cover entities disappear; light entities appear; the
      `channels` list extends to 12 if it was 6 before.
- [ ] Switch the same module back to `roller_module`. Confirm:
      light entities disappear; 6 cover entities appear; the
      `channels` list keeps the extended length (no truncation),
      slots 7-12 carry forward as no-ops.
- [ ] Verify in en / fr / nl: dropdown labels render localized
      ("Dimmer module" / "Module variateur" / "Dimmermodule"). The
      step description mentions the re-discovery caveat.
- [ ] Run *Discover modules & buttons* after an override. Confirm
      the override is clobbered (current library behaviour, expected
      until the library fix lands). Override survives across HA
      restarts in the meantime.

## Related

- Issue: #301
- Follow-up library fix needed in
  `nikobus_connect.discovery.fileio.merge_module_inventory` to
  respect non-`other_module` `module_type` values written by the
  integration.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_