### PR TITLE
Overlay legacy module config onto populated Store + always rename

### DIFF
--- a/custom_components/nikobus/nkbmigration.py
+++ b/custom_components/nikobus/nkbmigration.py
@@ -1,10 +1,19 @@
 """One-shot migration from the legacy ``nikobus_module_config.json`` file
 to the ``.storage/nikobus.modules`` Store introduced with nikobus-connect 0.4.0.
 
-The migration only runs when the Store is empty. After a successful convert,
-the source JSON is renamed to ``<name>.migrated`` — never deleted — so users
-retain an escape hatch for one release. Matches the button-side convention
-in ``__init__.py`` (``nikobus_button_config.json`` → ``.migrated``).
+Two flavours, picked by Store state:
+
+* **Empty Store** — full import. The legacy entries replace the empty
+  Store and the source file is renamed to ``.migrated``.
+
+* **Populated Store** — overlay user-editable fields (module / channel
+  descriptions, entity_type, LED triggers, roller travel times) onto
+  matching Store entries by address + channel index. Modules in the
+  legacy file whose addresses aren't in the Store get an INFO log but
+  are skipped — the Store is the authority for what exists. The source
+  file is still renamed afterwards so it stops being a confusing
+  artifact and the rename matches the button-side migration in
+  ``__init__.py`` (``nikobus_button_config.json`` → ``.migrated``).
 """
 
 from __future__ import annotations
@@ -27,6 +36,20 @@ _MIGRATED_SUFFIX = ".migrated"
 # Types the legacy file groups modules under. Anything else is kept verbatim
 # under its own ``module_type`` bucket on the flat entry.
 _OUTPUT_MODULE_TYPES = ("switch_module", "dimmer_module", "roller_module")
+
+# Fields the user can edit via the options flow. Discovery-owned fields
+# (``model``, ``module_type``, ``discovered_info``, channel count) are
+# intentionally NOT in this set — overlaying those would let stale legacy
+# data clobber what discovery just established.
+_USER_MODULE_FIELDS: tuple[str, ...] = ("description",)
+_USER_CHANNEL_FIELDS: tuple[str, ...] = (
+    "description",
+    "entity_type",
+    "led_on",
+    "led_off",
+    "operation_time_up",
+    "operation_time_down",
+)
 
 
 def convert_legacy_to_flat(legacy: dict[str, Any]) -> dict[str, dict[str, Any]]:
@@ -131,26 +154,74 @@ def _convert_channel(module_type: str, channel: dict[str, Any]) -> dict[str, Any
     return out
 
 
+def _overlay_user_fields(
+    store_modules: dict[str, dict[str, Any]],
+    legacy_flat: dict[str, dict[str, Any]],
+) -> tuple[int, int, list[str]]:
+    """Apply user-editable fields from the legacy file onto matching Store entries.
+
+    Returns ``(modules_overlaid, channels_overlaid, no_match)`` where
+    ``no_match`` is the list of legacy addresses with no Store counterpart.
+    Channels are matched by index — legacy channels beyond the Store's
+    channel-count are silently dropped, which is the correct behaviour for
+    cases like the 05-057 channel-3/4 over-count fix.
+    """
+    modules_overlaid = 0
+    channels_overlaid = 0
+    no_match: list[str] = []
+
+    for legacy_addr, legacy_entry in legacy_flat.items():
+        store_entry = store_modules.get(str(legacy_addr).upper())
+        if not isinstance(store_entry, dict):
+            no_match.append(legacy_addr)
+            continue
+
+        modules_overlaid += 1
+        for field in _USER_MODULE_FIELDS:
+            value = legacy_entry.get(field)
+            if value not in (None, ""):
+                store_entry[field] = value
+
+        legacy_channels = legacy_entry.get("channels") or []
+        store_channels = store_entry.get("channels") or []
+        if not isinstance(legacy_channels, list) or not isinstance(store_channels, list):
+            continue
+        for index, legacy_channel in enumerate(legacy_channels):
+            if index >= len(store_channels):
+                # Legacy file claims more channels than discovery — drop the
+                # extras rather than letting them re-introduce phantom
+                # entities (e.g. the 05-057 4→2 channel-count correction).
+                break
+            store_channel = store_channels[index]
+            if not isinstance(legacy_channel, dict) or not isinstance(store_channel, dict):
+                continue
+            for field in _USER_CHANNEL_FIELDS:
+                value = legacy_channel.get(field)
+                if value not in (None, ""):
+                    store_channel[field] = value
+                    channels_overlaid += 1
+
+    return modules_overlaid, channels_overlaid, no_match
+
+
 async def async_migrate_legacy_module_config(
     hass: HomeAssistant, store: NikobusModuleStorage
 ) -> bool:
     """Run the one-shot migration.
 
-    Returns ``True`` when a migration was performed, ``False`` otherwise
-    (store already populated, no legacy file, or file unreadable).
+    Returns ``True`` when something was applied (full import or overlay),
+    ``False`` otherwise (no legacy file present or file unreadable).
 
     Side effects on success:
-      * ``store.data["nikobus_module"]`` is replaced with the converted entries.
-      * ``store.async_save()`` is awaited.
-      * The source file is renamed to ``<config>/<LEGACY_FILENAME>.migrated``.
+      * **Empty Store path** — ``store.data["nikobus_module"]`` is replaced
+        with the converted entries.
+      * **Populated Store path** — user-editable fields from the legacy
+        file are overlaid onto matching Store entries by address + channel
+        index. Discovery-owned fields (``model``, ``module_type``,
+        ``discovered_info``, channel count) are NOT touched.
+      * In both cases ``store.async_save()`` is awaited and the source
+        file is renamed to ``<config>/<LEGACY_FILENAME>.migrated``.
     """
-    if not store.is_empty:
-        _LOGGER.debug(
-            "Module store already populated (%d entries) — skipping legacy migration",
-            len(store.data.get("nikobus_module", {})),
-        )
-        return False
-
     source_path = hass.config.path(LEGACY_FILENAME)
     if not os.path.exists(source_path):
         _LOGGER.debug(
@@ -171,38 +242,64 @@ async def async_migrate_legacy_module_config(
         return False
 
     flat = convert_legacy_to_flat(legacy)
-    if not flat:
-        _LOGGER.info(
-            "Legacy module config at %s contained no convertible entries — "
-            "leaving store empty and renaming the source anyway",
-            source_path,
-        )
-
-    store.data["nikobus_module"] = flat
-    await store.async_save()
-
     backup_path = source_path + _MIGRATED_SUFFIX
+
+    if store.is_empty:
+        if not flat:
+            _LOGGER.info(
+                "Legacy module config at %s contained no convertible entries — "
+                "leaving store empty and renaming the source anyway",
+                source_path,
+            )
+        store.data["nikobus_module"] = flat
+        await store.async_save()
+        _try_rename(source_path, backup_path, len(flat), "imported")
+    else:
+        store_modules = store.data.setdefault("nikobus_module", {})
+        modules_overlaid, channels_overlaid, no_match = _overlay_user_fields(
+            store_modules, flat
+        )
+        if modules_overlaid or channels_overlaid:
+            await store.async_save()
+        _LOGGER.info(
+            "Overlaid user-edited fields from %s onto Store: modules=%d channels=%d "
+            "no_match=%d (Store had %d entries before).",
+            source_path,
+            modules_overlaid,
+            channels_overlaid,
+            len(no_match),
+            len(store_modules),
+        )
+        if no_match:
+            _LOGGER.info(
+                "Legacy addresses with no Store counterpart (skipped): %s",
+                no_match,
+            )
+        _try_rename(source_path, backup_path, modules_overlaid, "overlaid")
+
+    return True
+
+
+def _try_rename(source_path: str, backup_path: str, count: int, action: str) -> None:
+    """Rename the legacy file out of the way; log loudly on failure."""
     try:
         os.replace(source_path, backup_path)
     except OSError as err:
-        # Rename failure is non-fatal — the data is already in the Store.
-        # Log loudly so the user knows the file is still there on disk.
         _LOGGER.warning(
-            "Migrated %d modules to the Store, but could not rename %s to %s: %s. "
-            "The integration will now ignore the source file; you can rename or "
+            "%s %d modules from %s, but could not rename to %s: %s. "
+            "The integration will now ignore the source file; rename or "
             "remove it manually.",
-            len(flat),
+            action.capitalize(),
+            count,
             source_path,
             backup_path,
             err,
         )
-        return True
-
+        return
     _LOGGER.info(
-        "Migrated %d modules from %s to the .storage/nikobus.modules Store. "
-        "Source renamed to %s.",
-        len(flat),
+        "%s %d modules from %s. Source renamed to %s.",
+        action.capitalize(),
+        count,
         source_path,
         backup_path,
     )
-    return True

--- a/tests/test_module_migration.py
+++ b/tests/test_module_migration.py
@@ -263,8 +263,8 @@ class TestMigrationScenarios(unittest.TestCase):
         # Source renamed, not deleted.
         self.assertFalse(os.path.exists(legacy_path))
         self.assertTrue(
-            os.path.exists(legacy_path + ".migrated.bak"),
-            "Source file should be renamed to .migrated.bak",
+            os.path.exists(legacy_path + ".migrated"),
+            "Source file should be renamed to .migrated",
         )
         # Exactly one save call — no double-write.
         self.assertEqual(len(store.saved_snapshots), 1)
@@ -283,17 +283,29 @@ class TestMigrationScenarios(unittest.TestCase):
 
     # -- Scenario C: populated Store + present JSON ----------------------
 
-    def test_skips_when_store_already_populated(self):
+    # -- Scenario C: populated Store + present JSON ----------------------
+    #
+    # Per the discussion on the in-place rename gap: when discovery has
+    # already populated the Store, we no longer bail. Instead we overlay
+    # user-editable fields from the legacy file onto matching entries
+    # (so descriptions, LED triggers, travel times, entity_type carry
+    # over) without touching discovery-owned fields (model, module_type,
+    # channel count). The source file is still renamed afterwards so it
+    # stops being authoritative.
+
+    def test_overlays_module_description_onto_populated_store(self):
         legacy_path = self._write_legacy({
             "switch_module": [
-                {"description": "S1", "address": "C9A5", "channels": []}
+                {"description": "Living Room Lights", "model": "05-000-02",
+                 "address": "C9A5", "channels": []}
             ]
         })
         store = _InMemoryModuleStore({
             "nikobus_module": {
-                "ABCD": {
+                "C9A5": {
                     "module_type": "switch_module",
-                    "description": "user-edited",
+                    "description": "Compact Switch Module (C9A5)",  # discovery default
+                    "model": "05-002-02",  # discovery sets this
                     "channels": [],
                 }
             }
@@ -301,14 +313,154 @@ class TestMigrationScenarios(unittest.TestCase):
 
         migrated = _run(nkbmigration.async_migrate_legacy_module_config(self.hass, store))
 
-        self.assertFalse(migrated)
-        # Store untouched.
-        self.assertIn("ABCD", store.data["nikobus_module"])
-        self.assertNotIn("C9A5", store.data["nikobus_module"])
-        self.assertEqual(store.saved_snapshots, [])
-        # Legacy file left in place for one more release.
-        self.assertTrue(os.path.exists(legacy_path))
-        self.assertFalse(os.path.exists(legacy_path + ".migrated.bak"))
+        self.assertTrue(migrated)
+        entry = store.data["nikobus_module"]["C9A5"]
+        # User-editable field overlaid:
+        self.assertEqual(entry["description"], "Living Room Lights")
+        # Discovery-owned field NOT overwritten by legacy:
+        self.assertEqual(entry["model"], "05-002-02")
+        # File renamed:
+        self.assertFalse(os.path.exists(legacy_path))
+        self.assertTrue(os.path.exists(legacy_path + ".migrated"))
+
+    def test_overlays_channel_user_fields_onto_populated_store(self):
+        legacy_path = self._write_legacy({
+            "switch_module": [{
+                "description": "Kitchen", "address": "AABB",
+                "channels": [
+                    {"description": "Counter", "entity_type": "light",
+                     "led_on": "1A2B3C", "led_off": "4D5E6F"},
+                    {"description": "Pendant"},
+                ],
+            }],
+            "roller_module": [{
+                "description": "Office Blinds", "address": "CCDD",
+                "channels": [
+                    {"description": "South window", "operation_time": "30"},
+                ],
+            }],
+        })
+        store = _InMemoryModuleStore({
+            "nikobus_module": {
+                "AABB": {
+                    "module_type": "switch_module",
+                    "description": "Compact Switch Module",
+                    "channels": [
+                        {"description": "Channel 1"},  # discovery default
+                        {"description": "Channel 2"},
+                    ],
+                },
+                "CCDD": {
+                    "module_type": "roller_module",
+                    "description": "Roller Module",
+                    "channels": [{"description": "Channel 1"}],
+                },
+            }
+        })
+
+        migrated = _run(nkbmigration.async_migrate_legacy_module_config(self.hass, store))
+
+        self.assertTrue(migrated)
+        ch0 = store.data["nikobus_module"]["AABB"]["channels"][0]
+        self.assertEqual(ch0["description"], "Counter")
+        self.assertEqual(ch0["entity_type"], "light")
+        self.assertEqual(ch0["led_on"], "1A2B3C")
+        self.assertEqual(ch0["led_off"], "4D5E6F")
+        # Roller travel time gets split via convert_legacy_to_flat then
+        # overlaid:
+        roller_ch = store.data["nikobus_module"]["CCDD"]["channels"][0]
+        self.assertEqual(roller_ch["operation_time_up"], "30")
+        self.assertEqual(roller_ch["operation_time_down"], "30")
+        self.assertFalse(os.path.exists(legacy_path))
+        self.assertTrue(os.path.exists(legacy_path + ".migrated"))
+
+    def test_legacy_address_not_in_store_is_skipped_not_added(self):
+        legacy_path = self._write_legacy({
+            "switch_module": [
+                {"description": "Ghost", "address": "9999", "channels": []}
+            ]
+        })
+        store = _InMemoryModuleStore({
+            "nikobus_module": {
+                "AABB": {
+                    "module_type": "switch_module",
+                    "description": "Real",
+                    "channels": [],
+                }
+            }
+        })
+
+        migrated = _run(nkbmigration.async_migrate_legacy_module_config(self.hass, store))
+
+        self.assertTrue(migrated)
+        # Ghost address from legacy must NOT land in the Store — discovery
+        # is the source of truth for what exists.
+        self.assertNotIn("9999", store.data["nikobus_module"])
+        self.assertIn("AABB", store.data["nikobus_module"])
+        # File still renamed.
+        self.assertTrue(os.path.exists(legacy_path + ".migrated"))
+
+    def test_legacy_extra_channels_silently_dropped(self):
+        # 05-057 4→2 channel-count correction: legacy says 4 channels,
+        # discovery says 2. Overlay applies to indices 0-1 only; legacy
+        # entries for indices 2-3 are dropped without complaint.
+        self._write_legacy({
+            "switch_module": [{
+                "description": "05-057 device", "address": "1F2E",
+                "channels": [
+                    {"description": "Ch1 user"},
+                    {"description": "Ch2 user"},
+                    {"description": "Ch3 ghost"},
+                    {"description": "Ch4 ghost"},
+                ],
+            }]
+        })
+        store = _InMemoryModuleStore({
+            "nikobus_module": {
+                "1F2E": {
+                    "module_type": "switch_module",
+                    "description": "05-057",
+                    "channels": [
+                        {"description": "Channel 1"},
+                        {"description": "Channel 2"},
+                    ],
+                }
+            }
+        })
+
+        migrated = _run(nkbmigration.async_migrate_legacy_module_config(self.hass, store))
+
+        self.assertTrue(migrated)
+        channels = store.data["nikobus_module"]["1F2E"]["channels"]
+        self.assertEqual(len(channels), 2)
+        self.assertEqual(channels[0]["description"], "Ch1 user")
+        self.assertEqual(channels[1]["description"], "Ch2 user")
+
+    def test_overlay_does_not_clobber_with_empty_legacy_values(self):
+        # If the legacy file has empty-string description for a channel,
+        # don't blow away whatever discovery set.
+        self._write_legacy({
+            "switch_module": [{
+                "description": "Studio", "address": "5678",
+                "channels": [{"description": ""}],
+            }]
+        })
+        store = _InMemoryModuleStore({
+            "nikobus_module": {
+                "5678": {
+                    "module_type": "switch_module",
+                    "description": "Compact",
+                    "channels": [{"description": "discovered ch"}],
+                }
+            }
+        })
+
+        _run(nkbmigration.async_migrate_legacy_module_config(self.hass, store))
+
+        self.assertEqual(
+            store.data["nikobus_module"]["5678"]["channels"][0]["description"],
+            "discovered ch",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`nikobus_button_config.json` and `nikobus_module_config.json` are both legacy 0.x JSON files that the v2 schema migrated into HA's Store. The button-side migration in `__init__.py` runs whenever the file is present and renames it to `.migrated` afterwards. The module-side migration in `nkbmigration.py` bails out with `return False` whenever `.storage/nikobus.modules` has *any* content:

```python
if not store.is_empty:
    _LOGGER.debug("Module store already populated — skipping legacy migration")
    return False
```

Result: a user upgrading with both legacy files present sees only the button file get `.migrated`; the module file sits on disk untouched indefinitely, and any descriptions / LED triggers / travel times the user had set in it never reach the Store entries that discovery just populated.

## Fix

Replace the bail with a dual-path migration:

- **Empty Store + legacy file** → full import as before (no regression).
- **Populated Store + legacy file** → overlay user-editable fields onto matching Store entries by address + channel index. Skip legacy modules whose addresses aren't in the Store.

In both paths the source file is renamed to `.migrated` afterwards so it stops being authoritative — matches the button-side convention.

## What gets overlaid

| Level | Field | Owner |
|---|---|---|
| Module | `description` | user-editable, overlaid |
| Module | `model`, `module_type`, `discovered_info` | discovery-owned, **not** overlaid |
| Channel | `description`, `entity_type`, `led_on`, `led_off`, `operation_time_up`, `operation_time_down` | user-editable, overlaid |
| Channel | channel count | discovery-owned, **not** overlaid (legacy extras dropped) |

The "channel count not overlaid" choice means the 05-057 4→2 channel-count correction silently drops stale legacy channels 3/4 instead of resurrecting them. There's a test pinning that.

## Conflict resolution

Per the design discussion, legacy values always win over Store values on conflict — this is a one-shot overlay on the first run after upgrade. From then on the file is gone (`.migrated`) and options-flow edits stay sticky.

## Tests

12 pass:

- 5 pre-existing `convert_legacy_to_flat` unit tests (unchanged)
- 2 pre-existing scenario tests fixed: `.migrated.bak` typo (suffix is `.migrated`, not `.migrated.bak`) and `test_skips_when_store_already_populated` rewritten
- 5 new overlay-path scenarios:
  - `test_overlays_module_description_onto_populated_store` — module description carries over, `model` doesn't
  - `test_overlays_channel_user_fields_onto_populated_store` — per-channel fields overlay incl. roller travel-time split
  - `test_legacy_address_not_in_store_is_skipped_not_added` — Store stays the authority for what exists
  - `test_legacy_extra_channels_silently_dropped` — 05-057 4→2 correction
  - `test_overlay_does_not_clobber_with_empty_legacy_values` — empty legacy values don't blow away discovery defaults

## Test plan (live)

- [ ] Affected user reloads the integration with both legacy files in `<config>/`.
- [ ] Log shows `Overlaid user-edited fields from <path>: modules=N channels=M no_match=K`.
- [ ] Both legacy files now end in `.migrated`.
- [ ] Module device names in HA reflect the legacy `description` field instead of the discovery-generated default.
- [ ] Channel descriptions / LED triggers / travel times match what was in the legacy file.
- [ ] Diff: `+296 / -47` across 2 files.

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_