### PR TITLE
Wire detect_stale_inventory into post-discovery reconciliation (closes #319)

### DIFF
--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -338,6 +338,13 @@ class NikobusButtonEntity(NikobusEntity, ButtonEntity):
         if wall_info:
             attrs["wall_button_model"] = wall_info.get("model")
             attrs["wall_button_type"] = wall_info.get("type")
+            # ``status`` comes from post-discovery reconciliation
+            # (coordinator._reconcile_post_discovery): one of "active",
+            # "legacy_orphan", "legacy_undecoded". Surface only the
+            # non-default flags so healthy buttons aren't cluttered.
+            status = wall_info.get("status")
+            if status and status != "active":
+                attrs["wall_button_status"] = status
         return attrs
 
     async def async_press(self) -> None:

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -631,6 +631,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             "address": physical_addr,
             "channels": phys.get("channels"),
             "key": key_label,
+            "status": phys.get("status"),
         }
 
     def get_button_linked_outputs(self, bus_address: str) -> list[dict[str, Any]]:
@@ -1020,11 +1021,128 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         entry_data = domain_data.get(self.config_entry.entry_id, {})
         entry_data.pop("routing", None)
 
+    @staticmethod
+    def _collect_button_linked_modules(phys: dict[str, Any]) -> set[str]:
+        """Union of every module address referenced by any of a button's op-points."""
+        linked: set[str] = set()
+        op_points = phys.get("operation_points") or {}
+        if not isinstance(op_points, dict):
+            return linked
+        for op_point in op_points.values():
+            if not isinstance(op_point, dict):
+                continue
+            for link in op_point.get("linked_modules") or []:
+                if not isinstance(link, dict):
+                    continue
+                addr = link.get("module_address")
+                if addr:
+                    linked.add(str(addr).upper())
+        return linked
+
+    async def _reconcile_post_discovery(self) -> None:
+        """Probe every output module + tag buttons by reachability.
+
+        Runs after the library finalizes its inventory + register-scan
+        merge. The library merges *additively* (it adds discovered records
+        but never evicts), so without this step a previous owner's
+        residue (a second-hand PC-Link, a re-keyed install, etc.) would
+        persist forever in the local stores. ``detect_stale_inventory``
+        (nikobus-connect 0.5.16+) probes each output module with a
+        ``$1012`` read; modules that don't ACK get evicted. Buttons are
+        then tagged into one of three buckets:
+
+          * ``active`` — at least one ``linked_modules`` entry resolves
+            to a present module.
+          * ``legacy_orphan`` — every linked module is in the absent set.
+          * ``legacy_undecoded`` — no ``linked_modules`` survived the
+            scan (decoder may catch up later; flag surfaces it).
+
+        Buttons stay in the store regardless of bucket — the ``status``
+        field is the marker for HA UI / diagnostics.
+        """
+        if self.nikobus_discovery is None:
+            return
+        if not hasattr(self.nikobus_discovery, "detect_stale_inventory"):
+            _LOGGER.warning(
+                "nikobus-connect lacks detect_stale_inventory — install >= 0.5.16; "
+                "skipping post-discovery reconciliation"
+            )
+            return
+
+        try:
+            manifest = await self.nikobus_discovery.detect_stale_inventory(timeout=0.6)
+        except Exception as err:  # pragma: no cover - defensive
+            _LOGGER.error("detect_stale_inventory probe failed: %s", err)
+            return
+
+        absent = {str(a).upper() for a in (manifest.get("absent_modules") or [])}
+        present = {str(a).upper() for a in (manifest.get("present_modules") or [])}
+        checked = manifest.get("checked") or []
+
+        # Replace-with-current-discovery: drop modules the probe says
+        # aren't on the bus. Other module types (PC-Logic, feedback,
+        # audio, interface) are intentionally excluded by the library
+        # from probing and stay in the store untouched.
+        modules = self.module_storage.data.setdefault("nikobus_module", {})
+        evicted: list[str] = []
+        for addr in list(modules.keys()):
+            if str(addr).upper() in absent:
+                modules.pop(addr, None)
+                evicted.append(str(addr).upper())
+
+        # Tag every physical-button record.
+        bucket_counts = {"active": 0, "legacy_orphan": 0, "legacy_undecoded": 0}
+        buttons = self.dict_button_data.setdefault("nikobus_button", {})
+        for phys in buttons.values():
+            if not isinstance(phys, dict):
+                continue
+            linked = self._collect_button_linked_modules(phys)
+            if not linked:
+                status = "legacy_undecoded"
+            elif linked.issubset(absent):
+                status = "legacy_orphan"
+            else:
+                status = "active"
+            phys["status"] = status
+            bucket_counts[status] += 1
+
+        # Persist. Both stores save unconditionally so the ``status``
+        # field on buttons + the eviction on modules land on disk.
+        await self.module_storage.async_save()
+        await self.button_storage.async_save()
+        self._rebuild_dict_module_data()
+        domain_data = self.hass.data.get(DOMAIN, {})
+        entry_data = domain_data.get(self.config_entry.entry_id, {})
+        entry_data.pop("routing", None)
+        self.invalidate_controlled_by_index()
+
+        _LOGGER.info(
+            "Post-discovery reconciliation: probed=%d present=%d absent=%d evicted=%d "
+            "| buttons active=%d legacy_orphan=%d legacy_undecoded=%d",
+            len(checked),
+            len(present),
+            len(absent),
+            len(evicted),
+            bucket_counts["active"],
+            bucket_counts["legacy_orphan"],
+            bucket_counts["legacy_undecoded"],
+        )
+        if evicted:
+            _LOGGER.info("Evicted stale modules: %s", evicted)
+
     async def _handle_discovery_finished(self) -> None:
         """Signal discovery completion; optionally reload the config entry."""
         self.discovery_running = False
         self.discovery_sub_phase = DISCOVERY_SUB_PHASE_FINISHED
         self.discovery_register_current = None
+
+        # Replace-with-current-discovery semantics: probe each output
+        # module on the bus, evict any that don't ACK, and tag buttons
+        # by reachability bucket. The library's merge is additive —
+        # without this step pre-0.5.13 residue (issue #319) survives
+        # every subsequent scan.
+        await self._reconcile_post_discovery()
+
         self._update_discovery_state(
             phase=DISCOVERY_PHASE_FINISHED,
             message=(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -519,5 +519,255 @@ class TestPurgeInventoryAddresses(unittest.IsolatedAsyncioTestCase):
         coord.hass.async_create_task.assert_not_called()
 
 
+# ---------------------------------------------------------------------------
+# Post-discovery stale-inventory reconciliation (issue #319)
+# ---------------------------------------------------------------------------
+
+class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
+    """Verify the reconciliation that fires from _handle_discovery_finished.
+
+    Three behaviours pinned: (1) absent modules get evicted from the store,
+    (2) buttons whose linked_modules are entirely absent are tagged
+    ``legacy_orphan``, (3) buttons with no linked_modules are tagged
+    ``legacy_undecoded``.
+    """
+
+    def _make_coordinator_stub(
+        self,
+        *,
+        modules: dict | None = None,
+        buttons: dict | None = None,
+        manifest: dict | None = None,
+        has_method: bool = True,
+    ):
+        coord = MagicMock()
+        coord.module_storage = MagicMock()
+        coord.module_storage.data = {"nikobus_module": dict(modules or {})}
+        coord.module_storage.async_save = AsyncMock()
+        coord.button_storage = MagicMock()
+        coord.button_storage.async_save = AsyncMock()
+        coord.dict_button_data = {"nikobus_button": dict(buttons or {})}
+        coord._rebuild_dict_module_data = MagicMock()
+        coord.invalidate_controlled_by_index = MagicMock()
+        coord.config_entry = MagicMock()
+        coord.config_entry.entry_id = "entry_test"
+        coord.hass = MagicMock()
+        coord.hass.data = {}
+        if has_method:
+            coord.nikobus_discovery = MagicMock()
+            coord.nikobus_discovery.detect_stale_inventory = AsyncMock(
+                return_value=manifest or {
+                    "checked": [],
+                    "present_modules": [],
+                    "absent_modules": [],
+                    "orphaned_buttons": [],
+                }
+            )
+        else:
+            # Library lacks the method (older nikobus-connect): the spec
+            # requires graceful skip-with-warning.
+            class _OldDiscovery:
+                pass
+            coord.nikobus_discovery = _OldDiscovery()
+
+        coord._collect_button_linked_modules = staticmethod(
+            NikobusDataCoordinator._collect_button_linked_modules
+        )
+        coord._reconcile_post_discovery = lambda self_=coord: \
+            NikobusDataCoordinator._reconcile_post_discovery(self_)
+        return coord
+
+    @staticmethod
+    def _button(*module_addrs: str) -> dict:
+        """Build a minimal physical-button record with one op-point linked
+        to the given module addresses."""
+        if module_addrs:
+            op_points = {
+                "1A": {
+                    "bus_address": "AABBCC",
+                    "linked_modules": [
+                        {"module_address": addr, "outputs": [{"channel": 1}]}
+                        for addr in module_addrs
+                    ],
+                }
+            }
+        else:
+            op_points = {"1A": {"bus_address": "AABBCC", "linked_modules": []}}
+        return {"type": "Button", "operation_points": op_points}
+
+    async def test_absent_module_is_evicted_from_store(self):
+        coord = self._make_coordinator_stub(
+            modules={"AABB": {"module_type": "switch_module"},
+                     "CCDD": {"module_type": "dimmer_module"}},
+            manifest={
+                "checked": ["AABB", "CCDD"],
+                "present_modules": ["AABB"],
+                "absent_modules": ["CCDD"],
+                "orphaned_buttons": [],
+            },
+        )
+
+        await coord._reconcile_post_discovery()
+
+        self.assertIn("AABB", coord.module_storage.data["nikobus_module"])
+        self.assertNotIn("CCDD", coord.module_storage.data["nikobus_module"])
+        coord.module_storage.async_save.assert_awaited_once()
+        coord.button_storage.async_save.assert_awaited_once()
+
+    async def test_button_linked_to_absent_module_only_is_legacy_orphan(self):
+        coord = self._make_coordinator_stub(
+            modules={"AABB": {"module_type": "switch_module"}},
+            buttons={"112233": self._button("CCDD")},  # CCDD will be absent
+            manifest={
+                "checked": ["AABB", "CCDD"],
+                "present_modules": ["AABB"],
+                "absent_modules": ["CCDD"],
+                "orphaned_buttons": ["112233"],
+            },
+        )
+
+        await coord._reconcile_post_discovery()
+
+        self.assertEqual(
+            coord.dict_button_data["nikobus_button"]["112233"]["status"],
+            "legacy_orphan",
+        )
+
+    async def test_button_with_no_linked_modules_is_legacy_undecoded(self):
+        coord = self._make_coordinator_stub(
+            modules={"AABB": {"module_type": "switch_module"}},
+            buttons={"112233": self._button()},  # no linked_modules
+            manifest={
+                "checked": ["AABB"],
+                "present_modules": ["AABB"],
+                "absent_modules": [],
+                "orphaned_buttons": [],
+            },
+        )
+
+        await coord._reconcile_post_discovery()
+
+        self.assertEqual(
+            coord.dict_button_data["nikobus_button"]["112233"]["status"],
+            "legacy_undecoded",
+        )
+
+    async def test_button_with_at_least_one_present_link_is_active(self):
+        coord = self._make_coordinator_stub(
+            modules={"AABB": {"module_type": "switch_module"},
+                     "CCDD": {"module_type": "switch_module"}},
+            # Linked to one absent + one present module → still active.
+            buttons={"112233": self._button("AABB", "CCDD")},
+            manifest={
+                "checked": ["AABB", "CCDD"],
+                "present_modules": ["AABB"],
+                "absent_modules": ["CCDD"],
+                "orphaned_buttons": [],
+            },
+        )
+
+        await coord._reconcile_post_discovery()
+
+        self.assertEqual(
+            coord.dict_button_data["nikobus_button"]["112233"]["status"],
+            "active",
+        )
+
+    async def test_module_address_comparison_is_case_insensitive(self):
+        # Storage might hold lowercase addresses (legacy data); manifest
+        # always returns upper-case. Reconciliation must still match.
+        coord = self._make_coordinator_stub(
+            modules={"aabb": {"module_type": "switch_module"}},
+            manifest={
+                "checked": ["AABB"],
+                "present_modules": [],
+                "absent_modules": ["AABB"],
+                "orphaned_buttons": [],
+            },
+        )
+
+        await coord._reconcile_post_discovery()
+
+        self.assertEqual(coord.module_storage.data["nikobus_module"], {})
+
+    async def test_skips_when_library_lacks_detect_method(self):
+        coord = self._make_coordinator_stub(
+            modules={"AABB": {"module_type": "switch_module"}},
+            buttons={"112233": self._button("AABB")},
+            has_method=False,
+        )
+
+        await coord._reconcile_post_discovery()
+
+        # Nothing saved, nothing tagged — graceful no-op.
+        coord.module_storage.async_save.assert_not_awaited()
+        coord.button_storage.async_save.assert_not_awaited()
+        self.assertNotIn(
+            "status", coord.dict_button_data["nikobus_button"]["112233"]
+        )
+
+    async def test_skips_when_no_discovery_attached(self):
+        coord = self._make_coordinator_stub()
+        coord.nikobus_discovery = None
+
+        await coord._reconcile_post_discovery()
+
+        coord.module_storage.async_save.assert_not_awaited()
+
+    async def test_probe_failure_is_logged_and_swallowed(self):
+        coord = self._make_coordinator_stub(
+            modules={"AABB": {"module_type": "switch_module"}},
+        )
+        coord.nikobus_discovery.detect_stale_inventory = AsyncMock(
+            side_effect=RuntimeError("bus busy")
+        )
+
+        # Should not raise.
+        await coord._reconcile_post_discovery()
+
+        # Storage stays untouched on probe failure.
+        self.assertIn("AABB", coord.module_storage.data["nikobus_module"])
+        coord.module_storage.async_save.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Helper: _collect_button_linked_modules
+# ---------------------------------------------------------------------------
+
+class TestCollectButtonLinkedModules(unittest.TestCase):
+    """Pure-function unit tests for the helper that drives bucket assignment."""
+
+    _collect = staticmethod(NikobusDataCoordinator._collect_button_linked_modules)
+
+    def test_no_op_points_returns_empty_set(self):
+        self.assertEqual(self._collect({}), set())
+        self.assertEqual(self._collect({"operation_points": {}}), set())
+
+    def test_collects_addresses_across_all_op_points(self):
+        phys = {
+            "operation_points": {
+                "1A": {"linked_modules": [
+                    {"module_address": "aabb", "outputs": [{"channel": 1}]},
+                ]},
+                "1B": {"linked_modules": [
+                    {"module_address": "CCDD", "outputs": [{"channel": 2}]},
+                ]},
+            }
+        }
+        self.assertEqual(self._collect(phys), {"AABB", "CCDD"})
+
+    def test_skips_links_without_module_address(self):
+        phys = {
+            "operation_points": {
+                "1A": {"linked_modules": [
+                    {"module_address": "AABB", "outputs": []},
+                    {"outputs": [{"channel": 1}]},  # malformed
+                    "garbage",  # malformed
+                ]}
+            }
+        }
+        self.assertEqual(self._collect(phys), {"AABB"})
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #319.

## What's broken (per IKIKN's log)

PC-Link inventory scan classifies 59 devices correctly (4 modules + 55 buttons), `discovered=59`, all-FF terminator drains 32 queued reads at the right boundary — library side is clean. But the integration ends up with **239 entities** because:

1. **`detect_stale_inventory()` is never called.** Zero log lines across the whole ~1h20 capture.
2. **The library's merge is additive.** `Module store merge summary: new=2 refreshed=2` — pre-0.5.13-scan residue persists in `nikobus_module.json` / `nikobus_button.json` indefinitely.
3. **`3D28` (a previous owner's compact switch, not on bus) gets polled 34 times** and times out every cycle from HA startup through end of log.

## Fix

Add `coordinator._reconcile_post_discovery()`, call it from `_handle_discovery_finished` before the auto-reload. Flow follows fdebrus's three-bucket spec from the issue:

```
1. await nikobus_discovery.detect_stale_inventory(timeout=0.6)
   → {checked, present_modules, absent_modules, orphaned_buttons}
2. Drop manifest["absent_modules"] from module_storage["nikobus_module"]
3. Tag every button.status:
     - linked to ≥1 present module     → "active"          (keep, no flag)
     - linked only to absent modules   → "legacy_orphan"   (keep + flag)
     - no linked_modules at all        → "legacy_undecoded" (keep + flag)
4. Save both stores; rebuild dict_module_data; invalidate caches
```

PC-Logic / feedback / audio / interface modules are excluded from probing by the library and stay in the store untouched.

## What surfaces in HA

- **Modules**: residue gets evicted from the store, polling loop stops trying to talk to ghosts on the next cycle.
- **Buttons**: `extra_state_attributes` gains `wall_button_status` when non-default (`legacy_orphan` or `legacy_undecoded`). Users can spot buttons that won't trigger anything by checking the device card — no need to dig through diagnostics.
- **Logs**: one INFO line per scan with the bucket counts + evicted addresses.

## Defensive behaviour

- If the library lacks `detect_stale_inventory` (< 0.5.16), reconciliation is a no-op with a single warning instead of a crash.
- If the probe itself fails (bus busy, comms error, etc.), the exception is logged and swallowed — storage is left untouched rather than half-mutated.

## Tests

11 new tests across two suites:

- `TestReconcilePostDiscovery` (8) — absent-module eviction, the three button buckets, case-insensitive address matching, both no-method + no-discovery skip paths, probe-failure swallow.
- `TestCollectButtonLinkedModules` (3) — pure-function tests for the helper that drives bucket assignment.

`pytest tests/test_coordinator.py::TestDiscoveryFrameRouting tests/test_coordinator.py::TestPurgeInventoryAddresses tests/test_coordinator.py::TestReconcilePostDiscovery tests/test_coordinator.py::TestCollectButtonLinkedModules` → 22 pass.

## Test plan (live)

- [ ] IKIKN re-runs PC-Link inventory on the affected install → log shows `Post-discovery reconciliation: probed=4 present=2 absent=2 evicted=2 | buttons active=N legacy_orphan=M legacy_undecoded=K`.
- [ ] After reload, polling loop no longer tries to reach `3D28`.
- [ ] Entity count drops from 239 toward the expected ~59.
- [ ] Buttons whose `linked_modules` only resolved to evicted addresses show `wall_button_status: legacy_orphan` in their attributes.

## Out of scope (carry-over)

- Repair-issue surface tied to non-zero `legacy_orphan` / `legacy_undecoded` counts (`ISSUE_STALE_INVENTORY_PRESENT` exists in const.py from #323 but isn't wired yet).
- Library-side ergonomics from the issue thread (adding `legacy_undecoded` to the manifest, shipping a `classify_button_status()` helper) — both deferred to nikobus-connect, not blocking this PR.
- PC-Logic LM input button entities, 05-057 channel-3/4 cleanup — independent.

## Diff

`+375 / 0 lines` across 3 files (coordinator + button entity attribute + tests).

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_