### PR TITLE
Add detect_stale_inventory + purge_stale_inventory services (nikobus-connect 0.5.16)

### DIFF
--- a/custom_components/nikobus/__init__.py
+++ b/custom_components/nikobus/__init__.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 from aiofiles import open as aio_open
 
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse, SupportsResponse
 from homeassistant.helpers import config_validation as cv, device_registry as dr, entity_registry as er
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.exceptions import ConfigEntryNotReady, ServiceValidationError
@@ -42,9 +42,28 @@ PLATFORMS: Final[list[str]] = [
 
 SERVICE_QUERY_MODULE_INVENTORY: Final = "query_module_inventory"
 SERVICE_SEND_BUTTON_PRESS: Final = "send_button_press"
+SERVICE_DETECT_STALE_INVENTORY: Final = "detect_stale_inventory"
+SERVICE_PURGE_STALE_INVENTORY: Final = "purge_stale_inventory"
+
+# Default per-module probe budget. The library's
+# ``NikobusDiscovery.detect_stale_inventory`` polls each candidate module
+# with a $1012/$1017 read and waits this long for an ACK before flagging
+# the module absent. Worst-case wall-clock budget is roughly
+# ``len(switch+dimmer+roller modules) * timeout`` — at the default 0.6 s
+# an 8-module install needs about five seconds.
+DEFAULT_DETECT_PROBE_TIMEOUT: Final[float] = 0.6
+
 SCAN_MODULE_SCHEMA = vol.Schema({vol.Optional("module_address", default=""): cv.string})
 SEND_BUTTON_PRESS_SCHEMA = vol.Schema({
     vol.Required("address"): cv.string,
+})
+DETECT_STALE_INVENTORY_SCHEMA = vol.Schema({
+    vol.Optional("timeout", default=DEFAULT_DETECT_PROBE_TIMEOUT): vol.All(
+        vol.Coerce(float), vol.Range(min=0.1, max=5.0)
+    ),
+})
+PURGE_STALE_INVENTORY_SCHEMA = vol.Schema({
+    vol.Required("addresses"): vol.All(cv.ensure_list, [cv.string], vol.Length(min=1)),
 })
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
@@ -114,6 +133,91 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         SERVICE_SEND_BUTTON_PRESS,
         handle_send_button_press,
         SEND_BUTTON_PRESS_SCHEMA,
+    )
+
+    async def handle_detect_stale_inventory(call: ServiceCall) -> ServiceResponse:
+        """Probe known output modules for liveness; return the manifest.
+
+        Wraps ``NikobusDiscovery.detect_stale_inventory`` (nikobus-connect
+        0.5.16+). The library deliberately doesn't mutate storage —
+        ``purge_stale_inventory`` consumes this manifest after the user
+        confirms which addresses to remove.
+        """
+        coordinator = _loaded_coordinator(hass)
+        if coordinator is None:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="no_loaded_entry",
+            )
+        if coordinator.nikobus_discovery is None:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="discovery_not_initialized",
+            )
+        if coordinator.discovery_running:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="discovery_already_running",
+            )
+
+        timeout = float(call.data.get("timeout", DEFAULT_DETECT_PROBE_TIMEOUT))
+        _LOGGER.info(
+            "Detecting stale Nikobus inventory (probe timeout=%.2fs)", timeout
+        )
+        manifest: dict = await coordinator.nikobus_discovery.detect_stale_inventory(
+            timeout=timeout
+        )
+        absent = manifest.get("absent_modules") or []
+        orphaned = manifest.get("orphaned_buttons") or []
+        _LOGGER.info(
+            "Stale-inventory probe done: checked=%d present=%d absent=%d orphaned_buttons=%d",
+            len(manifest.get("checked") or []),
+            len(manifest.get("present_modules") or []),
+            len(absent),
+            len(orphaned),
+        )
+        return manifest
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_DETECT_STALE_INVENTORY,
+        handle_detect_stale_inventory,
+        DETECT_STALE_INVENTORY_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    async def handle_purge_stale_inventory(call: ServiceCall) -> ServiceResponse:
+        """Remove the given addresses from the persisted module + button stores.
+
+        Delegates to ``coordinator.purge_inventory_addresses`` so the
+        storage write path lives next to the storage objects themselves.
+        Trust-the-input: the user (or a UI flow built on top of
+        ``detect_stale_inventory``) supplies the address list.
+        """
+        coordinator = _loaded_coordinator(hass)
+        if coordinator is None:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="no_loaded_entry",
+            )
+
+        result = await coordinator.purge_inventory_addresses(
+            call.data.get("addresses") or []
+        )
+        _LOGGER.info(
+            "Purged stale Nikobus inventory: modules=%s buttons=%s not_found=%s",
+            result["removed_modules"],
+            result["removed_buttons"],
+            result["not_found"],
+        )
+        return result
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_PURGE_STALE_INVENTORY,
+        handle_purge_stale_inventory,
+        PURGE_STALE_INVENTORY_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
     )
     return True
 

--- a/custom_components/nikobus/const.py
+++ b/custom_components/nikobus/const.py
@@ -48,6 +48,7 @@ DISCOVERY_WEIGHT_FINALIZING: Final[int] = 5
 # Repair issues
 # =============================================================================
 ISSUE_NO_BUTTONS_CONFIGURED: Final[str] = "no_buttons_configured"
+ISSUE_STALE_INVENTORY_PRESENT: Final[str] = "stale_inventory_present"
 
 # =============================================================================
 # Configuration Keys

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -738,6 +738,65 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         return self.get_bytearray_state(addr, ch)
 
     # ------------------------------------------------------------------
+    # Stale-inventory management
+    # ------------------------------------------------------------------
+
+    async def purge_inventory_addresses(self, addresses: list[str]) -> dict[str, list[str]]:
+        """Remove the given addresses from the persisted module + button stores.
+
+        Each address is tried as both a module-store key and a button-store
+        key; whichever matches is removed. The library deliberately doesn't
+        mutate storage in ``detect_stale_inventory`` — this is the
+        HA-side companion that consumes the manifest after the user has
+        confirmed which addresses to drop.
+
+        Saves both stores when at least one address was removed and
+        schedules a config-entry reload so platforms drop entities for
+        the purged addresses and the routing cache is rebuilt. Returns a
+        breakdown of what happened so the caller can report results.
+        """
+        normalised = [
+            str(addr).strip().upper() for addr in addresses if str(addr).strip()
+        ]
+        modules = self.module_storage.data.setdefault("nikobus_module", {})
+        buttons = self.dict_button_data.setdefault("nikobus_button", {})
+        removed_modules: list[str] = []
+        removed_buttons: list[str] = []
+        not_found: list[str] = []
+
+        for addr in normalised:
+            hit = False
+            if addr in modules:
+                modules.pop(addr, None)
+                removed_modules.append(addr)
+                hit = True
+            if addr in buttons:
+                buttons.pop(addr, None)
+                removed_buttons.append(addr)
+                hit = True
+            if not hit:
+                not_found.append(addr)
+
+        if removed_modules or removed_buttons:
+            await self.module_storage.async_save()
+            await self.button_storage.async_save()
+            self._rebuild_dict_module_data()
+            domain_data = self.hass.data.get(DOMAIN, {})
+            entry_data = domain_data.get(self.config_entry.entry_id, {})
+            entry_data.pop("routing", None)
+            # Reload so platforms drop entities for the purged addresses.
+            # Schedule rather than await — matches ``_async_options_updated``.
+            self.hass.async_create_task(
+                self.hass.config_entries.async_reload(self.config_entry.entry_id)
+            )
+
+        return {
+            "removed_modules": removed_modules,
+            "removed_buttons": removed_buttons,
+            "not_found": not_found,
+        }
+
+    # ------------------------------------------------------------------
     # Event / dispatcher
     # ------------------------------------------------------------------
 

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.5.14"
+    "nikobus-connect>=0.5.16"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }

--- a/custom_components/nikobus/services.yaml
+++ b/custom_components/nikobus/services.yaml
@@ -13,3 +13,24 @@ send_button_press:
       required: true
       selector:
         text:
+
+detect_stale_inventory:
+  fields:
+    timeout:
+      example: 0.6
+      required: false
+      default: 0.6
+      selector:
+        number:
+          min: 0.1
+          max: 5.0
+          step: 0.1
+          unit_of_measurement: "s"
+
+purge_stale_inventory:
+  fields:
+    addresses:
+      example: "['CCDD', 'EEFF']"
+      required: true
+      selector:
+        object:

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -204,6 +204,26 @@
                 }
             },
             "name": "Query module inventory"
+        },
+        "detect_stale_inventory": {
+            "description": "Probes every known output module (switch, dimmer, roller) on the bus and reports which ones don't respond. Returns a manifest with checked / present / absent module lists plus orphaned button addresses. Does not modify configuration; pair with purge_stale_inventory after reviewing the results.",
+            "fields": {
+                "timeout": {
+                    "description": "Per-module probe timeout. Worst-case scan time is roughly N modules × timeout.",
+                    "name": "Probe timeout (seconds)"
+                }
+            },
+            "name": "Detect stale inventory"
+        },
+        "purge_stale_inventory": {
+            "description": "Removes the given addresses from the persisted module and button stores, then reloads the integration so entities for the purged addresses are dropped. Run detect_stale_inventory first to obtain the list of safe-to-remove addresses.",
+            "fields": {
+                "addresses": {
+                    "description": "List of module / button addresses to remove (matched case-insensitively against both stores).",
+                    "name": "Addresses"
+                }
+            },
+            "name": "Purge stale inventory"
         }
     },
     "selector": {

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -407,5 +407,117 @@ class TestDiscoveryFrameRouting(unittest.IsolatedAsyncioTestCase):
         coord.nikobus_discovery.parse_inventory_response.assert_not_awaited()
 
 
+# ---------------------------------------------------------------------------
+# Stale-inventory purge (companion to the library's detect_stale_inventory)
+# ---------------------------------------------------------------------------
+
+class TestPurgeInventoryAddresses(unittest.IsolatedAsyncioTestCase):
+    """Verify the storage write path that consumes detect_stale_inventory()."""
+
+    def _make_coordinator_stub(self):
+        coord = MagicMock()
+        coord.module_storage = MagicMock()
+        coord.module_storage.data = {
+            "nikobus_module": {
+                "AABB": {"module_type": "switch_module", "model": "05-002-02"},
+                "CCDD": {"module_type": "dimmer_module", "model": "05-007-02"},
+            }
+        }
+        coord.module_storage.async_save = AsyncMock()
+        coord.button_storage = MagicMock()
+        coord.button_storage.async_save = AsyncMock()
+        coord.dict_button_data = {
+            "nikobus_button": {
+                "AABBCC": {"type": "Button", "operation_points": {}},
+                "DDEEFF": {"type": "Button", "operation_points": {}},
+            }
+        }
+        coord._rebuild_dict_module_data = MagicMock()
+
+        coord.config_entry = MagicMock()
+        coord.config_entry.entry_id = "entry_test"
+        coord.hass = MagicMock()
+        coord.hass.data = {}
+        coord.hass.config_entries.async_reload = MagicMock()
+        coord.hass.async_create_task = MagicMock()
+
+        coord.purge_inventory_addresses = lambda addrs, self_=coord: \
+            NikobusDataCoordinator.purge_inventory_addresses(self_, addrs)
+        return coord
+
+    async def test_removes_module_address(self):
+        coord = self._make_coordinator_stub()
+        result = await coord.purge_inventory_addresses(["AABB"])
+
+        self.assertEqual(result["removed_modules"], ["AABB"])
+        self.assertEqual(result["removed_buttons"], [])
+        self.assertEqual(result["not_found"], [])
+        self.assertNotIn("AABB", coord.module_storage.data["nikobus_module"])
+        # The other module is untouched.
+        self.assertIn("CCDD", coord.module_storage.data["nikobus_module"])
+        coord.module_storage.async_save.assert_awaited_once()
+        coord.button_storage.async_save.assert_awaited_once()
+        coord._rebuild_dict_module_data.assert_called_once()
+        coord.hass.async_create_task.assert_called_once()
+
+    async def test_removes_button_address(self):
+        coord = self._make_coordinator_stub()
+        result = await coord.purge_inventory_addresses(["DDEEFF"])
+
+        self.assertEqual(result["removed_buttons"], ["DDEEFF"])
+        self.assertEqual(result["removed_modules"], [])
+        self.assertNotIn("DDEEFF", coord.dict_button_data["nikobus_button"])
+        coord.hass.async_create_task.assert_called_once()
+
+    async def test_normalises_case_and_whitespace(self):
+        coord = self._make_coordinator_stub()
+        result = await coord.purge_inventory_addresses(["  aabb  ", "ddeeff"])
+
+        # Both inputs match after upper-case + strip.
+        self.assertEqual(set(result["removed_modules"]), {"AABB"})
+        self.assertEqual(set(result["removed_buttons"]), {"DDEEFF"})
+
+    async def test_unknown_address_reported_as_not_found(self):
+        coord = self._make_coordinator_stub()
+        result = await coord.purge_inventory_addresses(["AABB", "9999"])
+
+        self.assertEqual(result["removed_modules"], ["AABB"])
+        self.assertEqual(result["not_found"], ["9999"])
+
+    async def test_no_op_when_nothing_matches_skips_save_and_reload(self):
+        coord = self._make_coordinator_stub()
+        result = await coord.purge_inventory_addresses(["9999", "8888"])
+
+        self.assertEqual(result["removed_modules"], [])
+        self.assertEqual(result["removed_buttons"], [])
+        self.assertEqual(set(result["not_found"]), {"9999", "8888"})
+        coord.module_storage.async_save.assert_not_awaited()
+        coord.button_storage.async_save.assert_not_awaited()
+        coord._rebuild_dict_module_data.assert_not_called()
+        coord.hass.async_create_task.assert_not_called()
+
+    async def test_address_in_both_stores_removed_from_both(self):
+        coord = self._make_coordinator_stub()
+        # Synthesize an address that exists as both a module key and a
+        # button key — would be a hash collision in practice but the
+        # purge logic shouldn't care; both stores get the pop.
+        coord.module_storage.data["nikobus_module"]["1234"] = {"module_type": "switch_module"}
+        coord.dict_button_data["nikobus_button"]["1234"] = {"type": "Button"}
+
+        result = await coord.purge_inventory_addresses(["1234"])
+
+        self.assertEqual(result["removed_modules"], ["1234"])
+        self.assertEqual(result["removed_buttons"], ["1234"])
+        self.assertEqual(result["not_found"], [])
+
+    async def test_empty_input_is_no_op(self):
+        coord = self._make_coordinator_stub()
+        result = await coord.purge_inventory_addresses([])
+
+        self.assertEqual(result, {"removed_modules": [], "removed_buttons": [], "not_found": []})
+        coord.module_storage.async_save.assert_not_awaited()
+        coord.hass.async_create_task.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Wires up the `nikobus-connect 0.5.16` `detect_stale_inventory()` API with two HA services:

- **`nikobus.detect_stale_inventory`** — probes every known output module (switch / dimmer / roller) and returns a manifest of `{checked, present_modules, absent_modules, orphaned_buttons}`. **Read-only** — the library deliberately doesn't mutate storage.
- **`nikobus.purge_stale_inventory`** (`addresses=[...]`) — companion service that removes the supplied addresses from the persisted module + button stores, saves both, and reloads the integration so entities for the purged addresses are dropped.

Both services use `SupportsResponse.ONLY` so callers (developer tools, automations) get the result dict back inline.

## Why two services, not one

Per the prompt: the library treats removal as a separate decision. A single fire-and-forget service would be footgun-y on installs where some "absent" modules are temporarily offline (power-cycled, fuse-tripped). Splitting detect from purge gives the user / a UI flow a chance to inspect the manifest before anything is dropped from storage.

## Architecture notes

- **Pre-flight verified**: `coordinator.nikobus_command.get_output_state(addr, group=1)` exists in the library (the method `detect_stale_inventory` calls under the hood), and both `coordinator.nikobus_discovery` / `coordinator.nikobus_command` are populated in `connect()`.
- **Probe timing**: 0.6 s × N output modules. An 8-module install needs ~5 s; the field is exposed via the service schema (range 0.1–5.0 s) for installs that need a longer per-module budget.
- **Concurrency**: detect gates on `discovery_running` so it can't collide with an inventory or module scan.
- **Storage layout**: purge tries each address as both a module-store key and a button-store key; whichever matches is popped. Reload happens via `hass.async_create_task(async_reload(...))` (matches `_async_options_updated`'s pattern — avoids blocking the service-call response).
- **Logic placement**: the storage write path lives on the coordinator (`purge_inventory_addresses`) so it's testable without HA's service registry. The `__init__.py` handler is a thin wrapper.
- **PC-Link / PC-Logic / feedback / audio / interface modules**: intentionally excluded by the library (only output modules get probed). HA-side nothing to do.

## Out of scope (carry-over)

- Repair-issue surface with "Fix" → invokes purge. Constant `ISSUE_STALE_INVENTORY_PRESENT` added but not wired — follow-up PR.
- "3 consecutive empty blocks" early-stop removal validation, `interface_module` / `audio_module` registry surfacing, PC-Logic LM-input button entities, 05-057 channel-3/4 cleanup — all still pending from prior threads.
- `_VENDOR_REGISTER_MAP_BY_SUB` (informational only per prompt) — no integration work needed.

## Test plan

- [x] `pytest tests/test_coordinator.py::TestDiscoveryFrameRouting tests/test_coordinator.py::TestPurgeInventoryAddresses` — 11 pass (4 existing + 7 new).
- [x] `services.yaml` parses, `translations/en.json` valid JSON, `manifest.json` valid JSON.
- [ ] Live install: call `nikobus.detect_stale_inventory` with timeout=0.6 → returns manifest with present/absent breakdown.
- [ ] Call `nikobus.purge_stale_inventory(addresses=[<absent address>])` → purged from `.storage/nikobus.modules` and `.storage/nikobus.buttons`, integration reloads, entities for the address disappear.

## Diff

`+319 / -2 lines` across 7 files.

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_