### PR TITLE
Stop dual reload after PC Link inventory + drop scan triggers from options flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ All module and button data lives in Home Assistant's own storage (`.storage/niko
 
 ### 1. Discover modules and buttons
 
-Open the **Nikobus Bridge** device page and press **Discover modules & buttons** (or trigger the same from **Configure → Discover modules & buttons (PC Link inventory)**). This walks the PC Link registry, identifies every module (switch / dimmer / shutter / feedback / PC-logic), and creates every physical wall button found on the bus as its own HA device.
+Open the **Nikobus Bridge** device page and press **Discover modules & buttons**. This walks the PC Link registry, identifies every module (switch / dimmer / shutter / feedback / PC-logic), and creates every physical wall button found on the bus as its own HA device.
 
 A large install takes several minutes end-to-end — the per-register ACK timeout in the library is 1.5 s, so slow modules stretch the scan. Two diagnostic sensors on the Bridge device track progress:
 
@@ -277,9 +277,9 @@ Changes persist in `.storage/nikobus.modules` and survive re-discovery.
 
 ### 3. Scan module links
 
-Press **Scan all module links** on the Bridge device (or **Configure → Scan all modules for button links**). This walks every output module and records which button addresses drive which channels, populating the `linked_modules` metadata on each button entity.
+Press **Scan all module links** on the Bridge device. This walks every output module and records which button addresses drive which channels, populating the `linked_modules` metadata on each button entity.
 
-The button is greyed out until a PC Link inventory has run — scanning links against zero known modules does nothing. Likewise the options-flow item aborts with a "Run a PC-Link inventory first" message.
+The button is greyed out until a PC Link inventory has run — scanning links against zero known modules does nothing.
 
 ### Repair issues
 

--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import re
 from typing import Any
@@ -367,12 +366,20 @@ class NikobusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 # ---------------------------------------------------------------------------
 
 class NikobusOptionsFlow(config_entries.OptionsFlow):
-    """Change hardware/polling settings and trigger discovery with live progress."""
+    """Change hardware/polling settings and customize discovered modules.
+
+    Discovery itself (PC-Link inventory + module-link scan) is no
+    longer reachable from this options flow; both actions live on the
+    Nikobus Bridge device's button entities (`Discover modules &
+    buttons` and `Scan all module links`). Routing scans through the
+    options flow on top of the device buttons gave users two
+    different entry points for the same operation, and the flow's
+    progress-dialog → terminal-step plumbing was where the
+    "Invalid flow specified" failure mode kept resurfacing.
+    """
 
     def __init__(self) -> None:
         self._options: dict[str, Any] = {}
-        self._discovery_task: asyncio.Task[None] | None = None
-        self._discovery_kind: str | None = None  # "pc_link" or "module_scan"
         self._edit_module_address: str | None = None
         self._edit_channel_index: int | None = None
 
@@ -388,14 +395,19 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.FlowResult:
-        """Entry point — let the user pick what to do."""
+        """Entry point — let the user pick what to do.
+
+        Discovery actions (PC-Link inventory, full module scan) live
+        on the Nikobus Bridge device's button entities, not in this
+        menu. Keeping a single entry point avoids the "two ways to do
+        the same thing" UX and the progress-flow flakiness that
+        accompanied the options-flow path.
+        """
         return self.async_show_menu(
             step_id="init",
             menu_options=[
                 "hardware",
                 "configure_modules",
-                "discovery_pc_link",
-                "discovery_modules",
             ],
         )
 
@@ -426,124 +438,6 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
             step_id="polling",
             data_schema=_polling_schema(self._current()),
         )
-
-    # --- Discovery: PC Link inventory --------------------------------------
-
-    async def async_step_discovery_pc_link(
-        self, user_input: dict[str, Any] | None = None
-    ) -> config_entries.FlowResult:
-        """Kick off a PC Link inventory scan and show live progress."""
-        coordinator = self._coordinator()
-        if coordinator is None:
-            return self.async_abort(reason="not_loaded")
-
-        if self._discovery_task is None:
-            self._discovery_kind = "pc_link"
-            # auto_reload=True: let the coordinator schedule its own
-            # background reload when discovery finishes. The options flow
-            # terminates with async_abort (no update-listener round-trip),
-            # so we can't rely on the listener to kick off a reload here.
-            self._discovery_task = self.hass.async_create_task(
-                coordinator.start_pc_link_inventory(auto_reload=True)
-            )
-
-        return await self._progress_step("discovery_pc_link")
-
-    # --- Discovery: full module scan ---------------------------------------
-
-    async def async_step_discovery_modules(
-        self, user_input: dict[str, Any] | None = None
-    ) -> config_entries.FlowResult:
-        """Kick off a full module-scan discovery and show live progress."""
-        coordinator = self._coordinator()
-        if coordinator is None:
-            return self.async_abort(reason="not_loaded")
-
-        # Gate: the module scan walks the list of known output modules.
-        # Without a prior PC Link inventory (or a legacy-file migration)
-        # that list is empty and the scan has nothing to do. Steer the
-        # user to run the inventory first instead of silently finishing
-        # with zero records.
-        if self._discovery_task is None and not coordinator.has_known_output_modules:
-            return self.async_abort(reason="no_modules")
-
-        if self._discovery_task is None:
-            self._discovery_kind = "module_scan"
-            # auto_reload=True: same rationale as the PC Link step above
-            # — the coordinator handles reload asynchronously once
-            # discovery finishes; the flow terminates via async_abort.
-            self._discovery_task = self.hass.async_create_task(
-                coordinator.start_module_scan(auto_reload=True)
-            )
-
-        return await self._progress_step("discovery_modules")
-
-    async def _progress_step(
-        self, step_id: str
-    ) -> config_entries.FlowResult:
-        """Show a progress spinner until the discovery task completes.
-
-        Passes the real discovery task itself as ``progress_task`` so
-        HA re-runs this step exactly once — when the task finishes —
-        and we transition to the terminal step. No intermediate
-        re-renders while the scan is running.
-
-        The earlier implementation created a fresh 1-second
-        ``asyncio.sleep`` task as ``progress_task`` on every call to
-        refresh the dialog text mid-scan. On long scans that piled
-        up hundreds of short-lived tasks and a handful of race
-        windows: a poll task could fire after we'd already returned
-        ``PROGRESS_DONE``, HA would re-enter a flow whose state had
-        moved on, and the frontend rendered "Invalid flow specified"
-        even when nothing crashed server-side. See the prior attempts
-        in #288 (fire-and-forget reload) and #294 (abort instead of
-        create_entry) — both were real fixes but missed this layer.
-
-        The trade-off is that the progress-dialog description is
-        static for the duration of the scan. Live per-register detail
-        is surfaced via the **Discovery Status** and **Discovery
-        Progress** sensors on the Nikobus Bridge device, which are
-        what the user should watch during a long scan.
-        """
-        coordinator = self._coordinator()
-        task = self._discovery_task
-
-        if task is None:
-            # The caller always creates the task before we get here; treat
-            # a missing task as an error rather than spinning forever.
-            _LOGGER.error("Discovery progress step reached without a task")
-            return self.async_show_progress_done(next_step_id="discovery_error")
-
-        if task.done():
-            self._discovery_task = None
-            try:
-                task.result()
-            except Exception as err:
-                _LOGGER.error("Discovery failed: %s", err)
-                return self.async_show_progress_done(next_step_id="discovery_error")
-            return self.async_show_progress_done(next_step_id="discovery_done")
-
-        raw_message = (
-            coordinator.discovery_status_message
-            if coordinator
-            else "Discovery in progress…"
-        )
-        percent = coordinator.discovery_progress_percent if coordinator else 0
-        display = raw_message or "Starting…"
-
-        kwargs: dict[str, Any] = {
-            "step_id": step_id,
-            "progress_action": "discovery",
-            "description_placeholders": {
-                "message": display,
-                "percent": str(percent),
-            },
-        }
-        try:
-            return self.async_show_progress(progress_task=task, **kwargs)
-        except TypeError:
-            # Older HA without progress_task support — fall back to plain call.
-            return self.async_show_progress(**kwargs)
 
     # --- Module customization ----------------------------------------------
 
@@ -828,42 +722,3 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
             errors=errors,
         )
 
-    async def async_step_discovery_done(
-        self, user_input: dict[str, Any] | None = None
-    ) -> config_entries.FlowResult:
-        """Finalize the flow after a successful discovery.
-
-        Abort with the ``discovery_done`` reason so HA closes the flow
-        via a plain terminal response — no options persistence, no
-        update listener invocation, no awaiting of the reload.
-
-        Entity refresh is delegated to the coordinator:
-        ``_handle_discovery_finished`` schedules the config-entry reload
-        via ``hass.async_create_task`` (see ``coordinator.py``), so it
-        runs independently of the flow lifecycle. This keeps the
-        flow-close HTTP response fast enough for the frontend to render
-        the success dialog instead of falling back to its generic
-        "Invalid flow specified" error.
-
-        (The previous ``async_create_entry`` version kept the flow
-        dependent on the options update listener, which — even after
-        it was made fire-and-forget in #288 — was still entangled with
-        the ``async_show_progress_done → next_step → create_entry``
-        hand-off on the flow-manager side.)
-        """
-        return self.async_abort(reason="discovery_done")
-
-    async def async_step_discovery_error(
-        self, user_input: dict[str, Any] | None = None
-    ) -> config_entries.FlowResult:
-        """Close the flow after a failed discovery, surfacing the error."""
-        coordinator = self._coordinator()
-        err = (
-            coordinator.discovery_last_error
-            if coordinator
-            else "Unknown error"
-        ) or "Unknown error"
-        return self.async_abort(
-            reason="discovery_error",
-            description_placeholders={"error": err},
-        )

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -518,8 +518,23 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         return len(message) < 9 or message[7:9].upper() == "FF"
 
     async def _abort_discovery_early(self) -> None:
-        """Stop the PC-Link inventory scan ahead of schedule."""
-        # Drain remaining discovery commands so they are not sent on the bus.
+        """Stop the PC-Link inventory scan ahead of schedule.
+
+        Drains the remaining queued discovery commands so they aren't
+        sent on the bus, and updates the UI to surface the early-stop
+        state. Does **not** call ``_handle_discovery_finished`` here —
+        the library's deferred ``_finalize_inventory_phase`` is
+        already scheduled and will fire its ``on_discovery_finished``
+        callback (wired to ``_handle_discovery_finished`` in
+        ``connect()``) once its inventory-timeout elapses (~10 s
+        after the last frame). That single completion path drives
+        the reload.
+
+        Calling ``_handle_discovery_finished`` here as well caused
+        a dual-reload cycle on every inventory click: an immediate
+        reload from the early-stop, followed ~10 s later by a
+        second reload when the deferred finalize fired post-reload.
+        """
         if self.nikobus_command and hasattr(self.nikobus_command, "_command_queue"):
             drained = 0
             while not self.nikobus_command._command_queue.empty():
@@ -530,7 +545,13 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                     break
             if drained:
                 _LOGGER.debug("Drained %d queued discovery commands", drained)
-        await self._handle_discovery_finished()
+        # Surface the transitional state in the UI so the small gap
+        # before the library's deferred finalize fires doesn't look
+        # like the integration is stuck.
+        self._update_discovery_state(
+            phase=DISCOVERY_PHASE_PC_LINK,
+            message="PC Link inventory: stopping early; finalising…",
+        )
 
     # ------------------------------------------------------------------
     # Data update

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -126,28 +126,14 @@
     },
     "options": {
         "abort": {
-            "discovery_done": "Discovery finished. The integration is reloading and the newly-discovered entities will appear shortly.",
-            "discovery_error": "Discovery failed: {error}",
             "not_loaded": "The Nikobus integration is not loaded. Please reload the integration and try again.",
-            "no_modules": "No Nikobus modules are configured yet. Run a PC-Link inventory discovery first.",
             "module_not_found": "The selected module was not found in storage.",
             "channel_not_found": "The selected channel was not found."
         },
         "error": {
             "invalid_hex_address": "LED address must be exactly 6 hexadecimal characters (or empty)."
         },
-        "progress": {
-            "discovery": "{message}"
-        },
         "step": {
-            "discovery_modules": {
-                "description": "Scanning each output module for button links.\n\n**Progress:** {percent}%\n\n{message}",
-                "title": "Module Scan"
-            },
-            "discovery_pc_link": {
-                "description": "Scanning the PC Link registry for modules and buttons.\n\n**Progress:** {percent}%\n\n{message}",
-                "title": "PC Link Inventory"
-            },
             "hardware": {
                 "data": {
                     "has_feedbackmodule": "Feedback Module (05-207) installed and connected via PC-Link",
@@ -164,8 +150,6 @@
                 "description": "What would you like to do?",
                 "menu_options": {
                     "configure_modules": "Customize a module (description, entity type, LED triggers, travel time)",
-                    "discovery_modules": "Scan all modules for button links",
-                    "discovery_pc_link": "Discover modules & buttons (PC Link inventory)",
                     "hardware": "Change hardware settings"
                 },
                 "title": "Nikobus"

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -59,9 +59,7 @@
                 "description": "Que souhaitez-vous faire ?",
                 "menu_options": {
                     "hardware": "Modifier la configuration matérielle",
-                    "configure_modules": "Personnaliser un module (description, type d'entité, déclencheurs LED, temps de course)",
-                    "discovery_pc_link": "Découvrir les modules et boutons (inventaire PC Link)",
-                    "discovery_modules": "Scanner tous les modules pour les liens de boutons"
+                    "configure_modules": "Personnaliser un module (description, type d'entité, déclencheurs LED, temps de course)"
                 }
             },
             "hardware": {
@@ -85,10 +83,6 @@
                 "data_description": {
                     "refresh_interval": "Fréquence de lecture des états des modules (60–3600 s)."
                 }
-            },
-            "discovery_pc_link": {
-                "title": "Inventaire PC Link",
-                "description": "Analyse du registre PC Link pour trouver les modules et boutons.\n\n**Progression :** {percent}%\n\n{message}"
             },
             "configure_modules": {
                 "title": "Personnaliser un module Nikobus",
@@ -117,20 +111,10 @@
                     "operation_time_up": "Temps de course à l'ouverture (secondes)",
                     "operation_time_down": "Temps de course à la fermeture (secondes)"
                 }
-            },
-            "discovery_modules": {
-                "title": "Scan des modules",
-                "description": "Analyse de chaque module de sortie pour récupérer les liens de boutons.\n\n**Progression :** {percent}%\n\n{message}"
             }
         },
-        "progress": {
-            "discovery": "{message}"
-        },
         "abort": {
-            "not_loaded": "L'intégration Nikobus n'est pas chargée. Veuillez la recharger puis réessayer.",
-            "discovery_done": "Découverte terminée. L'intégration est en cours de rechargement, les nouvelles entités apparaîtront sous peu.",
-            "discovery_error": "Échec de la découverte : {error}",
-            "no_modules": "Aucun module Nikobus n'est encore configuré. Lancez d'abord un inventaire PC-Link."
+            "not_loaded": "L'intégration Nikobus n'est pas chargée. Veuillez la recharger puis réessayer."
         }
     },
     "entity": {

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -59,9 +59,7 @@
                 "description": "Wat wilt u doen?",
                 "menu_options": {
                     "hardware": "Hardware-instellingen wijzigen",
-                    "configure_modules": "Module aanpassen (beschrijving, entiteitstype, LED-triggers, looptijd)",
-                    "discovery_pc_link": "Modules en knoppen ontdekken (PC Link-inventaris)",
-                    "discovery_modules": "Alle modules scannen voor knoppenkoppelingen"
+                    "configure_modules": "Module aanpassen (beschrijving, entiteitstype, LED-triggers, looptijd)"
                 }
             },
             "hardware": {
@@ -85,10 +83,6 @@
                 "data_description": {
                     "refresh_interval": "Hoe vaak modulestatussen worden gelezen (60–3600 s)."
                 }
-            },
-            "discovery_pc_link": {
-                "title": "PC Link-inventaris",
-                "description": "Het PC Link-register wordt gescand op modules en knoppen.\n\n**Voortgang:** {percent}%\n\n{message}"
             },
             "configure_modules": {
                 "title": "Een Nikobus-module aanpassen",
@@ -117,20 +111,10 @@
                     "operation_time_up": "Looptijd omhoog (seconden)",
                     "operation_time_down": "Looptijd omlaag (seconden)"
                 }
-            },
-            "discovery_modules": {
-                "title": "Modules scannen",
-                "description": "Elk uitgangsmodule wordt gescand op knoppenkoppelingen.\n\n**Voortgang:** {percent}%\n\n{message}"
             }
         },
-        "progress": {
-            "discovery": "{message}"
-        },
         "abort": {
-            "not_loaded": "De Nikobus-integratie is niet geladen. Herlaad de integratie en probeer het opnieuw.",
-            "discovery_done": "Ontdekking voltooid. De integratie wordt herladen; nieuwe entiteiten verschijnen zo dadelijk.",
-            "discovery_error": "Ontdekking mislukt: {error}",
-            "no_modules": "Er zijn nog geen Nikobus-modules geconfigureerd. Voer eerst een PC-Link-inventaris uit."
+            "not_loaded": "De Nikobus-integratie is niet geladen. Herlaad de integratie en probeer het opnieuw."
         }
     },
     "entity": {


### PR DESCRIPTION
## Summary

Two cleanups grounded in the trace from a working install (2026-05-05 ~10:53–11:08):

1. **Coordinator: stop the dual reload after PC Link inventory.** Single click was producing two `Starting setup of Nikobus (single-instance)` cycles per scan.
2. **Options flow: drop the discovery-trigger steps.** Keep only the Bridge device's button entities as the entry point for scans.

## 1. Dual-reload fix

Trace evidence:

```
10:54:07.122  PC Link inventory: 3 consecutive empty blocks — stopping early
10:54:07.123  Drained 39 queued discovery commands
10:54:07.442  Starting setup of Nikobus (single-instance)        ← reload #1
10:54:14.217  Nikobus integration setup complete
10:54:17.123  Entering _finalize_inventory_phase. Stage: inventory_addresses
10:54:17.138  Discovery finished
10:54:17.527  Starting setup of Nikobus (single-instance)        ← reload #2
10:54:24.251  Nikobus integration setup complete
```

Root cause: the coordinator's early-stop branch (3 consecutive `FFFF…` blocks) called `_handle_discovery_finished` immediately, which schedules a reload. Meanwhile, the library's `_finalize_inventory_phase` was already scheduled (inventory-timeout ~10 s after the last frame); it fires post-reload and calls `on_discovery_finished` → `_handle_discovery_finished` → schedules a *second* reload (the existing in-flight-reload guard at `coordinator.py:1013` passes because by then the first reload's task is `done()`).

**Fix:** in `_abort_discovery_early`, drain the queue and update the UI to show the transitional state (`"PC Link inventory: stopping early; finalising…"`), but do **not** call `_handle_discovery_finished`. Let the library's deferred finalize be the single authoritative completion path — it merges + saves + reloads. `_discovery_finished_event` still gets set by that finalize, so callers awaiting it (notably `start_pc_link_inventory`) unblock normally, just ~10 s later instead of immediately. Net effect: same end state, one reload instead of two.

## 2. Options-flow cleanup

The `Configure` dialog had `discovery_pc_link` and `discovery_modules` menu entries that ran scans through a `_progress_step` ↔ `async_show_progress_done` ↔ terminal-step pipeline. That pipeline was the source of every *"Invalid flow specified"* failure mode chased in #288 / #294 / #296, and it duplicated functionality already available on the Nikobus Bridge device's button entities (`Discover modules & buttons` and `Scan all module links` — confirmed in the trace at `10:53:58.340` and `10:54:33.492`).

Removed from `config_flow.py`:

- `async_step_discovery_pc_link`
- `async_step_discovery_modules`
- `_progress_step`
- `async_step_discovery_done`
- `async_step_discovery_error`
- `_discovery_task` and `_discovery_kind` fields on `OptionsFlow.__init__`
- The two menu entries in `async_step_init`
- `import asyncio` (no longer needed)

Pruned in translations (en / fr / nl):

- `options.step.discovery_pc_link` / `discovery_modules` step blocks
- `options.progress.discovery`
- `options.abort.discovery_done` / `discovery_error` / `no_modules`
- The two menu entries in `options.step.init.menu_options`

README: dropped the "(or **Configure → …**)" parentheticals from the two discovery-step instructions and the trailing options-flow note.

### Upgrade safety

`_async_options_updated` reloads the entry on any options change — it doesn't interpret keys, so leftover options on existing installs (none of the removed steps wrote any) are no-ops, no crash on load.

## Test plan

- [ ] Click **Discover modules & buttons** on the Nikobus Bridge device. Capture a trace. Confirm exactly **one** `Starting setup of Nikobus (single-instance)` and **one** `Nikobus integration setup complete` per click.
- [ ] During the inventory's early-stop, confirm the *Discovery Status* sensor surfaces `"PC Link inventory: stopping early; finalising…"` until the library's finalize completes (~10 s).
- [ ] Click **Scan all module links** on the Bridge device, confirm it still works and the existing trigger log line `Module scan discovery triggered via UI button` still appears.
- [ ] Open *Settings → Devices & Services → Nikobus → Configure*. Confirm the menu now offers only **Change hardware settings** and **Customize a module** — no scan / discover entries.
- [ ] Walk through *Customize a module* end-to-end (pick module, edit channel, save) — no regression.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_