### PR TITLE
Replace-with-current-discovery + bump nikobus-connect to 0.5.17

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -1046,10 +1046,20 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         merge. The library merges *additively* (it adds discovered records
         but never evicts), so without this step a previous owner's
         residue (a second-hand PC-Link, a re-keyed install, etc.) would
-        persist forever in the local stores. ``detect_stale_inventory``
-        (nikobus-connect 0.5.16+) probes each output module with a
-        ``$1012`` read; modules that don't ACK get evicted. Buttons are
-        then tagged into one of three buckets:
+        persist forever in the local stores. Two eviction passes run:
+
+        1. **Probe** — ``detect_stale_inventory`` (nikobus-connect
+           0.5.16+) probes each output module with a ``$1012`` read;
+           modules that don't ACK get evicted.
+        2. **Replace-with-current-discovery** — when the user just ran a
+           full PC-Link inventory sweep, any module address absent from
+           the sweep's ``discovered_devices`` is also evicted. This
+           catches residue that ACKs on the bus but is no longer in the
+           PC-Link's active project, which the probe alone can't see —
+           and which entered the store at the read layer once
+           nikobus-connect 0.5.17 dropped its all-FF terminator.
+
+        Buttons are then tagged into one of three buckets:
 
           * ``active`` — at least one ``linked_modules`` entry resolves
             to a present module.
@@ -1079,10 +1089,10 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         present = {str(a).upper() for a in (manifest.get("present_modules") or [])}
         checked = manifest.get("checked") or []
 
-        # Replace-with-current-discovery: drop modules the probe says
-        # aren't on the bus. Other module types (PC-Logic, feedback,
-        # audio, interface) are intentionally excluded by the library
-        # from probing and stay in the store untouched.
+        # Step 1 — probe-based eviction. ``detect_stale_inventory`` only
+        # probes output modules (switch / dimmer / roller); PC-Logic,
+        # feedback, audio and interface modules are skipped by the library
+        # and stay in the store untouched here.
         modules = self.module_storage.data.setdefault("nikobus_module", {})
         evicted: list[str] = []
         for addr in list(modules.keys()):
@@ -1090,7 +1100,36 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 modules.pop(addr, None)
                 evicted.append(str(addr).upper())
 
-        # Tag every physical-button record.
+        # Step 2 — replace-with-current-discovery. Since nikobus-connect
+        # 0.5.17 the PC-Link inventory sweep no longer early-stops on
+        # all-FF blocks, which means residue from previous installs can
+        # enter the store at the read layer. The probe in step 1 only
+        # catches modules that don't ACK on the bus; modules that DO ACK
+        # but aren't in the PC-Link's current project would otherwise
+        # survive forever. Drop any module address absent from the
+        # just-completed sweep — but only when the user actually ran a
+        # full PC-Link sweep, and only when the sweep produced at least
+        # one module (so a failed read can't catastrophically empty the
+        # store).
+        replace_evicted: list[str] = []
+        if self.inventory_query_type == InventoryQueryType.PC_LINK:
+            discovered = getattr(self.nikobus_discovery, "discovered_devices", None)
+            if isinstance(discovered, dict):
+                currently_swept = {
+                    str(addr).upper()
+                    for addr, dev in discovered.items()
+                    if isinstance(dev, dict) and dev.get("category") == "Module"
+                }
+                if currently_swept:
+                    for addr in list(modules.keys()):
+                        if str(addr).upper() not in currently_swept:
+                            modules.pop(addr, None)
+                            replace_evicted.append(str(addr).upper())
+
+        # Tag every physical-button record. ``gone`` covers both eviction
+        # reasons so a button whose only link points at a replace-evicted
+        # module is correctly classified as ``legacy_orphan``.
+        gone = absent | set(replace_evicted)
         bucket_counts = {"active": 0, "legacy_orphan": 0, "legacy_undecoded": 0}
         buttons = self.dict_button_data.setdefault("nikobus_button", {})
         for phys in buttons.values():
@@ -1099,7 +1138,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             linked = self._collect_button_linked_modules(phys)
             if not linked:
                 status = "legacy_undecoded"
-            elif linked.issubset(absent):
+            elif linked.issubset(gone):
                 status = "legacy_orphan"
             else:
                 status = "active"
@@ -1117,18 +1156,25 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self.invalidate_controlled_by_index()
 
         _LOGGER.info(
-            "Post-discovery reconciliation: probed=%d present=%d absent=%d evicted=%d "
+            "Post-discovery reconciliation: probed=%d present=%d absent=%d "
+            "evicted_by_probe=%d evicted_by_sweep=%d "
             "| buttons active=%d legacy_orphan=%d legacy_undecoded=%d",
             len(checked),
             len(present),
             len(absent),
             len(evicted),
+            len(replace_evicted),
             bucket_counts["active"],
             bucket_counts["legacy_orphan"],
             bucket_counts["legacy_undecoded"],
         )
         if evicted:
-            _LOGGER.info("Evicted stale modules: %s", evicted)
+            _LOGGER.info("Evicted stale modules (probe): %s", evicted)
+        if replace_evicted:
+            _LOGGER.info(
+                "Evicted modules absent from current PC-Link sweep: %s",
+                replace_evicted,
+            )
 
     async def _handle_discovery_finished(self) -> None:
         """Signal discovery completion; optionally reload the config entry."""
@@ -1136,11 +1182,11 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self.discovery_sub_phase = DISCOVERY_SUB_PHASE_FINISHED
         self.discovery_register_current = None
 
-        # Replace-with-current-discovery semantics: probe each output
-        # module on the bus, evict any that don't ACK, and tag buttons
-        # by reachability bucket. The library's merge is additive —
-        # without this step pre-0.5.13 residue (issue #319) survives
-        # every subsequent scan.
+        # Two-step residue defence: probe-evict modules that don't ACK,
+        # then (on a full PC-Link sweep) evict anything absent from the
+        # sweep's discovered_devices. The library's merge is additive,
+        # so without this step pre-0.5.13 residue + post-0.5.17 mid-
+        # project FF-gap residue (issue #319) survives every scan.
         await self._reconcile_post_discovery()
 
         self._update_discovery_state(

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.0.16",
+  "version": "2.0.17",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.5.16"
+    "nikobus-connect>=0.5.17"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -539,6 +539,8 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
         buttons: dict | None = None,
         manifest: dict | None = None,
         has_method: bool = True,
+        inventory_query_type=None,
+        discovered_devices: dict | None = None,
     ):
         coord = MagicMock()
         coord.module_storage = MagicMock()
@@ -553,6 +555,10 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
         coord.config_entry.entry_id = "entry_test"
         coord.hass = MagicMock()
         coord.hass.data = {}
+        # Default to None so the replace-with-current-discovery branch is
+        # inert in existing tests; explicit PC_LINK + dict opt-in for the
+        # new tests below.
+        coord.inventory_query_type = inventory_query_type
         if has_method:
             coord.nikobus_discovery = MagicMock()
             coord.nikobus_discovery.detect_stale_inventory = AsyncMock(
@@ -562,6 +568,9 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
                     "absent_modules": [],
                     "orphaned_buttons": [],
                 }
+            )
+            coord.nikobus_discovery.discovered_devices = (
+                dict(discovered_devices) if discovered_devices is not None else None
             )
         else:
             # Library lacks the method (older nikobus-connect): the spec
@@ -728,6 +737,142 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
         # Storage stays untouched on probe failure.
         self.assertIn("AABB", coord.module_storage.data["nikobus_module"])
         coord.module_storage.async_save.assert_not_awaited()
+
+    # ------------------------------------------------------------------
+    # Replace-with-current-discovery semantics (nikobus-connect 0.5.17)
+    # ------------------------------------------------------------------
+
+    async def test_pc_link_sweep_evicts_modules_not_in_discovered_devices(self):
+        # AABB ACKs the probe (so it'd survive step 1) but is no longer
+        # in the PC-Link's current project — discovered_devices doesn't
+        # list it, so step 2 evicts it.
+        coord = self._make_coordinator_stub(
+            modules={
+                "AABB": {"module_type": "switch_module"},
+                "CCDD": {"module_type": "switch_module"},
+            },
+            manifest={
+                "checked": ["AABB", "CCDD"],
+                "present_modules": ["AABB", "CCDD"],
+                "absent_modules": [],
+                "orphaned_buttons": [],
+            },
+            inventory_query_type=InventoryQueryType.PC_LINK,
+            discovered_devices={"CCDD": {"category": "Module"}},
+        )
+
+        await coord._reconcile_post_discovery()
+
+        self.assertNotIn("AABB", coord.module_storage.data["nikobus_module"])
+        self.assertIn("CCDD", coord.module_storage.data["nikobus_module"])
+        coord.module_storage.async_save.assert_awaited_once()
+
+    async def test_module_scan_does_not_evict_modules_not_in_discovered_devices(self):
+        # Same Store + same single-module sweep output, but the user ran
+        # a per-module scan (InventoryQueryType.MODULE), so step 2 must
+        # not fire — otherwise re-scanning one module would wipe the rest.
+        coord = self._make_coordinator_stub(
+            modules={
+                "AABB": {"module_type": "switch_module"},
+                "CCDD": {"module_type": "switch_module"},
+            },
+            manifest={
+                "checked": ["AABB", "CCDD"],
+                "present_modules": ["AABB", "CCDD"],
+                "absent_modules": [],
+                "orphaned_buttons": [],
+            },
+            inventory_query_type=InventoryQueryType.MODULE,
+            discovered_devices={"CCDD": {"category": "Module"}},
+        )
+
+        await coord._reconcile_post_discovery()
+
+        self.assertIn("AABB", coord.module_storage.data["nikobus_module"])
+        self.assertIn("CCDD", coord.module_storage.data["nikobus_module"])
+
+    async def test_empty_discovered_devices_does_not_wipe_store(self):
+        # A failed read produces an empty discovered_devices dict; we
+        # must not interpret that as "the project is empty" and evict
+        # everything. Step 1 still runs normally.
+        coord = self._make_coordinator_stub(
+            modules={
+                "AABB": {"module_type": "switch_module"},
+                "CCDD": {"module_type": "switch_module"},
+            },
+            manifest={
+                "checked": ["AABB", "CCDD"],
+                "present_modules": ["AABB", "CCDD"],
+                "absent_modules": [],
+                "orphaned_buttons": [],
+            },
+            inventory_query_type=InventoryQueryType.PC_LINK,
+            discovered_devices={},
+        )
+
+        await coord._reconcile_post_discovery()
+
+        self.assertIn("AABB", coord.module_storage.data["nikobus_module"])
+        self.assertIn("CCDD", coord.module_storage.data["nikobus_module"])
+
+    async def test_button_linked_only_to_replace_evicted_module_is_legacy_orphan(self):
+        # AABB ACKs the probe but isn't in the current sweep, so step 2
+        # evicts it. A button whose only link points at AABB should be
+        # tagged ``legacy_orphan`` even though AABB never appeared in
+        # the manifest's ``absent_modules`` list.
+        coord = self._make_coordinator_stub(
+            modules={
+                "AABB": {"module_type": "switch_module"},
+                "CCDD": {"module_type": "switch_module"},
+            },
+            buttons={
+                "112233": self._button("AABB"),
+                "445566": self._button("CCDD"),
+            },
+            manifest={
+                "checked": ["AABB", "CCDD"],
+                "present_modules": ["AABB", "CCDD"],
+                "absent_modules": [],
+                "orphaned_buttons": [],
+            },
+            inventory_query_type=InventoryQueryType.PC_LINK,
+            discovered_devices={"CCDD": {"category": "Module"}},
+        )
+
+        await coord._reconcile_post_discovery()
+
+        self.assertEqual(
+            coord.dict_button_data["nikobus_button"]["112233"]["status"],
+            "legacy_orphan",
+        )
+        self.assertEqual(
+            coord.dict_button_data["nikobus_button"]["445566"]["status"],
+            "active",
+        )
+
+    async def test_pc_link_sweep_ignores_non_module_categories(self):
+        # discovered_devices also contains buttons under category="Button".
+        # Only entries with category=="Module" should count toward the
+        # currently-swept set; otherwise a real module that just happens
+        # not to share an address with any button would get wrongly evicted.
+        coord = self._make_coordinator_stub(
+            modules={"AABB": {"module_type": "switch_module"}},
+            manifest={
+                "checked": ["AABB"],
+                "present_modules": ["AABB"],
+                "absent_modules": [],
+                "orphaned_buttons": [],
+            },
+            inventory_query_type=InventoryQueryType.PC_LINK,
+            discovered_devices={
+                "AABB": {"category": "Module"},
+                "FFEE": {"category": "Button"},
+            },
+        )
+
+        await coord._reconcile_post_discovery()
+
+        self.assertIn("AABB", coord.module_storage.data["nikobus_module"])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

`nikobus-connect` 0.5.17 ([PR #52](https://github.com/fdebrus/nikobus-connect/pull/52)) drops the PC-Link inventory all-FF terminator. Necessary fix — the previous behaviour silently dropped real modules sitting past a mid-project FF gap (concrete case: a user with 9 modules where 3 with ~24 named channels were missing from the post-discovery Store). But it also removes a previously-implicit residue defence: the read-layer terminator used to filter records past the last valid block as residue. With it gone, residue records enter the store unfiltered.

PR #324's reconciliation (already on main) calls `detect_stale_inventory` post-discovery and evicts modules whose `$1012` probe didn't ACK. That's strictly weaker than "replace with current PC-Link inventory":

- Module physically on the bus but no longer in the active project → ACKs the probe → survives forever.
- Pre-0.5.13-scan residue already in users' JSON stores → same property if it happens to ACK.

`detect_stale_inventory` alone can't close this gap.

## What this PR does

Adds a **second eviction pass** in `_reconcile_post_discovery`:

```python
if self.inventory_query_type == InventoryQueryType.PC_LINK:
    discovered = getattr(self.nikobus_discovery, "discovered_devices", None)
    if isinstance(discovered, dict):
        currently_swept = {addr for addr, dev in discovered.items()
                           if dev.get("category") == "Module"}
        if currently_swept:
            for addr in list(modules.keys()):
                if addr not in currently_swept:
                    modules.pop(addr)
                    replace_evicted.append(addr)
```

Two safety rails baked in:

| Risk | Guard |
|---|---|
| Per-module rescan would wipe the rest of the store | Gate on `inventory_query_type == PC_LINK` |
| Failed/empty read would catastrophically empty the store | Require non-empty `currently_swept` |

Button bucket assignment now compares `linked_modules` against the union of probe-evictions and sweep-evictions, so a button whose only link points at a sweep-evicted module is correctly classified as `legacy_orphan` (it would otherwise stay `active` because the address never appeared in the manifest's `absent_modules`).

## Tests

13/13 reconciliation tests pass (8 pre-existing + 5 new):

- `test_pc_link_sweep_evicts_modules_not_in_discovered_devices` — happy path
- `test_module_scan_does_not_evict_modules_not_in_discovered_devices` — `MODULE` gate
- `test_empty_discovered_devices_does_not_wipe_store` — failed-read guard
- `test_button_linked_only_to_replace_evicted_module_is_legacy_orphan` — bucketing reflects step-2 evictions
- `test_pc_link_sweep_ignores_non_module_categories` — only `category=="Module"` counts

Pre-existing failures in `TestGetByteArrayState` / `TestSetByteArrayGroupState` / `TestFeedbackCallback` are unrelated to this branch (`_FakeCoord` fixture is missing `_module_states`); confirmed they fail identically on main.

## Other changes

- `manifest.json`: `nikobus-connect>=0.5.16` → `>=0.5.17`, integration version `2.0.16` → `2.0.17`
- Tightened the `_reconcile_post_discovery` docstring to describe both eviction passes
- Replaced the misleading "Replace-with-current-discovery" comment that previously labelled the probe-only block

## Test plan

- [ ] Install on the affected user's setup (the 9-module install): on first reload after upgrade, expect to see in logs `evicted_by_sweep=N` for any modules whose addresses aren't in the current PC-Link project, plus `Evicted modules absent from current PC-Link sweep: [...]`.
- [ ] Re-run a per-module scan (Scan all module links button → single module): no eviction beyond what the probe says (gated by `InventoryQueryType.MODULE`).
- [ ] Force a discovery failure (disconnect mid-sweep): store stays intact (gated by empty `discovered_devices`).

## Independence

- Independent of PR #325 (legacy migration overlay) — both can land in any order.
- Builds on PR #324 (already merged) for the probe + bucket scaffolding.

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_