### PR TITLE
Surface PC-Logic / Modular Interface / Audio devices + fix zero-byte register early-stop

### DIFF
--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from .const import BRAND, DOMAIN, HUB_IDENTIFIER, SIGNAL_DISCOVERY_STATE
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity
+from .router import INPUT_MODULE_TYPES, OPAQUE_MODULE_TYPES
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,6 +38,16 @@ async def async_setup_entry(
     buttons = (coordinator.dict_button_data or {}).get("nikobus_button", {})
     register_wall_button_devices(hass, entry, buttons)
     entities.extend(_iter_button_entities(coordinator, buttons))
+
+    # Input-class modules (PC-Logic, Modular Interface) — register one
+    # device per module address and one button entity per channel.
+    register_input_module_devices(hass, entry, coordinator.dict_module_data)
+    entities.extend(_iter_input_module_entities(coordinator))
+
+    # Opaque modules (Audio Distribution) — register the device so it's
+    # visible in HA's device registry, but don't create any entities
+    # for it yet (input/output schema not validated).
+    register_opaque_module_devices(hass, entry, coordinator.dict_module_data)
 
     async_add_entities(entities)
 
@@ -97,6 +108,110 @@ def _hub_device_info() -> dr.DeviceInfo:
         manufacturer=BRAND,
         model="PC-Link Bridge",
     )
+
+
+def _iter_module_records(
+    dict_module_data: dict[str, Any], module_types: frozenset[str]
+):
+    """Yield ``(module_type, address, module_data)`` for the requested buckets."""
+    for module_type in module_types:
+        bucket = dict_module_data.get(module_type)
+        if not isinstance(bucket, dict):
+            continue
+        for address, module_data in bucket.items():
+            if isinstance(module_data, dict):
+                yield module_type, str(address).upper(), module_data
+
+
+def register_input_module_devices(
+    hass: HomeAssistant,
+    entry: NikobusConfigEntry,
+    dict_module_data: dict[str, Any],
+) -> None:
+    """Register one device per PC-Logic / Modular Interface module.
+
+    Each input module groups its N input channels (LM01–LM06 on PC-Logic,
+    six inputs on the Modular Interface) under a single parent device in
+    the registry, mirroring the wall-button device layout.
+    """
+    device_registry = dr.async_get(hass)
+    for module_type, address, module_data in _iter_module_records(
+        dict_module_data, INPUT_MODULE_TYPES
+    ):
+        description = str(
+            module_data.get("description") or f"{module_type} ({address})"
+        )
+        model = str(module_data.get("model") or module_type)
+        device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, address)},
+            manufacturer=BRAND,
+            name=description,
+            model=model,
+            via_device=(DOMAIN, HUB_IDENTIFIER),
+        )
+
+
+def register_opaque_module_devices(
+    hass: HomeAssistant,
+    entry: NikobusConfigEntry,
+    dict_module_data: dict[str, Any],
+) -> None:
+    """Register a placeholder device per Audio Distribution module.
+
+    Audio modules surface no entities yet (input/output schema not
+    validated), but registering the device keeps them visible in the HA
+    device registry so users can confirm discovery saw them.
+    """
+    device_registry = dr.async_get(hass)
+    for module_type, address, module_data in _iter_module_records(
+        dict_module_data, OPAQUE_MODULE_TYPES
+    ):
+        description = str(
+            module_data.get("description") or f"{module_type} ({address})"
+        )
+        model = str(module_data.get("model") or module_type)
+        device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, address)},
+            manufacturer=BRAND,
+            name=description,
+            model=model,
+            via_device=(DOMAIN, HUB_IDENTIFIER),
+        )
+
+
+def _iter_input_module_entities(coordinator: NikobusDataCoordinator):
+    """Yield one NikobusInputEntity per channel of every input-class module."""
+    for module_type, address, module_data in _iter_module_records(
+        coordinator.dict_module_data, INPUT_MODULE_TYPES
+    ):
+        module_desc = str(
+            module_data.get("description") or f"{module_type} ({address})"
+        )
+        module_model = str(module_data.get("model") or module_type)
+        channels = module_data.get("channels") or []
+        if not isinstance(channels, list):
+            continue
+        for channel_index, channel_info in enumerate(channels, start=1):
+            if not isinstance(channel_info, dict):
+                continue
+            if channel_info.get("entity_type") == "disabled":
+                continue
+            channel_description = str(
+                channel_info.get("description") or f"Input {channel_index}"
+            )
+            if channel_description.startswith("not_in_use"):
+                continue
+            yield NikobusInputEntity(
+                coordinator,
+                module_type=module_type,
+                module_address=address,
+                channel=channel_index,
+                channel_description=channel_description,
+                module_description=module_desc,
+                module_model=module_model,
+            )
 
 
 def op_point_display_name(
@@ -238,4 +353,78 @@ class NikobusButtonEntity(NikobusEntity, ButtonEntity):
         Stateless entity: Ignore general coordinator updates to reduce log noise.
         This prevents the "Targeted refresh received" log for buttons during polling.
         """
+        pass
+
+
+class NikobusInputEntity(NikobusEntity, ButtonEntity):
+    """One ButtonEntity per input channel of a PC-Logic / Modular Interface.
+
+    Input-class modules (PC-Logic 05-201, Modular Interface 05-206) feed
+    six dry-contact inputs onto the Nikobus bus. Each input is surfaced as
+    a stateless button so users can see the device, attach automations to
+    its press events, and confirm discovery saw the module.
+
+    TODO(input-routing): the on-bus press-frame format for LM/IM inputs
+    is not yet known. Until ``coordinator.async_event_handler`` learns to
+    route those frames, the UI press handler is a no-op (only logs) — it
+    cannot fake a press onto the bus the way ``NikobusButtonEntity`` does.
+    Library work is needed to sniff and document the press-frame layout.
+    """
+
+    def __init__(
+        self,
+        coordinator: NikobusDataCoordinator,
+        *,
+        module_type: str,
+        module_address: str,
+        channel: int,
+        channel_description: str,
+        module_description: str,
+        module_model: str,
+    ) -> None:
+        """Initialize an input-channel button entity."""
+        super().__init__(
+            coordinator=coordinator,
+            address=module_address,
+            name=module_description,
+            model=module_model,
+            via_device=(DOMAIN, HUB_IDENTIFIER),
+        )
+        self._module_type = module_type
+        self._channel = channel
+        self._channel_description = channel_description
+        self._attr_name = channel_description
+        self._attr_unique_id = (
+            f"{DOMAIN}_input_button_{module_address}_{channel}"
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose channel and parent-module info."""
+        parent_attrs = super().extra_state_attributes or {}
+        return {
+            **parent_attrs,
+            "channel": self._channel,
+            "channel_description": self._channel_description,
+            "module_type": self._module_type,
+        }
+
+    async def async_press(self) -> None:
+        """UI press handler — no bus action until input routing is wired.
+
+        See class docstring TODO: the press-frame format for input-class
+        modules is unknown, so we can't dispatch ``ha_button_pressed``
+        with a meaningful address yet.
+        """
+        _LOGGER.warning(
+            "UI press on Nikobus input %s ch%d (module %s) ignored — "
+            "input-module press routing is not yet implemented",
+            self._address,
+            self._channel,
+            self._module_type,
+        )
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Stateless entity: ignore polling updates to reduce log noise."""
         pass

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -948,7 +948,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
 
     def get_known_entity_unique_ids(self) -> set[str]:
         """Return the set of valid unique_ids for all Nikobus entities."""
-        from .router import build_routing, build_unique_id
+        from .router import build_routing, build_unique_id, INPUT_MODULE_TYPES
         known: set[str] = set()
         routing = build_routing(self.dict_module_data)
         for specs in routing.values():
@@ -963,6 +963,31 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 if bus_addr := op_point.get("bus_address"):
                     known.add(f"{DOMAIN}_button_{bus_addr}")
                     known.add(f"{DOMAIN}_push_button_{bus_addr}")
+        # Input-class modules (PC-Logic, Modular Interface) skip ``build_routing``
+        # because they don't drive output relays — emit their input-channel
+        # button unique IDs directly so orphan-cleanup doesn't remove them.
+        for module_type in INPUT_MODULE_TYPES:
+            bucket = self.dict_module_data.get(module_type) or {}
+            if not isinstance(bucket, dict):
+                continue
+            for address, module_data in bucket.items():
+                if not isinstance(module_data, dict):
+                    continue
+                channels = module_data.get("channels") or []
+                if not isinstance(channels, list):
+                    continue
+                addr_upper = str(address).upper()
+                for channel_index, channel_info in enumerate(channels, start=1):
+                    if not isinstance(channel_info, dict):
+                        continue
+                    if channel_info.get("entity_type") == "disabled":
+                        continue
+                    desc = channel_info.get("description") or ""
+                    if isinstance(desc, str) and desc.startswith("not_in_use"):
+                        continue
+                    known.add(
+                        f"{DOMAIN}_input_button_{addr_upper}_{channel_index}"
+                    )
         for scene in self.dict_scene_data.get("scene", []):
             if sid := scene.get("id"):
                 known.add(f"{DOMAIN}_scene_{sid}")

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -511,11 +511,24 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
     def _is_empty_inventory_block(message: str) -> bool:
         """Check whether a $2E/$1E inventory response carries no device data.
 
-        The first data byte after the PC-Link address indicates the record
-        type (0x03 = module, 0x04+ = button).  A value of 0xFF means the
-        registry slot is unused.
+        Aligns with nikobus-connect's two empty-classification paths so the
+        ``_discovery_found_data`` gate doesn't get opened by a register
+        whose first byte is ``0x00`` — a real-world install
+        (2026-05-06 trace, register ``A0``) returned
+        ``$2E828000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF3AE3CC`` with the leading
+        ``00`` byte, which the library logged as
+        ``reason=empty_register`` but HA-side previously treated as data,
+        flipping the gate True and letting the next three FF-prefixed
+        empty registers trip the early-stop before any real record had
+        been seen.
+
+        Empty markers per nikobus-connect:
+          * first record byte ``FF`` → ``Empty PC Link registry block``
+          * first record byte ``00`` → ``Discovery skipped reason=empty_register``
         """
-        return len(message) < 9 or message[7:9].upper() == "FF"
+        if len(message) < 9:
+            return True
+        return message[7:9].upper() in ("FF", "00")
 
     async def _abort_discovery_early(self) -> None:
         """Stop the PC-Link inventory scan ahead of schedule.

--- a/custom_components/nikobus/router.py
+++ b/custom_components/nikobus/router.py
@@ -22,6 +22,31 @@ _CAPABILITIES = {
     "dimmer_module": {"light"},
 }
 
+# Module types whose channels are *inputs* (presses on the bus), not
+# output relays. Each channel of these modules surfaces as a button
+# entity in ``custom_components/nikobus/button.py``; ``build_routing``
+# below skips them so they don't get rendered as switch / light / cover
+# entities by mistake.
+#
+#   * ``pc_logic`` — Master PC-Logic component (05-201). DEVICE_TYPES
+#     entry gained ``Channels: 6`` in nikobus-connect 0.5.10; the six
+#     channels correspond to the LM01–LM06 local inputs in the Niko
+#     PC software.
+#   * ``interface_module`` — Modular Interface 6 inputs (05-206).
+#     Promoted out of ``other_module`` into its own bucket in 0.5.10.
+INPUT_MODULE_TYPES: frozenset[str] = frozenset({"pc_logic", "interface_module"})
+
+# Module types we recognise but for which no entity schema is validated
+# yet — the inventory record alone makes the device visible in the HA
+# device registry, but no platform creates entities for it.
+#
+#   * ``audio_module`` — Audio Distribution module (05-205). Promoted
+#     out of ``other_module`` into its own bucket in nikobus-connect
+#     0.5.10. Input/output schema not yet validated; creating switches
+#     for it (the previous fall-through behaviour) was wrong, so the
+#     router skips it explicitly.
+OPAQUE_MODULE_TYPES: frozenset[str] = frozenset({"audio_module"})
+
 
 @dataclass(frozen=True)
 class EntitySpec:
@@ -97,6 +122,14 @@ def build_routing(
     routing: dict[str, list[EntitySpec]] = {"cover": [], "switch": [], "light": []}
 
     for module_type, modules in dict_module_data.items():
+        # Input-class modules (PC-Logic, Modular Interface) and opaque
+        # modules (Audio Distribution) don't drive output relays; the
+        # button platform handles input modules and audio modules don't
+        # surface entities yet. Skip both so we don't create phantom
+        # switch entities for their channels.
+        if module_type in INPUT_MODULE_TYPES or module_type in OPAQUE_MODULE_TYPES:
+            continue
+
         modules_map = _modules_to_address_map(modules)
 
         for address, module_data in modules_map.items():

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -357,6 +357,15 @@ class TestIsEmptyInventoryBlock(unittest.TestCase):
         msg = "$1EF586FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000"
         self.assertTrue(self._check(msg))
 
+    def test_zero_first_byte_is_empty(self):
+        # nikobus-connect 0.5.x logs ``reason=empty_register`` when the
+        # first record byte is 00 — HA must agree so ``_discovery_found_data``
+        # doesn't flip True on a register the library considers empty.
+        # 2026-05-06 trace: register A0 returned this exact frame and the
+        # gate opened prematurely, letting later FF empties trip the threshold.
+        msg = "$2E828000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF3AE3CC"
+        self.assertTrue(self._check(msg))
+
 
 # ---------------------------------------------------------------------------
 # Early termination of PC Link discovery
@@ -375,6 +384,9 @@ class TestDiscoveryEarlyTermination(unittest.IsolatedAsyncioTestCase):
         coord.inventory_query_type = InventoryQueryType.PC_LINK
         coord._discovery_found_data = False
         coord._consecutive_empty_blocks = 0
+        coord.discovery_registers_done = 0
+        coord.discovery_registers_total = 96
+        coord._update_discovery_state = MagicMock()
         coord.nikobus_command = MagicMock()
         coord.nikobus_command._command_queue = asyncio.Queue()
 
@@ -397,19 +409,27 @@ class TestDiscoveryEarlyTermination(unittest.IsolatedAsyncioTestCase):
 
     async def test_abort_after_consecutive_empties_following_data(self):
         coord = self._make_coordinator_stub()
+        # Pre-load the queue so the abort path has commands to drain.
+        for i in range(5):
+            coord.nikobus_command._command_queue.put_nowait({"command": f"$1410F586{i:02X}04"})
         data = "$2EF58603000000030000006C0E000001000000F938E8"
         empty = "$2EF586FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFCC98D0"
 
-        # First: a real data response
+        # First: a real data response opens the gate.
         await coord._discovery_frame_callback(data)
         self.assertTrue(coord._discovery_found_data)
         self.assertEqual(coord._consecutive_empty_blocks, 0)
 
-        # Then: 3 consecutive empties → should trigger abort
+        # Then: 3 consecutive empties → early-stop drains the queue.
+        # ``_abort_discovery_early`` deliberately does NOT call
+        # ``_handle_discovery_finished`` (see coordinator commit 686fb9c —
+        # the library's deferred ``_finalize_inventory_phase`` is the sole
+        # reload trigger). The observable effect is the drained queue.
         for _ in range(3):
             await coord._discovery_frame_callback(empty)
 
-        coord._handle_discovery_finished.assert_awaited_once()
+        self.assertEqual(coord.nikobus_command._command_queue.qsize(), 0)
+        coord._handle_discovery_finished.assert_not_awaited()
 
     async def test_data_resets_empty_counter(self):
         coord = self._make_coordinator_stub()
@@ -452,6 +472,25 @@ class TestDiscoveryEarlyTermination(unittest.IsolatedAsyncioTestCase):
         await coord._discovery_frame_callback(data)
 
         coord.nikobus_discovery.parse_inventory_response.assert_not_awaited()
+
+    async def test_zero_byte_register_does_not_open_gate(self):
+        # Real-install regression (2026-05-06): the user's PC-Link returned
+        # register A0 as ``$2E828000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF3AE3CC``
+        # (first record byte = 00), then A1/A2/A3 as ``$2E8280FF...``
+        # (first record byte = FF). Before the fix, A0's ``00`` looked like
+        # data, flipped ``_discovery_found_data`` True, and the next three
+        # FF empties tripped the early-stop before any real record arrived.
+        coord = self._make_coordinator_stub()
+        zero_byte_empty = "$2E828000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF3AE3CC"
+        ff_empty = "$2E8280FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA2BE5D"
+
+        await coord._discovery_frame_callback(zero_byte_empty)
+        for _ in range(3):
+            await coord._discovery_frame_callback(ff_empty)
+
+        # Gate must stay closed and the queue must not be drained.
+        self.assertFalse(coord._discovery_found_data)
+        coord._handle_discovery_finished.assert_not_awaited()
 
     async def test_module_query_does_not_trigger_early_termination(self):
         coord = self._make_coordinator_stub()


### PR DESCRIPTION
## Summary

Two independent fixes on the same branch:

### 1. Recognise the new input / opaque module buckets (nikobus-connect 0.5.10)

Library 0.5.10 promoted three module types out of the `other_module` catch-all: `pc_logic` (PC-Logic 05-201, six LM inputs), `interface_module` (Modular Interface 05-206, six inputs), and `audio_module` (Audio Distribution 05-205). Without an explicit branch in `router.build_routing` the new buckets fell through to the switch fallback and would have created phantom switch entities for each input channel.

- **`router.py`** — declare `INPUT_MODULE_TYPES = {"pc_logic", "interface_module"}` and `OPAQUE_MODULE_TYPES = {"audio_module"}` frozensets; skip both in `build_routing` so they don't generate `EntitySpec` rows.
- **`button.py`** — render each input-channel as a stateless `ButtonEntity` grouped under one parent device per module address, mirroring the wall-button device layout. UI press handler logs a warning (TODO listener routing — bus press-frame format for LM/IM inputs not yet documented). Audio modules register a placeholder device (no entities) so users can confirm discovery saw them.
- **`coordinator.py`** — add `{DOMAIN}_input_button_<addr>_<ch>` unique IDs to `get_known_entity_unique_ids` so orphan-cleanup doesn't strip the input-channel buttons after a reload.

### 2. Stop early-stop from firing on zero-byte registers

A real-install trace (2026-05-06) showed PC Link inventory aborting after only three register reads despite the install having ~5 modules and many buttons. The early-stop's data-found gate (Option A, in place since `81735c1`) was being opened by register `A0`'s `$2E828000FF...` response: the first record byte `00` made `_is_empty_inventory_block` return False even though the library itself logged `Discovery skipped reason=empty_register` for that frame. Once the gate flipped True, the next three FF-prefixed empties (`A1/A2/A3`) tripped the threshold and the queue drained 92 unread commands.

`nikobus-connect` treats a register as empty in two cases:
* first record byte `FF` → `Empty PC Link registry block`
* first record byte `00` → `Discovery skipped reason=empty_register`

HA-side previously only recognised the `FF` case. `_is_empty_inventory_block` now matches both, so the gate stays closed on leading empties and the scan continues into the populated region.

Tests:
- New `test_zero_first_byte_is_empty` pins the helper's new behaviour against the user's exact A0 frame.
- New `test_zero_byte_register_does_not_open_gate` replays the user's A0→A1→A2→A3 sequence and asserts the gate stays closed and the queue is not drained.
- Fixed `_make_coordinator_stub` to seed numeric register counters (was failing comparisons against `MagicMock`) and updated `test_abort_after_consecutive_empties_following_data` to match the dual-reload fix from `686fb9c` (drains the queue but does not await `_handle_discovery_finished`).

## Test plan

- [ ] User re-runs PC Link inventory on the affected install → discovery now traverses the full register range (`A0..FF`) instead of stopping at A3, and devices populate.
- [ ] On a previously-working install, confirm early-stop still fires once the populated region ends (counter still trips on a tail of FF empties after data has been seen).
- [ ] Verify PC-Logic module shows up as a single device with 6 input-button entities (one per LM channel).
- [ ] Verify Modular Interface module shows up the same way.
- [ ] Verify Audio Distribution module shows up as a device with no entities.
- [ ] `pytest tests/test_coordinator.py::TestIsEmptyInventoryBlock tests/test_coordinator.py::TestDiscoveryEarlyTermination` — 14 pass.

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_