### PR TITLE
Drop probe timeout override; bump nikobus-connect to 0.5.18

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -1080,7 +1080,13 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             return
 
         try:
-            manifest = await self.nikobus_discovery.detect_stale_inventory(timeout=0.6)
+            # No explicit timeout — defer to the library default. 0.5.18+
+            # raised it to 2.0 s after real-install reports (issue #319,
+            # nikobus-connect#53) showed 0.6 s false-negatives output
+            # modules whose ACK arrives while the bus is still draining
+            # from discovery. Hard-coding 0.6 s here would silently
+            # override that fix.
+            manifest = await self.nikobus_discovery.detect_stale_inventory()
         except Exception as err:  # pragma: no cover - defensive
             _LOGGER.error("detect_stale_inventory probe failed: %s", err)
             return

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.5.17"
+    "nikobus-connect>=0.5.18"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }


### PR DESCRIPTION
## Why

Real-install evidence on the maintainer's own 9-module install (issue #319) shows three output modules — `C9A5` (12-ch switch), `9105` (roller), `8394` (roller) — being silently dropped from the persisted store. Initial diagnosis suggested an HA-side pre-validator was filtering modules; an exhaustive search of the codebase rules that out — there is no separate pre-validator. The only HA-side bus probe is `detect_stale_inventory()` inside `_reconcile_post_discovery`, called with a hard-coded `timeout=0.6`.

That `0.6` was right for `nikobus-connect` 0.5.16's defaults but is wrong now: 0.5.18 ([fdebrus/nikobus-connect#53](https://github.com/fdebrus/nikobus-connect/pull/53)) raises the library's default to 2.0 s after real-install reports showed 0.6 s false-negatives output modules whose ACK lands while the bus is still draining discovery traffic. Hard-coding `0.6` here silently overrides that fix.

## Forensic chain (matches every observed symptom)

1. `merge_discovered_modules` runs on all 9 — proven by the description-suffix gap in the persisted file (`5B05 → switch_module_s2`, `4707 → switch_module_s3` implies an `s1` existed at insert time, even though no surviving module is named `s1`; same pattern for `r1`/`r2` vs the surviving rollers).
2. `_async_on_module_save` saves all 9 to disk transiently.
3. `detect_stale_inventory(timeout=0.6)` — 3 modules ACK fast, 3 ACK slow → manifest reports 3 `absent`.
4. Step-1 eviction pops them from `module_storage.data`.
5. Final `module_storage.async_save()` writes the truncated 6-module file. `_rebuild_dict_module_data` re-syncs the in-memory bucket dict to the truncated state — which is why the "probe-only-saw-3" log lines look like a pre-validator was filtering before the probe.

Maintainer's own quote — *"My new logic validates that each module actually exists on the bus before registering it; otherwise, it gets dropped"* — is PR #324's `_reconcile_post_discovery`, slightly imprecise wording.

## Fix

```diff
# coordinator.py:1083
-    manifest = await self.nikobus_discovery.detect_stale_inventory(timeout=0.6)
+    manifest = await self.nikobus_discovery.detect_stale_inventory()
```

```diff
# manifest.json
-  "version": "2.0.17",
+  "version": "2.0.18",
-    "nikobus-connect>=0.5.17"
+    "nikobus-connect>=0.5.18"
```

The dep pin bump is load-bearing: passing no kwarg to a 0.5.16 install would still inherit its 0.6 s default and reproduce the bug. Only 0.5.18+ has the 2.0 s default that fixes this.

## Tests

13/13 reconciliation tests pass. The suite uses `AsyncMock` for `detect_stale_inventory` and never asserts on call args, so no test changes needed.

```
$ python -m pytest tests/test_coordinator.py::TestReconcilePostDiscovery -q
.............
13 passed in 0.32s
```

## Live test plan

- [ ] Maintainer reloads the 9-module install on this version. Expect log line `Stale-inventory probe | manifest=...` with all 6 output modules in `present_modules`, none in `absent_modules`. The `nikobus.modules` JSON should now contain all 9 entries (3 switch + 1 dimmer + 2 roller + pc_link + pc_logic + feedback).
- [ ] Confirm no `evicted_by_probe` line in the post-discovery log on a healthy install.
- [ ] On an actually-stale install (a module physically removed): probe should still flag it `absent` after 2.0 s and evict it normally.

## Independence

Builds on PRs #324 / #325 / #326 (all already merged). No file conflicts. Independent of any open work.

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_