### PR TITLE
Add issue templates (bug, discovery, feature)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,156 @@
+name: Bug report
+description: Something is broken or behaves unexpectedly in the integration.
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. To keep things efficient, please fill in **every required field** below — most of them point you at exactly where to find the value.
+
+        For setup help / "how do I…" / general questions, post on the [HA community thread](https://community.home-assistant.io/t/custom-component-nikobus/732832) instead.
+
+  - type: checkboxes
+    id: prereqs
+    attributes:
+      label: Before opening
+      options:
+        - label: I have searched [existing issues](https://github.com/fdebrus/Nikobus-HA/issues?q=is%3Aissue) and didn't find a duplicate.
+          required: true
+        - label: I have read the [README](https://github.com/fdebrus/Nikobus-HA#readme).
+          required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What's broken
+      description: One or two sentences describing the bug from the user's perspective.
+      placeholder: e.g. "Pressing the wall button no longer toggles the light in HA — but it did before the 2.0 upgrade."
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps from a freshly-restarted HA, including which buttons / services / automations you triggered.
+      placeholder: |
+        1. Settings → Devices & Services → Nikobus → Configure → Discover modules & buttons
+        2. Wait for completion
+        3. Press wall button at address 3AC4A9
+        4. Observe …
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_actual
+    attributes:
+      label: Expected vs actual behaviour
+      placeholder: |
+        Expected: light.living_room turns on when button 3AC4A9 is pressed.
+        Actual: nothing happens; light state stays off until the next polling cycle (~2 min later).
+    validations:
+      required: true
+
+  - type: input
+    id: integration_version
+    attributes:
+      label: Nikobus integration version
+      description: From `Settings → Devices & Services → Nikobus → ⋮ → Information`, or `manifest.json` (`"version"` field).
+      placeholder: "2.0.2"
+    validations:
+      required: true
+
+  - type: input
+    id: library_version
+    attributes:
+      label: nikobus-connect library version
+      description: From `Settings → System → Logs` at HA startup (look for `nikobus_connect …`), or run `pip show nikobus-connect` inside your HA Python env. The pin in `manifest.json` is what was *requested* — the actual installed version may differ on dev installs.
+      placeholder: "0.5.1"
+    validations:
+      required: true
+
+  - type: input
+    id: ha_version
+    attributes:
+      label: Home Assistant Core version
+      description: From `Settings → About`.
+      placeholder: "2026.4.5"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: ha_install
+    attributes:
+      label: HA installation type
+      options:
+        - Home Assistant OS (HAOS)
+        - Home Assistant Supervised
+        - Home Assistant Container (Docker)
+        - Home Assistant Core (manual install)
+        - Other / unsure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: connection
+    attributes:
+      label: How HA connects to the PC-Link
+      options:
+        - USB / serial adapter (e.g. `/dev/ttyUSB0`, `COM3`)
+        - TCP bridge (e.g. `192.168.1.50:9999`)
+    validations:
+      required: true
+
+  - type: textarea
+    id: hardware
+    attributes:
+      label: Hardware mix on the bus
+      description: |
+        List the Niko module models in your install (one per line). At minimum, list anything other than standard switch / dimmer / roller modules — feedback module, PC-Link, PC-Logic, modular interface (05-206), pushbutton/switch interface (05-056 / 05-057 / 05-058), audio link (05-205), RF transmitters, etc. The more specific, the easier it is to spot hardware-specific bugs.
+      placeholder: |
+        2× 05-000-02 (Switch module, 12-ch)
+        1× 05-007-02 (Dimmer)
+        4× 05-001-02 (Roller / shutter)
+        1× 05-200 (PC-Link)
+        1× 05-201 (PC-Logic)
+        1× 05-205 (Audio Distribution)
+        Wall buttons: ~10× 05-346, 2× 05-348 (IR), 1× 05-349 (8-OP)
+
+  - type: textarea
+    id: log
+    attributes:
+      label: Debug log
+      description: |
+        Enable debug logging for the integration (see below), restart HA, reproduce the bug, then paste the relevant log section here.
+
+        ```yaml
+        # configuration.yaml
+        logger:
+          default: warning
+          logs:
+            custom_components.nikobus: debug
+            nikobus_connect: debug
+            nikobus_connect.discovery: debug
+        ```
+
+        For a long log, attach the file instead of pasting (drag-and-drop the `.log` file into this comment box).
+      render: text
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: diagnostics_attached
+    attributes:
+      label: Diagnostics download
+      description: |
+        Attach the **Download Diagnostics** file from `Settings → Devices & Services → Nikobus → ⋮ → Download Diagnostics`. It bundles the integration's storage state, redacted; no credentials.
+      options:
+        - label: I have attached the diagnostics download to this issue.
+          required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Anything else worth knowing — what changed recently, what you've already tried, links to forum threads, screenshots, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Home Assistant community thread
+    url: https://community.home-assistant.io/t/custom-component-nikobus/732832
+    about: For general questions, setup help, "how do I…", and exchanging tips with other users — please post on the community thread first. The GitHub issue tracker is for bug reports and feature requests against the integration code.
+  - name: Nikobus integration documentation
+    url: https://github.com/fdebrus/Nikobus-HA#readme
+    about: Setup guide, supported modules, discovery walkthrough, troubleshooting tips. Worth a re-read before opening an issue.

--- a/.github/ISSUE_TEMPLATE/discovery_issue.yml
+++ b/.github/ISSUE_TEMPLATE/discovery_issue.yml
@@ -1,0 +1,150 @@
+name: Discovery / scan issue
+description: A button isn't found, a module is misclassified, linked_modules is empty, or "Scan all module links" produces wrong results.
+labels:
+  - discovery
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template when something is wrong with **discovery output** — buttons not appearing, modules ending up as covers when they should be lights, `linked_modules` empty, "unknown device detected" warnings in the log, etc.
+
+        Discovery issues are the hardest to debug remotely. The required attachments below are the bare minimum needed to reproduce on the maintainer's side; please don't skip them.
+
+  - type: checkboxes
+    id: prereqs
+    attributes:
+      label: Before opening
+      options:
+        - label: I have searched [existing issues](https://github.com/fdebrus/Nikobus-HA/issues?q=is%3Aissue) and didn't find a duplicate.
+          required: true
+        - label: I have run **Discover modules & buttons** (PC Link inventory) **and** **Scan all module links**, in that order, on the Nikobus Bridge device.
+          required: true
+
+  - type: textarea
+    id: symptom
+    attributes:
+      label: What's missing or wrong
+      description: |
+        Describe what you expected to see vs what discovery actually produced. Include specific bus addresses where possible — both the user-facing one (e.g. "BP9: Bed rechts") and the inventory address from your Niko PC software (e.g. `3AC4A9`) if you have access to it.
+      placeholder: |
+        BP9 (3AC4A9, bedroom door right) is in the device list after PC Link inventory, but its `linked_outputs` attribute is empty even though the button physically controls light L1 on module 9105 channel 4.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: symptom_class
+    attributes:
+      label: Symptom category (tick all that apply)
+      options:
+        - label: Button device exists in HA but `linked_outputs` is empty.
+        - label: Button device doesn't exist in HA at all (PC Link inventory missed it).
+        - label: Module misclassified (e.g. dimmer rendered as cover entities, or vice versa).
+        - label: '"Unknown device detected: Type 0x__ at Address ______" warnings in the log.'
+        - label: Scan terminates earlier than expected.
+        - label: Scan completes but no records / very few records found across all modules.
+        - label: Other (describe in "What's missing or wrong" above).
+
+  - type: input
+    id: integration_version
+    attributes:
+      label: Nikobus integration version
+      placeholder: "2.0.2"
+    validations:
+      required: true
+
+  - type: input
+    id: library_version
+    attributes:
+      label: nikobus-connect library version
+      description: From `Settings → System → Logs` at HA startup, or `pip show nikobus-connect`. Discovery behaviour changes meaningfully between library versions; please be precise.
+      placeholder: "0.5.1"
+    validations:
+      required: true
+
+  - type: input
+    id: ha_version
+    attributes:
+      label: Home Assistant Core version
+      placeholder: "2026.4.5"
+    validations:
+      required: true
+
+  - type: textarea
+    id: hardware
+    attributes:
+      label: Hardware mix on the bus
+      description: |
+        List every Niko module model in your install (one per line). Discovery issues often correlate with specific hardware variants the library doesn't yet recognise — the more specific the list, the faster we can map it.
+      placeholder: |
+        2× 05-000-02 (Switch module, 12-ch)
+        1× 05-007-02 (Dimmer)
+        4× 05-001-02 (Roller / shutter)
+        1× 05-200 (PC-Link)
+        1× 05-201 (PC-Logic) — used as central routing
+        Wall buttons: ~10× 05-346, 2× 05-348 (IR), 1× 05-349 (8-OP)
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: storage_attached
+    attributes:
+      label: Storage files attached
+      description: |
+        Attach **both** files. They live in `<config>/.storage/` (HA's storage directory). Safe to share — addresses only, no credentials.
+      options:
+        - label: I have attached `.storage/nikobus.modules` to this issue.
+          required: true
+        - label: I have attached `.storage/nikobus.buttons` to this issue.
+          required: true
+
+  - type: checkboxes
+    id: log_attached
+    attributes:
+      label: Debug log of "Scan all module links" attached
+      description: |
+        Required. Enable debug logging, restart HA, click **Scan all module links** on the Nikobus Bridge device, wait for it to fully complete (several minutes for ~12 modules), then save the log file and attach it to this issue. The library's debug output is the only way to root-cause register-level issues.
+
+        ```yaml
+        # configuration.yaml
+        logger:
+          default: warning
+          logs:
+            custom_components.nikobus: debug
+            nikobus_connect: debug
+            nikobus_connect.discovery: debug
+        ```
+      options:
+        - label: I have attached the debug log of a fresh `Scan all module links` run.
+          required: true
+
+  - type: checkboxes
+    id: diagnostics_attached
+    attributes:
+      label: Diagnostics download
+      description: From `Settings → Devices & Services → Nikobus → ⋮ → Download Diagnostics`.
+      options:
+        - label: I have attached the diagnostics download.
+          required: true
+
+  - type: textarea
+    id: pc_software
+    attributes:
+      label: Niko PC-software cross-reference (highly recommended)
+      description: |
+        If you have access to your install's `.nbc` config file from the Niko PC-software, **attaching its export is enormously useful** — it's the ground truth that lets us verify what discovery should have produced.
+
+        Alternatively, screenshots of:
+        - The PC-software's address-list / device-inventory view (one row per device with model + address).
+        - The connection list / programming view for any specific BP, button, or module mentioned in "What's missing or wrong" above.
+
+        Without this, we're often guessing at what your install actually contains.
+      placeholder: |
+        Attached: Beukenbos20150822.nkb.json (Niko PC-software config export).
+        Screenshots: address-list view, BP9 connection grid showing it controls module 9105 ch4.
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Recent changes (added new hardware? upgraded library?), what you've already tried, links to forum threads, etc.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,46 @@
+name: Feature request
+description: Suggest a new capability or enhancement to the integration.
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Please describe what you'd like to do and why — the "why" is often more important than the "what" because it lets us find the simplest design that solves the actual need.
+
+  - type: checkboxes
+    id: prereqs
+    attributes:
+      label: Before opening
+      options:
+        - label: I have searched [existing issues](https://github.com/fdebrus/Nikobus-HA/issues?q=is%3Aissue) (open and closed) and didn't find this proposal.
+          required: true
+
+  - type: textarea
+    id: feature
+    attributes:
+      label: What you'd like to do
+      description: One or two sentences on the feature itself.
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Why — the underlying need
+      description: |
+        What are you trying to accomplish in your home? Concrete scenarios help; "I want to be able to do X so that Y happens" is much easier to design for than "the integration should support Z".
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you've considered
+      description: Workarounds you've tried, or other integrations / scripts that solve part of the problem today.
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Hardware specifics, screenshots, links to forum discussions, etc.


### PR DESCRIPTION
## Summary

Adds three GitHub issue forms plus a config that steers general questions to the HA community thread. Driven by the recent debugging cycles (#301, #303) where the same "what version are you on / paste your storage file / paste a debug log" round-trips happened on every issue before any actual diagnosis could begin.

### Files

```
.github/ISSUE_TEMPLATE/
├── config.yml             ← disables blank issues + adds contact links
├── bug_report.yml         ← general bug report
├── discovery_issue.yml    ← hot category: scan / discovery / linking issues
└── feature_request.yml    ← minimal feature request form
```

### `bug_report.yml` — required fields

- Integration version (where to find: Settings → Devices & Services → Nikobus → ⋮ → Information).
- **`nikobus-connect` library version** (where to find: HA startup log, or `pip show nikobus-connect`). The pin in `manifest.json` is what was *requested* — the actual installed version may differ on dev installs, so we ask for the live one.
- Home Assistant Core version.
- HA install type (HAOS / Supervised / Container / Core).
- Connection type (USB serial / TCP bridge).
- Reproduction steps + expected vs actual behaviour.
- Debug log (with the YAML logger snippet inline so users don't have to look it up).
- Diagnostics download attachment confirmation.

### `discovery_issue.yml` — the hot category from #301 / #303

- All of the above versions, plus a free-form **hardware mix** field (the long tail of unknown `device_type` bytes correlates strongly with hardware variants the library doesn't yet recognise — the more specific the list, the faster we map it).
- **Symptom checkboxes** for the recurring patterns: empty `linked_outputs`, missing button device, misclassified module, "Unknown device detected" warnings, scan terminates early, etc.
- **Required attachments**: `.storage/nikobus.modules`, `.storage/nikobus.buttons`, full debug log of a fresh *Scan all module links* run, diagnostics download.
- **Strongly encourages** a Niko PC-software config export (`.nbc.json`) or screenshots — these have been the single biggest unblocker on every recent discovery issue.

### `feature_request.yml`

Minimal — what / why / alternatives.

### `config.yml`

- `blank_issues_enabled: false` — forces template usage.
- Two contact links: HA community thread (for general "how do I…" questions) and the README (for setup help).

## Why

Across recent issues (#301 dimmer-as-cover, #303 91 %-empty `linked_modules`), the first 1–2 round-trips on every issue were just collecting baseline data. Each ticket cost a multi-day delay because the user had to find the storage files, enable debug logging, re-run a scan, and attach everything. Templates encode that as a one-shot ask up-front.

## Test plan

- [ ] After merge, *Issues → New Issue* shows three template choices (Bug / Discovery / Feature) plus the two contact links instead of a blank textarea.
- [ ] Picking *Discovery / scan issue* renders the form fields, the required-attachment checkboxes, and the inline logger config snippet.
- [ ] Picking *Bug report* shows the version + install fields with the in-form instructions for where to find each.
- [ ] All four YAML files validate against the GitHub schema (the form preview at `https://github.com/fdebrus/Nikobus-HA/issues/new/choose` renders cleanly).
- [ ] No regression on existing issues (templates only affect the *new issue* flow).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_