### PR TITLE
Combined sweep ∪ probe eviction predicate (fix IKIKN 8110 false-eviction)

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -1046,24 +1046,30 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         merge. The library merges *additively* (it adds discovered records
         but never evicts), so without this step a previous owner's
         residue (a second-hand PC-Link, a re-keyed install, etc.) would
-        persist forever in the local stores. Two eviction passes run:
+        persist forever in the local stores.
 
-        1. **Probe** — ``detect_stale_inventory`` (nikobus-connect
-           0.5.16+) probes each output module with a ``$1012`` read;
-           modules that don't ACK get evicted.
-        2. **Replace-with-current-discovery** — when the user just ran a
-           full PC-Link inventory sweep, any module address absent from
-           the sweep's ``discovered_devices`` is also evicted. This
-           catches residue that ACKs on the bus but is no longer in the
-           PC-Link's active project, which the probe alone can't see —
-           and which entered the store at the read layer once
-           nikobus-connect 0.5.17 dropped its all-FF terminator.
+        **Eviction predicate (combined sweep ∪ probe).** A module survives
+        if EITHER the just-completed PC-Link sweep surfaced it OR
+        ``detect_stale_inventory`` reported it as ``present_modules``.
+        Only modules absent from BOTH signals are evicted. This is
+        deliberately conservative: probe-only eviction false-negatived
+        real modules whose ``$1012`` ACK arrived past the timeout on a
+        busy bus (issue #319 — IKIKN's 8110 evicted at 2.0 s with
+        nikobus-connect 0.5.18). Sweep-only eviction would miss residue
+        that's wired and ACKs but no longer in the PC-Link's project.
+
+        Eviction only runs when the user just performed a full PC-Link
+        sweep (``InventoryQueryType.PC_LINK``) AND the sweep produced at
+        least one module. Per-module scans never trigger eviction —
+        their ``discovered_devices`` only covers a single address, so
+        applying sweep-based logic would catastrophically drop the rest
+        of the store.
 
         Buttons are then tagged into one of three buckets:
 
           * ``active`` — at least one ``linked_modules`` entry resolves
-            to a present module.
-          * ``legacy_orphan`` — every linked module is in the absent set.
+            to a surviving module.
+          * ``legacy_orphan`` — every linked module was evicted.
           * ``legacy_undecoded`` — no ``linked_modules`` survived the
             scan (decoder may catch up later; flag surfaces it).
 
@@ -1095,29 +1101,9 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         present = {str(a).upper() for a in (manifest.get("present_modules") or [])}
         checked = manifest.get("checked") or []
 
-        # Step 1 — probe-based eviction. ``detect_stale_inventory`` only
-        # probes output modules (switch / dimmer / roller); PC-Logic,
-        # feedback, audio and interface modules are skipped by the library
-        # and stay in the store untouched here.
-        modules = self.module_storage.data.setdefault("nikobus_module", {})
-        evicted: list[str] = []
-        for addr in list(modules.keys()):
-            if str(addr).upper() in absent:
-                modules.pop(addr, None)
-                evicted.append(str(addr).upper())
-
-        # Step 2 — replace-with-current-discovery. Since nikobus-connect
-        # 0.5.17 the PC-Link inventory sweep no longer early-stops on
-        # all-FF blocks, which means residue from previous installs can
-        # enter the store at the read layer. The probe in step 1 only
-        # catches modules that don't ACK on the bus; modules that DO ACK
-        # but aren't in the PC-Link's current project would otherwise
-        # survive forever. Drop any module address absent from the
-        # just-completed sweep — but only when the user actually ran a
-        # full PC-Link sweep, and only when the sweep produced at least
-        # one module (so a failed read can't catastrophically empty the
-        # store).
-        replace_evicted: list[str] = []
+        # Snapshot the current PC-Link sweep, when applicable. Empty for
+        # per-module scans — eviction is gated on a non-empty value.
+        currently_swept: set[str] = set()
         if self.inventory_query_type == InventoryQueryType.PC_LINK:
             discovered = getattr(self.nikobus_discovery, "discovered_devices", None)
             if isinstance(discovered, dict):
@@ -1126,16 +1112,21 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                     for addr, dev in discovered.items()
                     if isinstance(dev, dict) and dev.get("category") == "Module"
                 }
-                if currently_swept:
-                    for addr in list(modules.keys()):
-                        if str(addr).upper() not in currently_swept:
-                            modules.pop(addr, None)
-                            replace_evicted.append(str(addr).upper())
 
-        # Tag every physical-button record. ``gone`` covers both eviction
-        # reasons so a button whose only link points at a replace-evicted
-        # module is correctly classified as ``legacy_orphan``.
-        gone = absent | set(replace_evicted)
+        modules = self.module_storage.data.setdefault("nikobus_module", {})
+        evicted: list[str] = []
+
+        if currently_swept:
+            # Combined predicate: keep if EITHER signal says "real".
+            keep = currently_swept | present
+            for addr in list(modules.keys()):
+                if str(addr).upper() not in keep:
+                    modules.pop(addr, None)
+                    evicted.append(str(addr).upper())
+
+        # Tag every physical-button record. A button is orphaned only
+        # when none of its linked modules survived eviction.
+        remaining = {str(a).upper() for a in modules.keys()}
         bucket_counts = {"active": 0, "legacy_orphan": 0, "legacy_undecoded": 0}
         buttons = self.dict_button_data.setdefault("nikobus_button", {})
         for phys in buttons.values():
@@ -1144,7 +1135,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             linked = self._collect_button_linked_modules(phys)
             if not linked:
                 status = "legacy_undecoded"
-            elif linked.issubset(gone):
+            elif not (linked & remaining):
                 status = "legacy_orphan"
             else:
                 status = "active"
@@ -1163,23 +1154,20 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
 
         _LOGGER.info(
             "Post-discovery reconciliation: probed=%d present=%d absent=%d "
-            "evicted_by_probe=%d evicted_by_sweep=%d "
-            "| buttons active=%d legacy_orphan=%d legacy_undecoded=%d",
+            "swept=%d evicted=%d | buttons active=%d legacy_orphan=%d "
+            "legacy_undecoded=%d",
             len(checked),
             len(present),
             len(absent),
+            len(currently_swept),
             len(evicted),
-            len(replace_evicted),
             bucket_counts["active"],
             bucket_counts["legacy_orphan"],
             bucket_counts["legacy_undecoded"],
         )
         if evicted:
-            _LOGGER.info("Evicted stale modules (probe): %s", evicted)
-        if replace_evicted:
             _LOGGER.info(
-                "Evicted modules absent from current PC-Link sweep: %s",
-                replace_evicted,
+                "Evicted modules (absent from sweep AND probe): %s", evicted
             )
 
     async def _handle_discovery_finished(self) -> None:
@@ -1188,11 +1176,11 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self.discovery_sub_phase = DISCOVERY_SUB_PHASE_FINISHED
         self.discovery_register_current = None
 
-        # Two-step residue defence: probe-evict modules that don't ACK,
-        # then (on a full PC-Link sweep) evict anything absent from the
-        # sweep's discovered_devices. The library's merge is additive,
-        # so without this step pre-0.5.13 residue + post-0.5.17 mid-
-        # project FF-gap residue (issue #319) survives every scan.
+        # Combined sweep ∪ probe residue defence: a module survives if
+        # the just-completed PC-Link sweep surfaced it OR the bus probe
+        # ACKed it. Only modules absent from BOTH signals are evicted.
+        # Probe-only eviction false-negatived real modules at 2.0 s on
+        # busy buses (issue #319 — IKIKN's 8110 evicted on 2.0.18).
         await self._reconcile_post_discovery()
 
         self._update_discovery_state(

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.0.18",
+  "version": "2.0.19",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -605,6 +605,8 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
         return {"type": "Button", "operation_points": op_points}
 
     async def test_absent_module_is_evicted_from_store(self):
+        # Combined predicate: CCDD is absent from BOTH the sweep and the
+        # probe → evicted. AABB is in the sweep → kept.
         coord = self._make_coordinator_stub(
             modules={"AABB": {"module_type": "switch_module"},
                      "CCDD": {"module_type": "dimmer_module"}},
@@ -614,6 +616,8 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
                 "absent_modules": ["CCDD"],
                 "orphaned_buttons": [],
             },
+            inventory_query_type=InventoryQueryType.PC_LINK,
+            discovered_devices={"AABB": {"category": "Module"}},
         )
 
         await coord._reconcile_post_discovery()
@@ -624,15 +628,19 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
         coord.button_storage.async_save.assert_awaited_once()
 
     async def test_button_linked_to_absent_module_only_is_legacy_orphan(self):
+        # CCDD is absent from BOTH sweep and probe → evicted. The button
+        # only linked to CCDD has zero remaining links → legacy_orphan.
         coord = self._make_coordinator_stub(
             modules={"AABB": {"module_type": "switch_module"}},
-            buttons={"112233": self._button("CCDD")},  # CCDD will be absent
+            buttons={"112233": self._button("CCDD")},
             manifest={
                 "checked": ["AABB", "CCDD"],
                 "present_modules": ["AABB"],
                 "absent_modules": ["CCDD"],
                 "orphaned_buttons": ["112233"],
             },
+            inventory_query_type=InventoryQueryType.PC_LINK,
+            discovered_devices={"AABB": {"category": "Module"}},
         )
 
         await coord._reconcile_post_discovery()
@@ -662,10 +670,11 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
         )
 
     async def test_button_with_at_least_one_present_link_is_active(self):
+        # Button linked to AABB (in sweep, kept) + CCDD (absent in both,
+        # evicted). At least one link survives → active.
         coord = self._make_coordinator_stub(
             modules={"AABB": {"module_type": "switch_module"},
                      "CCDD": {"module_type": "switch_module"}},
-            # Linked to one absent + one present module → still active.
             buttons={"112233": self._button("AABB", "CCDD")},
             manifest={
                 "checked": ["AABB", "CCDD"],
@@ -673,6 +682,8 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
                 "absent_modules": ["CCDD"],
                 "orphaned_buttons": [],
             },
+            inventory_query_type=InventoryQueryType.PC_LINK,
+            discovered_devices={"AABB": {"category": "Module"}},
         )
 
         await coord._reconcile_post_discovery()
@@ -684,7 +695,8 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
 
     async def test_module_address_comparison_is_case_insensitive(self):
         # Storage might hold lowercase addresses (legacy data); manifest
-        # always returns upper-case. Reconciliation must still match.
+        # and discovered_devices are upper-case. Reconciliation must
+        # still match — combined predicate keeps that contract.
         coord = self._make_coordinator_stub(
             modules={"aabb": {"module_type": "switch_module"}},
             manifest={
@@ -693,11 +705,17 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
                 "absent_modules": ["AABB"],
                 "orphaned_buttons": [],
             },
+            inventory_query_type=InventoryQueryType.PC_LINK,
+            # Sweep needs to be non-empty for eviction to fire; pin a
+            # different address so the lower-case 'aabb' is the one
+            # being tested for case-insensitive eviction.
+            discovered_devices={"FFFF": {"category": "Module"}},
         )
 
         await coord._reconcile_post_discovery()
 
-        self.assertEqual(coord.module_storage.data["nikobus_module"], {})
+        self.assertNotIn("aabb", coord.module_storage.data["nikobus_module"])
+        self.assertNotIn("AABB", coord.module_storage.data["nikobus_module"])
 
     async def test_skips_when_library_lacks_detect_method(self):
         coord = self._make_coordinator_stub(
@@ -739,33 +757,75 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
         coord.module_storage.async_save.assert_not_awaited()
 
     # ------------------------------------------------------------------
-    # Replace-with-current-discovery semantics (nikobus-connect 0.5.17)
+    # Combined sweep ∪ probe predicate (issue #319 regression set)
     # ------------------------------------------------------------------
 
-    async def test_pc_link_sweep_evicts_modules_not_in_discovered_devices(self):
-        # AABB ACKs the probe (so it'd survive step 1) but is no longer
-        # in the PC-Link's current project — discovered_devices doesn't
-        # list it, so step 2 evicts it.
+    async def test_module_in_sweep_with_probe_timeout_is_kept(self):
+        # IKIKN's 8110 regression: real switch_module surfaced by the
+        # PC-Link inventory sweep, but its $1012 ACK arrived past the
+        # probe's 2.0 s timeout. Probe reports it as ``absent``. Under
+        # the combined predicate, sweep presence is sufficient to keep
+        # the module — probe timeout alone must NOT evict.
         coord = self._make_coordinator_stub(
-            modules={
-                "AABB": {"module_type": "switch_module"},
-                "CCDD": {"module_type": "switch_module"},
-            },
+            modules={"8110": {"module_type": "switch_module"}},
             manifest={
-                "checked": ["AABB", "CCDD"],
-                "present_modules": ["AABB", "CCDD"],
-                "absent_modules": [],
+                "checked": ["8110"],
+                "present_modules": [],
+                "absent_modules": ["8110"],
                 "orphaned_buttons": [],
             },
             inventory_query_type=InventoryQueryType.PC_LINK,
-            discovered_devices={"CCDD": {"category": "Module"}},
+            discovered_devices={"8110": {"category": "Module"}},
         )
 
         await coord._reconcile_post_discovery()
 
-        self.assertNotIn("AABB", coord.module_storage.data["nikobus_module"])
-        self.assertIn("CCDD", coord.module_storage.data["nikobus_module"])
-        coord.module_storage.async_save.assert_awaited_once()
+        self.assertIn("8110", coord.module_storage.data["nikobus_module"])
+
+    async def test_module_only_in_probe_present_is_kept(self):
+        # Edge case: module wired and ACKing the bus, but not in the
+        # current PC-Link project (so absent from the sweep). Combined
+        # predicate keeps it — user can purge_stale_inventory if they
+        # want it gone.
+        coord = self._make_coordinator_stub(
+            modules={"7777": {"module_type": "switch_module"}},
+            manifest={
+                "checked": ["7777"],
+                "present_modules": ["7777"],
+                "absent_modules": [],
+                "orphaned_buttons": [],
+            },
+            inventory_query_type=InventoryQueryType.PC_LINK,
+            # Sweep contains a different module so eviction-step is
+            # eligible to fire; 7777 is missing from it.
+            discovered_devices={"AAAA": {"category": "Module"}},
+        )
+
+        await coord._reconcile_post_discovery()
+
+        self.assertIn("7777", coord.module_storage.data["nikobus_module"])
+
+    async def test_module_in_neither_sweep_nor_probe_present_is_evicted(self):
+        # IKIKN's 3D28: the previous owner's residue. Not in current
+        # sweep, doesn't ACK probe → evicted. The intended behaviour
+        # of post-discovery reconciliation.
+        coord = self._make_coordinator_stub(
+            modules={"3D28": {"module_type": "switch_module"},
+                     "AABB": {"module_type": "switch_module"}},
+            manifest={
+                "checked": ["3D28", "AABB"],
+                "present_modules": ["AABB"],
+                "absent_modules": ["3D28"],
+                "orphaned_buttons": [],
+            },
+            inventory_query_type=InventoryQueryType.PC_LINK,
+            discovered_devices={"AABB": {"category": "Module"}},
+        )
+
+        await coord._reconcile_post_discovery()
+
+        self.assertNotIn("3D28", coord.module_storage.data["nikobus_module"])
+        self.assertIn("AABB", coord.module_storage.data["nikobus_module"])
 
     async def test_module_scan_does_not_evict_modules_not_in_discovered_devices(self):
         # Same Store + same single-module sweep output, but the user ran
@@ -814,41 +874,6 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
 
         self.assertIn("AABB", coord.module_storage.data["nikobus_module"])
         self.assertIn("CCDD", coord.module_storage.data["nikobus_module"])
-
-    async def test_button_linked_only_to_replace_evicted_module_is_legacy_orphan(self):
-        # AABB ACKs the probe but isn't in the current sweep, so step 2
-        # evicts it. A button whose only link points at AABB should be
-        # tagged ``legacy_orphan`` even though AABB never appeared in
-        # the manifest's ``absent_modules`` list.
-        coord = self._make_coordinator_stub(
-            modules={
-                "AABB": {"module_type": "switch_module"},
-                "CCDD": {"module_type": "switch_module"},
-            },
-            buttons={
-                "112233": self._button("AABB"),
-                "445566": self._button("CCDD"),
-            },
-            manifest={
-                "checked": ["AABB", "CCDD"],
-                "present_modules": ["AABB", "CCDD"],
-                "absent_modules": [],
-                "orphaned_buttons": [],
-            },
-            inventory_query_type=InventoryQueryType.PC_LINK,
-            discovered_devices={"CCDD": {"category": "Module"}},
-        )
-
-        await coord._reconcile_post_discovery()
-
-        self.assertEqual(
-            coord.dict_button_data["nikobus_button"]["112233"]["status"],
-            "legacy_orphan",
-        )
-        self.assertEqual(
-            coord.dict_button_data["nikobus_button"]["445566"]["status"],
-            "active",
-        )
 
     async def test_pc_link_sweep_ignores_non_module_categories(self):
         # discovered_devices also contains buttons under category="Button".


### PR DESCRIPTION
## Why

IKIKN's 2.0.18 log on issue #319 shows a real switch module being false-evicted because its probe ACK didn't arrive within the 2 s timeout:

```
09:10:54.673  Discovered Module - Switching module 05-000-02 at Address: 8110
                              ↑ library decoded its $2E reply byte-for-byte
09:11:18.842  Bus presence probe | addr=1CEC status=present
09:11:20.843  Bus presence probe | addr=3D28 status=absent reason=timeout
09:11:22.844  Bus presence probe | addr=8110 status=absent reason=timeout
09:11:22.855  Evicted stale modules (probe): ['8110', '3D28']
                              ↑ 8110 is real, 3D28 is residue — both dropped
```

8110 is physically present. 3D28 is the previous owner's residue. The current step-1 probe-based eviction can't tell them apart.

Bumping the timeout further is structurally fragile — busy buses can push real ACKs past any deadline. The right fix is to **trust either signal** (sweep or probe), and only evict modules absent from both.

## Fix

Replace the two-step eviction with a single combined predicate:

```python
keep   = currently_swept ∪ probe_present     # union — either signal counts
evict  = store \ keep
```

Outcomes for the two real-install regressions:

| Module | Sweep | Probe | Old (2.0.18) | This PR |
|---|---|---|---|---|
| IKIKN 8110 (real switch) | ✓ in | ✗ timeout | **evicted** | **kept** ✓ |
| IKIKN 3D28 (residue) | ✗ not in | ✗ timeout | evicted | evicted ✓ |
| fdebrus C9A5 (real switch) | ✓ in | ✗ timeout @ 0.6s | (was evicted on 2.0.16) | kept ✓ |
| 1CEC (real, fast probe) | ✓ in | ✓ present | kept | kept ✓ |

Eviction stays gated on a non-empty PC-Link sweep — per-module scans never trigger eviction. Buttons are now bucketed against the post-eviction Store directly (`legacy_orphan` only when none of the linked modules survived).

## Tests

14/14 reconciliation tests pass.

- 4 pre-existing tests updated: they relied on probe-only eviction; now stub PC_LINK sweep + missing-from-`discovered_devices` to trigger the combined eviction.
- 1 test removed (`test_button_linked_only_to_replace_evicted_module_is_legacy_orphan`) — its premise (step-2 evicts probe-ACK modules) is the exact regression this PR fixes.
- 3 regression pins added:
  - `test_module_in_sweep_with_probe_timeout_is_kept` (IKIKN 8110)
  - `test_module_only_in_probe_present_is_kept` (rare edge case: physically present but not in PC-Link's active project)
  - `test_module_in_neither_sweep_nor_probe_present_is_evicted` (3D28)

```
$ python -m pytest tests/test_coordinator.py::TestReconcilePostDiscovery -q
..............
14 passed in 0.29s
```

## Live test plan (IKIKN install)

- [ ] Reload the integration on 2.0.19. Expect log line `Post-discovery reconciliation: probed=3 present=1 absent=2 swept=3 evicted=1 | buttons active=0 legacy_orphan=0 legacy_undecoded=51` and `Evicted modules (absent from sweep AND probe): ['3D28']`.
- [ ] `nikobus.modules` JSON now contains 3 modules: 823D (pc_link), 8110 (switch), 1CEC (compact switch). 3D28 gone.
- [ ] No `Error refreshing 8110 group ...` in subsequent polling cycles.
- [ ] Stage-2 module scan still needed to populate `linked_modules` on the 51 buttons (they'll keep `legacy_undecoded` until then — separate from this PR).

## Independence

Builds on PRs #324 / #325 / #326 / #327 (all merged). No file conflicts.

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_