### PR TITLE
Pin nikobus-connect&gt;=0.5.14 (skip 0.5.13 regression)

### DIFF
--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.5.13"
+    "nikobus-connect>=0.5.14"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }


### PR DESCRIPTION
## Summary

One-line manifest bump: `nikobus-connect>=0.5.13` → `>=0.5.14`.

`0.5.13` shipped a regression in the all-FF PC-Link inventory terminator: installs whose project starts past register A0 (leading flash of pristine FF before the active records) had discovery abort after reading only the PC-Link itself, because the library treated the leading-flash all-FF as the terminator without first verifying any real record had been parsed.

`0.5.14` ([fdebrus/nikobus-connect#49](https://github.com/fdebrus/nikobus-connect/pull/49)) adds the `data_seen` gate — only honours the all-FF terminator after at least one real record has been parsed.

## Why this matters now

Main currently pins `>=0.5.13`, which means a fresh install or a HACS update will pull the buggy version. Anyone whose PC-Link project doesn't start at register A0 will see discovery silently abort. Skip `0.5.13` entirely.

## Context

The HA-side "3 consecutive empty blocks" early-stop was already removed in `cc3dc65` on the assumption the library handles termination cleanly. With `0.5.14`'s `data_seen` gate, all three install patterns should work:

1. Project starts at A0 (no leading flash)
2. Project starts past A0 (the regression case)
3. Active records + trailing residue from a previous install

## Test plan

- [ ] User on `nikobus-connect==0.5.14` re-runs PC Link inventory across the three install patterns above → discovery completes naturally.
- [ ] Confirm HACS / pip resolves to `0.5.14` after this lands; no install can pin to the broken `0.5.13`.

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_