### PR TITLE
Include pc_link in start_module_scan ALL queue (nikobus-connect 0.5.0)

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -1192,21 +1192,29 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             # Build the list of addresses we expect the library to walk
             # during the "ALL" scan, mirroring the library's own
             # queue-builder filter (nikobus_connect/discovery/discovery.py
-            # ~line 1115). The library excludes pc_link / feedback_module
-            # / other_module; we use the same filter here so the progress
+            # ~line 1115). The library excludes feedback_module /
+            # other_module; we use the same filter here so the progress
             # total matches what the library actually scans.
             #
             # ``pc_logic`` is intentionally NOT excluded as of
-            # nikobus-connect 0.4.11 — the library now register-scans
-            # 05-201 modules with the PcLogicDecoder (currently a
-            # logging stub) so installs that route button → output via
-            # PC-Logic can capture the BP-cell data needed for the real
-            # decoder. If we excluded pc_logic here, the no-modules-known
-            # gate below could falsely reject scans on installs that
-            # have a PC-Logic but no other output modules.
+            # nikobus-connect 0.4.11 — the library register-scans
+            # 05-201 modules with the PcLogicDecoder so installs that
+            # route button → output via PC-Logic can capture the
+            # BP-cell data needed for the real decoder.
+            #
+            # ``pc_link`` is intentionally NOT excluded as of
+            # nikobus-connect 0.5.0 — the library now register-scans
+            # 05-200 modules too, with PcLinkDecoder emitting
+            # structured "PC-Link module-registry record" and
+            # "PC-Link link record" INFO log lines. Stage 2a is
+            # visibility-only (decoder returns None — no merge yet),
+            # but the queue alignment must match either way so the
+            # progress total stays correct and the no-modules-known
+            # gate below doesn't falsely reject scans on installs
+            # that have only a PC-Link.
             self._discovery_module_order = []
             for m_type, modules in self.dict_module_data.items():
-                if m_type in ("pc_link", "feedback_module", "other_module"):
+                if m_type in ("feedback_module", "other_module"):
                     continue
                 if isinstance(modules, dict):
                     self._discovery_module_order.extend(

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect==0.4.12"
+    "nikobus-connect>=0.5.0"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }


### PR DESCRIPTION
## Summary

HA-side counterpart of [`nikobus-connect#34`](https://github.com/fdebrus/nikobus-connect/pull/34) (Stage 2a — PC Link register-scan inclusion, shipped in `nikobus-connect 0.5.0`).

### What 0.5.0 changes on the library side

- Adds **PC Link (05-200)** to the register-scan queue, mirroring what 0.4.11 did for PC Logic.
- `query_module_inventory("ALL")` no longer excludes `pc_link`; per-module path no longer routes pc_link through the non-output-module skip.
- Corrects the chunk stride for both `pc_logic` and `pc_link` from 12 hex chars (Stage-1 guess) to 32 hex chars (validated against a real Nikobus PC-software serial trace).
- Ships a real 16-byte record parser that emits structured INFO log lines per record:

  ```
  PC-Link module-registry record | module=86F5 device_type=0x03
      address=0E6C type_slot=1 raw=...
  PC-Link link record | module=86F5 channel_idx=0x04 mode=0x06
      flag=0x80 payload=B44318 slot=0x01 raw=...
  ```

  Same shape with the `PC-Logic` prefix for 05-201.

**Stage 2a is visibility-only.** The decoder returns `None` — no `DecodedCommand` is emitted, nothing merges into `linked_modules` yet. Stage 2b will add the merge once the byte-0 → `(target_module, channel)` mapping is validated against multiple installs.

### What this PR changes on the HA side

- Drops `pc_link` from the queue-exclusion set in `coordinator.start_module_scan`, mirroring what #311 did for `pc_logic`. The remaining excluded types are `feedback_module` and `other_module`, matching the library's filter.
- Bumps the manifest pin to `nikobus-connect>=0.5.0`.
- Comment block updated to note the 0.5.0 contract for `pc_link` alongside the existing 0.4.11 note for `pc_logic`.

The DEBUG log of `dict_module_data` at scan time (added by #311) already covers the diagnostic role for the new bucket; no further logging needed.

### Why it matters

Without this alignment, on installs with a PC Link in storage:

- `_discovery_module_order` is one short of what the library actually scans → the *Discovery Progress* sensor stalls at *N − 1 / N*.
- `no_modules_known` could falsely reject scans on installs that only have a PC Link (no output modules).

### Sanity sweep — no leftover overlap

Grepped `custom_components/nikobus/` for stray `pc_link` handling. All remaining references are about the **PC-Link inventory phase** (`start_pc_link_inventory`, `discovery_pc_link`, `_discovery_kind = "pc_link"`, `DISCOVERY_PHASE_PC_LINK`) — completely unrelated to the new register-scan path the library now owns. No HA-side decoder logic to remove.

## Test plan

- [ ] On an install with a PC Link (e.g. roswennen's via #303): bump the pin, restart HA, click **Scan all module links**. Verify the queue includes the PC Link's address (e.g. `86F5`) alongside the output modules. New DEBUG log confirms `dict_module_data["pc_link"]` is populated.
- [ ] Verify the HA log shows the new `PC-Link module-registry record | …` and `PC-Link link record | …` INFO lines.
- [ ] Verify discovery completes cleanly with the existing per-module scans still running for switch / dimmer / roller (no regression).
- [ ] On an install **without** a PC Link in storage: behaviour unchanged — `pc_link` only enters the queue when `dict_module_data["pc_link"]` is populated.

## Related

- Library PR: [`fdebrus/nikobus-connect#34`](https://github.com/fdebrus/nikobus-connect/pull/34)
- HA-side template: #311 (same shape, for `pc_logic`)
- Driving install: #303 (roswennen, 91 % unmatched-button-link rate)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_