### PR TITLE
Bump nikobus-connect pin to >=0.5.1

### DIFF
--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.5.0"
+    "nikobus-connect>=0.5.1"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }


### PR DESCRIPTION
## Summary

Pure dependency bump. `nikobus-connect 0.5.1` ([library PR #35](https://github.com/fdebrus/nikobus-connect/pull/35)) lands two fixes on top of 0.5.0 (Stage 2a — PC Link register-scan inclusion):

1. **PC-Link scan range tuned to its productive band.** 0.5.0 sweep `0x00..0xFF` tripped the consecutive-give-up early-stop on every install at register `0x04`, because the PC-Link doesn't respond to reads in `0x00..0x07`. 0.5.1 narrows the override to `range(0xA3, 0x100)` — the productive band identified by a Nikobus PC-software serial trace.
2. **PC-Logic decoder rejects near-empty link records.** Chunks like `FFFFFFFFFFFFFFFFFFFFFFFFFFFF05FF` (all-FF except a stray byte the parser doesn't even extract) used to surface as phantom "PC-Logic link record" log lines. 0.5.1 tightens `_parse_link_record` to drop chunks where every extracted field is `0xFF`.

## What HA users see after this lands

- Next *Scan all module links* run on a PC-Link install will actually produce records via the structured INFO logs added in 0.5.0:
  ```
  PC-Link module-registry record | module=86F5 device_type=...
      address=... type_slot=... raw=...
  PC-Link link record | module=86F5 channel_idx=0x.. mode=0x..
      flag=0x.. payload=... slot=0x.. raw=...
  ```
- PC-Logic scans no longer emit phantom `link record | … channel_idx=0xFF mode=0xFF flag=0xFF payload=FFFFFF slot=0xFF` lines on installs with bus noise.
- `linked_modules` behaviour is **unchanged** — Stage 2a is still visibility-only. Stage 2b will wire records into the merge layer once the byte-0 → `(target_module, channel)` mapping is validated across multiple installs (now collectable thanks to the maintainer's install actually producing real PC-Link bytes).

## Why no HA-side code changes

The queue-filter alignment that includes `pc_link` in `start_module_scan`'s ALL queue is already in place from #312 (the equivalent of #311 for `pc_logic`). The maintainer's live log confirms both controllers are queued:

```
queue=['C9A5','5B05','4707','0E6C','9105','8394','86F5','940C']
```

Sanity sweep of `custom_components/nikobus` for stray `0.5.0` references: only one match outside the manifest pin — a historical comment in `coordinator.py:1206` noting when the `pc_link` inclusion landed, which stays accurate.

## Test plan

- [ ] Bump pin (this PR), restart HA, click **Scan all module links** on the Nikobus Bridge device.
- [ ] Verify the HA log shows `PC-Link module-registry record | …` **and** `PC-Link link record | …` INFO lines — proves library fix #1 is wired through.
- [ ] Verify **no** `PC-Logic link record | module=… channel_idx=0xFF mode=0xFF flag=0xFF payload=FFFFFF slot=0xFF` lines anymore — proves library fix #2 is wired through.
- [ ] Verify discovery completes cleanly with the existing per-module scans (switch / dimmer / roller) producing decoded records as before — no regression.

## Related

- Library PR: [`fdebrus/nikobus-connect#35`](https://github.com/fdebrus/nikobus-connect/pull/35) — tune PC-Link scan range, reject near-empty link records (0.5.1).
- Library PR: [`fdebrus/nikobus-connect#34`](https://github.com/fdebrus/nikobus-connect/pull/34) — PC-Link decoder + 16-byte record parser (Stage 2a, 0.5.0). The work this 0.5.1 patches.
- HA-side: #312 (pc_link queue inclusion, already merged).
- Driving install: #303 (roswennen, 91 % unmatched-button-link rate). Stage 2 target.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_