### PR TITLE
Include pc_logic in start_module_scan ALL queue + add diagnostics

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -1189,15 +1189,36 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             self._discovery_module_order = [target]
         else:
             target = "ALL"
-            # Count configured output modules for progress display.
+            # Build the list of addresses we expect the library to walk
+            # during the "ALL" scan, mirroring the library's own
+            # queue-builder filter (nikobus_connect/discovery/discovery.py
+            # ~line 1115). The library excludes pc_link / feedback_module
+            # / other_module; we use the same filter here so the progress
+            # total matches what the library actually scans.
+            #
+            # ``pc_logic`` is intentionally NOT excluded as of
+            # nikobus-connect 0.4.11 — the library now register-scans
+            # 05-201 modules with the PcLogicDecoder (currently a
+            # logging stub) so installs that route button → output via
+            # PC-Logic can capture the BP-cell data needed for the real
+            # decoder. If we excluded pc_logic here, the no-modules-known
+            # gate below could falsely reject scans on installs that
+            # have a PC-Logic but no other output modules.
             self._discovery_module_order = []
             for m_type, modules in self.dict_module_data.items():
-                if m_type in ("pc_link", "pc_logic", "feedback_module", "other_module"):
+                if m_type in ("pc_link", "feedback_module", "other_module"):
                     continue
                 if isinstance(modules, dict):
                     self._discovery_module_order.extend(
                         str(addr).upper() for addr in modules.keys()
                     )
+            _LOGGER.debug(
+                "start_module_scan ALL — dict_module_data buckets=%s, "
+                "queue=%s",
+                {k: list(v.keys()) if isinstance(v, dict) else v
+                 for k, v in self.dict_module_data.items()},
+                self._discovery_module_order,
+            )
             total = len(self._discovery_module_order)
             if total == 0:
                 raise HomeAssistantError(


### PR DESCRIPTION
## Summary

`start_module_scan(target="ALL")` was excluding `pc_logic` from the
address list it builds for progress / no-modules-known gating. That
was correct when both the library and the HA-side queues excluded
PC-Logic, but **nikobus-connect 0.4.11** changed the contract — the
library now register-scans `pc_logic` modules with the new
`PcLogicDecoder` (currently a logging stub, Stage 1 instrumentation;
see [`fdebrus/nikobus-connect#33`](https://github.com/fdebrus/nikobus-connect/pull/33))
and excludes only `("pc_link", "feedback_module", "other_module")`.

The stale HA-side filter has two real consequences on installs with
a 05-201 PC-Logic in storage:

- `modules_total` reported to the *Discovery Progress* sensor is one
  short of what the library actually walks. The progress bar can
  stall at *N − 1 / N*.
- On installs with **only** a PC-Logic and no output modules
  (`total == 0`), `start_module_scan` raises `no_modules_known` and
  the library never gets called. The PC-Logic register scan that
  would feed Stage 2 of the BP-cell decoder work (#308) can't even
  start.

This PR drops `pc_logic` from the HA-side exclusion so the queue
counted here matches what the library actually scans, and adds a
DEBUG log of `dict_module_data` (keys + per-bucket addresses) plus
the resulting queue right before the scan kicks off — so future
"missing pc_logic at scan time" regressions surface in user logs
(handy for #303 follow-up) instead of manifesting as a silent "0
PC-Logic chunk lines" symptom.

### Why the silent symptom wasn't reproducible from the data alone

I simulated the `_rebuild_dict_module_data` + library queue-builder
end-to-end on the user's exact `nikobus.modules` data:

```
storage = {
    'nikobus_module': {
        '940C': {'module_type': 'pc_logic', 'model': '05-201',
                 'channels': [], 'discovered_info': {...}},
        'B909': {'module_type': 'switch_module', 'model': '05-000-02',
                 'channels': [{}]*12},
    }
}

# After _rebuild_dict_module_data:
dict_module_data['pc_logic'] == {'940C': {..., 'address': '940C'}}

# After library 0.4.12 queue-build:
all_addresses == ['940C', 'B909']
```

So 940C *should* land in the library's `all_addresses`. The fact
that it doesn't on the user's install means either (a) the library
is older than 0.4.12 in their environment, (b) `dict_module_data`
isn't built when the scan starts, or (c) something we haven't seen
clears `pc_logic` from `dict_module_data` before
`query_module_inventory("ALL")` runs. The new DEBUG log will tell us
which.

## Test plan

- [ ] On the reporter's install, after pulling this branch, restart
      HA, press *Scan all module links*, and check the log for the
      new DEBUG line `start_module_scan ALL — dict_module_data
      buckets={...}, queue=[...]`. If `pc_logic: ['940C']` is in the
      buckets dict, the HA side has the data and the next thing to
      look at is the library version. If `pc_logic` is missing,
      `_rebuild_dict_module_data` isn't producing it for some
      reason on his install.
- [ ] Confirm the *Discovery Progress* sensor's percentage now
      tracks against the full module count (12 output + 1 PC-Logic
      = 13) instead of stalling at 12/12 partway through.
- [ ] On installs with no PC-Logic, behaviour is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_