### PR TITLE
Snapshot sweep before probe + HA-side retry loop (issue #319)

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -68,6 +68,15 @@ _LOGGER = logging.getLogger(__name__)
 # Module types supported for polling
 MODULE_TYPES = ("switch_module", "dimmer_module", "roller_module")
 
+# Post-discovery reconciliation: outer probe loop. ``detect_stale_inventory``
+# already does N internal retries per address (library 0.5.19: attempts=3),
+# but on heavily-loaded buses (issue #319 — IKIKN's install) those back-to-
+# back attempts all fail because the bus is still draining post-discovery
+# traffic. The HA-side outer loop re-calls the probe after a bus-quiet
+# delay so slow-but-real modules get a second chance.
+_PROBE_RETRY_ATTEMPTS = 2
+_PROBE_RETRY_DELAY_S = 3.0
+
 
 class NikobusDataCoordinator(DataUpdateCoordinator[None]):
     """Coordinator for managing asynchronous updates and connections to Nikobus."""
@@ -1048,22 +1057,33 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         residue (a second-hand PC-Link, a re-keyed install, etc.) would
         persist forever in the local stores.
 
-        **Eviction predicate (combined sweep ∪ probe).** A module survives
-        if EITHER the just-completed PC-Link sweep surfaced it OR
-        ``detect_stale_inventory`` reported it as ``present_modules``.
-        Only modules absent from BOTH signals are evicted. This is
-        deliberately conservative: probe-only eviction false-negatived
-        real modules whose ``$1012`` ACK arrived past the timeout on a
-        busy bus (issue #319 — IKIKN's 8110 evicted at 2.0 s with
-        nikobus-connect 0.5.18). Sweep-only eviction would miss residue
-        that's wired and ACKs but no longer in the PC-Link's project.
+        **Sweep snapshot before await.** ``inventory_query_type`` and
+        ``discovered_devices`` are captured *before* awaiting the probe
+        because the library resets both during the probe phase. Reading
+        them afterwards yields stale data — concretely, IKIKN's 2.0.19
+        log showed ``swept=0`` even though the library had just dumped
+        4 modules in ``discovered_devices`` a millisecond before
+        ``on_discovery_finished`` fired (issue #319).
+
+        **Eviction predicate.** A module survives if any of:
+
+          * It ACKed the probe in at least one retry attempt
+            (``present_anywhere``), OR
+          * It's in the just-completed PC-Link sweep AND didn't fail
+            every retry attempt (``currently_swept - absent_everywhere``).
+
+        Phrased the other way: a module is evicted iff it fails every
+        probe attempt AND isn't kept by any other signal. The retry
+        loop runs ``detect_stale_inventory`` up to N times with a
+        bus-quiet delay between attempts — modules whose ACK is delayed
+        by sustained bus contention (IKIKN's 8110: real switch_module,
+        timed out 3× internal library retries on first call) get a
+        second chance once discovery traffic has fully drained.
 
         Eviction only runs when the user just performed a full PC-Link
-        sweep (``InventoryQueryType.PC_LINK``) AND the sweep produced at
+        sweep (``InventoryQueryType.PC_LINK``) and the sweep produced at
         least one module. Per-module scans never trigger eviction —
-        their ``discovered_devices`` only covers a single address, so
-        applying sweep-based logic would catastrophically drop the rest
-        of the store.
+        their ``discovered_devices`` only covers a single address.
 
         Buttons are then tagged into one of three buckets:
 
@@ -1085,24 +1105,11 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             )
             return
 
-        try:
-            # No explicit timeout — defer to the library default. 0.5.18+
-            # raised it to 2.0 s after real-install reports (issue #319,
-            # nikobus-connect#53) showed 0.6 s false-negatives output
-            # modules whose ACK arrives while the bus is still draining
-            # from discovery. Hard-coding 0.6 s here would silently
-            # override that fix.
-            manifest = await self.nikobus_discovery.detect_stale_inventory()
-        except Exception as err:  # pragma: no cover - defensive
-            _LOGGER.error("detect_stale_inventory probe failed: %s", err)
-            return
-
-        absent = {str(a).upper() for a in (manifest.get("absent_modules") or [])}
-        present = {str(a).upper() for a in (manifest.get("present_modules") or [])}
-        checked = manifest.get("checked") or []
-
-        # Snapshot the current PC-Link sweep, when applicable. Empty for
-        # per-module scans — eviction is gated on a non-empty value.
+        # --- Snapshot BEFORE the probe await --------------------------
+        # The library resets ``inventory_query_type`` and/or
+        # ``discovered_devices`` while ``detect_stale_inventory`` runs,
+        # so we capture the sweep state up-front. Reading them after
+        # the probe yields an empty set on every install (issue #319).
         currently_swept: set[str] = set()
         if self.inventory_query_type == InventoryQueryType.PC_LINK:
             discovered = getattr(self.nikobus_discovery, "discovered_devices", None)
@@ -1113,19 +1120,70 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                     if isinstance(dev, dict) and dev.get("category") == "Module"
                 }
 
+        # --- Probe with HA-side retries -------------------------------
+        # The library does N internal retries per probe (attempts=3 in
+        # 0.5.19), but on heavily-loaded buses even three back-to-back
+        # attempts can all fail when the bus is still draining post-
+        # discovery traffic. We re-call detect_stale_inventory after a
+        # bus-quiet delay; a module counts as "present" if it ACKed in
+        # ANY outer attempt.
+        present_anywhere: set[str] = set()
+        checked_addrs: set[str] = set()
+        manifest: dict = {}
+
+        for attempt in range(1, _PROBE_RETRY_ATTEMPTS + 1):
+            try:
+                manifest = await self.nikobus_discovery.detect_stale_inventory()
+            except Exception as err:  # pragma: no cover - defensive
+                _LOGGER.error(
+                    "detect_stale_inventory attempt %d/%d failed: %s",
+                    attempt,
+                    _PROBE_RETRY_ATTEMPTS,
+                    err,
+                )
+                if attempt == 1:
+                    return  # nothing to act on — bail
+                break
+
+            attempt_present = {
+                str(a).upper() for a in (manifest.get("present_modules") or [])
+            }
+            attempt_checked = {
+                str(a).upper() for a in (manifest.get("checked") or [])
+            }
+            present_anywhere |= attempt_present
+            checked_addrs |= attempt_checked
+
+            # Early exit: every probed module has ACKed by now.
+            if not (checked_addrs - present_anywhere):
+                break
+            if attempt < _PROBE_RETRY_ATTEMPTS:
+                _LOGGER.debug(
+                    "detect_stale_inventory attempt %d: %d module(s) still "
+                    "unconfirmed; waiting %.1fs for bus to quiesce before retry",
+                    attempt,
+                    len(checked_addrs - present_anywhere),
+                    _PROBE_RETRY_DELAY_S,
+                )
+                await asyncio.sleep(_PROBE_RETRY_DELAY_S)
+
+        absent_everywhere = checked_addrs - present_anywhere
+        # Use the last manifest for "this attempt's" log counts; the
+        # combined predicate uses the union/intersection across attempts.
+        absent_last = {str(a).upper() for a in (manifest.get("absent_modules") or [])}
+        checked_last = manifest.get("checked") or []
+
+        # --- Eviction --------------------------------------------------
         modules = self.module_storage.data.setdefault("nikobus_module", {})
         evicted: list[str] = []
-
         if currently_swept:
-            # Combined predicate: keep if EITHER signal says "real".
-            keep = currently_swept | present
+            keep = present_anywhere | (currently_swept - absent_everywhere)
             for addr in list(modules.keys()):
                 if str(addr).upper() not in keep:
                     modules.pop(addr, None)
                     evicted.append(str(addr).upper())
 
-        # Tag every physical-button record. A button is orphaned only
-        # when none of its linked modules survived eviction.
+        # --- Button bucketing ----------------------------------------
         remaining = {str(a).upper() for a in modules.keys()}
         bucket_counts = {"active": 0, "legacy_orphan": 0, "legacy_undecoded": 0}
         buttons = self.dict_button_data.setdefault("nikobus_button", {})
@@ -1153,12 +1211,12 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self.invalidate_controlled_by_index()
 
         _LOGGER.info(
-            "Post-discovery reconciliation: probed=%d present=%d absent=%d "
-            "swept=%d evicted=%d | buttons active=%d legacy_orphan=%d "
-            "legacy_undecoded=%d",
-            len(checked),
-            len(present),
-            len(absent),
+            "Post-discovery reconciliation: probed=%d present_anywhere=%d "
+            "absent_everywhere=%d swept=%d evicted=%d | buttons active=%d "
+            "legacy_orphan=%d legacy_undecoded=%d",
+            len(checked_last),
+            len(present_anywhere),
+            len(absent_everywhere),
             len(currently_swept),
             len(evicted),
             bucket_counts["active"],
@@ -1167,7 +1225,8 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         )
         if evicted:
             _LOGGER.info(
-                "Evicted modules (absent from sweep AND probe): %s", evicted
+                "Evicted modules (failed every probe attempt AND not "
+                "kept by sweep): %s", evicted
             )
 
     async def _handle_discovery_finished(self) -> None:
@@ -1176,11 +1235,11 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self.discovery_sub_phase = DISCOVERY_SUB_PHASE_FINISHED
         self.discovery_register_current = None
 
-        # Combined sweep ∪ probe residue defence: a module survives if
-        # the just-completed PC-Link sweep surfaced it OR the bus probe
-        # ACKed it. Only modules absent from BOTH signals are evicted.
-        # Probe-only eviction false-negatived real modules at 2.0 s on
-        # busy buses (issue #319 — IKIKN's 8110 evicted on 2.0.18).
+        # Residue defence: snapshot the sweep state BEFORE awaiting the
+        # probe (library resets it during the await), then probe with
+        # HA-side retries so slow-but-real modules get a second chance
+        # once the bus has quiesced. Evict only modules that fail every
+        # probe attempt AND aren't kept by the snapshotted sweep.
         await self._reconcile_post_discovery()
 
         self._update_discovery_state(

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -532,12 +532,27 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
     ``legacy_undecoded``.
     """
 
+    async def asyncSetUp(self) -> None:
+        # The reconciliation retry loop sleeps _PROBE_RETRY_DELAY_S
+        # between attempts. Skip the real wait in tests — assertions
+        # only care about predicate behaviour, not wallclock.
+        self._sleep_patcher = patch(
+            "custom_components.nikobus.coordinator.asyncio.sleep",
+            new=AsyncMock(),
+        )
+        self._sleep_patcher.start()
+        self.addAsyncCleanup(self._stop_sleep_patcher)
+
+    async def _stop_sleep_patcher(self) -> None:
+        self._sleep_patcher.stop()
+
     def _make_coordinator_stub(
         self,
         *,
         modules: dict | None = None,
         buttons: dict | None = None,
         manifest: dict | None = None,
+        manifest_sequence: list[dict] | None = None,
         has_method: bool = True,
         inventory_query_type=None,
         discovered_devices: dict | None = None,
@@ -555,20 +570,27 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
         coord.config_entry.entry_id = "entry_test"
         coord.hass = MagicMock()
         coord.hass.data = {}
-        # Default to None so the replace-with-current-discovery branch is
-        # inert in existing tests; explicit PC_LINK + dict opt-in for the
-        # new tests below.
+        # Default to None so the eviction branch is inert in existing
+        # tests; explicit PC_LINK + dict opt-in for the new tests below.
         coord.inventory_query_type = inventory_query_type
         if has_method:
             coord.nikobus_discovery = MagicMock()
-            coord.nikobus_discovery.detect_stale_inventory = AsyncMock(
-                return_value=manifest or {
-                    "checked": [],
-                    "present_modules": [],
-                    "absent_modules": [],
-                    "orphaned_buttons": [],
-                }
-            )
+            default_manifest = manifest or {
+                "checked": [],
+                "present_modules": [],
+                "absent_modules": [],
+                "orphaned_buttons": [],
+            }
+            if manifest_sequence is not None:
+                # Each retry attempt gets its own manifest. AsyncMock with
+                # side_effect=list yields the next value per call.
+                coord.nikobus_discovery.detect_stale_inventory = AsyncMock(
+                    side_effect=list(manifest_sequence)
+                )
+            else:
+                coord.nikobus_discovery.detect_stale_inventory = AsyncMock(
+                    return_value=default_manifest
+                )
             coord.nikobus_discovery.discovered_devices = (
                 dict(discovered_devices) if discovered_devices is not None else None
             )
@@ -760,20 +782,30 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
     # Combined sweep ∪ probe predicate (issue #319 regression set)
     # ------------------------------------------------------------------
 
-    async def test_module_in_sweep_with_probe_timeout_is_kept(self):
-        # IKIKN's 8110 regression: real switch_module surfaced by the
-        # PC-Link inventory sweep, but its $1012 ACK arrived past the
-        # probe's 2.0 s timeout. Probe reports it as ``absent``. Under
-        # the combined predicate, sweep presence is sufficient to keep
-        # the module — probe timeout alone must NOT evict.
+    async def test_retry_recovers_slow_module(self):
+        # IKIKN's 8110: real switch_module that fails the first probe
+        # call (bus still draining post-discovery) but ACKs on the
+        # retry after the bus-quiet delay. Module is in sweep, so the
+        # second attempt's ``present`` adds it to present_anywhere
+        # and the predicate keeps it.
         coord = self._make_coordinator_stub(
             modules={"8110": {"module_type": "switch_module"}},
-            manifest={
-                "checked": ["8110"],
-                "present_modules": [],
-                "absent_modules": ["8110"],
-                "orphaned_buttons": [],
-            },
+            manifest_sequence=[
+                # Attempt 1: bus is busy, probe times out.
+                {
+                    "checked": ["8110"],
+                    "present_modules": [],
+                    "absent_modules": ["8110"],
+                    "orphaned_buttons": [],
+                },
+                # Attempt 2: bus quiet, probe ACKs.
+                {
+                    "checked": ["8110"],
+                    "present_modules": ["8110"],
+                    "absent_modules": [],
+                    "orphaned_buttons": [],
+                },
+            ],
             inventory_query_type=InventoryQueryType.PC_LINK,
             discovered_devices={"8110": {"category": "Module"}},
         )
@@ -781,6 +813,104 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
         await coord._reconcile_post_discovery()
 
         self.assertIn("8110", coord.module_storage.data["nikobus_module"])
+        # Library was called exactly twice; the retry was needed.
+        self.assertEqual(
+            coord.nikobus_discovery.detect_stale_inventory.await_count, 2
+        )
+
+    async def test_all_retries_failing_evicts_module_in_sweep(self):
+        # 3D28-style residue surfaced by the 0.5.18 no-terminator
+        # sweep: in discovered_devices but physically not on the bus.
+        # Every probe attempt times out → absent_everywhere → predicate
+        # subtracts it from currently_swept → evicted.
+        absent_manifest = {
+            "checked": ["3D28"],
+            "present_modules": [],
+            "absent_modules": ["3D28"],
+            "orphaned_buttons": [],
+        }
+        coord = self._make_coordinator_stub(
+            modules={"3D28": {"module_type": "switch_module"}},
+            manifest_sequence=[absent_manifest, absent_manifest],
+            inventory_query_type=InventoryQueryType.PC_LINK,
+            discovered_devices={"3D28": {"category": "Module"}},
+        )
+
+        await coord._reconcile_post_discovery()
+
+        self.assertNotIn("3D28", coord.module_storage.data["nikobus_module"])
+
+    async def test_early_exit_when_first_attempt_clears_everyone(self):
+        # Healthy install: every probed module ACKs on the first call.
+        # Predicate should NOT retry — only one detect_stale_inventory
+        # call, no asyncio.sleep, fast reconciliation.
+        coord = self._make_coordinator_stub(
+            modules={"AABB": {"module_type": "switch_module"},
+                     "CCDD": {"module_type": "switch_module"}},
+            manifest_sequence=[
+                {
+                    "checked": ["AABB", "CCDD"],
+                    "present_modules": ["AABB", "CCDD"],
+                    "absent_modules": [],
+                    "orphaned_buttons": [],
+                },
+            ],
+            inventory_query_type=InventoryQueryType.PC_LINK,
+            discovered_devices={"AABB": {"category": "Module"},
+                                "CCDD": {"category": "Module"}},
+        )
+
+        await coord._reconcile_post_discovery()
+
+        self.assertEqual(
+            coord.nikobus_discovery.detect_stale_inventory.await_count, 1
+        )
+        self.assertIn("AABB", coord.module_storage.data["nikobus_module"])
+        self.assertIn("CCDD", coord.module_storage.data["nikobus_module"])
+
+    async def test_snapshot_captured_before_probe_await(self):
+        # Bug A regression pin (issue #319 — IKIKN's 2.0.19 log showed
+        # ``swept=0``). The library resets discovered_devices /
+        # inventory_query_type DURING the long detect_stale_inventory
+        # await. Our snapshot must capture the sweep state BEFORE
+        # awaiting the probe; otherwise the eviction gate sees an
+        # empty currently_swept and no eviction fires.
+        coord = self._make_coordinator_stub(
+            modules={"AABB": {"module_type": "switch_module"},
+                     "3D28": {"module_type": "switch_module"}},
+            manifest={
+                "checked": ["AABB", "3D28"],
+                "present_modules": ["AABB"],
+                "absent_modules": ["3D28"],
+                "orphaned_buttons": [],
+            },
+            inventory_query_type=InventoryQueryType.PC_LINK,
+            discovered_devices={"AABB": {"category": "Module"},
+                                "3D28": {"category": "Module"}},
+        )
+
+        # Simulate the library resetting state during the probe await.
+        async def reset_during_probe(*_a, **_kw):
+            coord.inventory_query_type = None
+            coord.nikobus_discovery.discovered_devices = {}
+            return {
+                "checked": ["AABB", "3D28"],
+                "present_modules": ["AABB"],
+                "absent_modules": ["3D28"],
+                "orphaned_buttons": [],
+            }
+
+        coord.nikobus_discovery.detect_stale_inventory = AsyncMock(
+            side_effect=reset_during_probe
+        )
+
+        await coord._reconcile_post_discovery()
+
+        # Snapshot was taken before the await, so currently_swept
+        # contained 3D28 and AABB. Probe says 3D28 absent everywhere →
+        # 3D28 evicted. AABB is in present_anywhere → kept.
+        self.assertIn("AABB", coord.module_storage.data["nikobus_module"])
+        self.assertNotIn("3D28", coord.module_storage.data["nikobus_module"])
 
     async def test_module_only_in_probe_present_is_kept(self):
         # Edge case: module wired and ACKing the bus, but not in the


### PR DESCRIPTION
## Why

IKIKN's 2.0.19 log on issue #319 exposed two layered bugs in `_reconcile_post_discovery`:

### Bug A — sweep snapshot taken AFTER probe await

```
10:04:21.252  PC Link inventory phase completed
10:04:21.252  DUMP OF DISCOVERED DEVICES: {823D, 8110, 1CEC, 3D28, +55 buttons}
10:04:21.253  Discovery finished                 ← reconciliation entered
              ↓ await detect_stale_inventory()  ~14 seconds
10:04:35.592  Post-discovery reconciliation: ... swept=0 evicted=0
```

The library dumped 4 modules in `discovered_devices` 1 ms before firing `on_discovery_finished`, but our code read `inventory_query_type` and `discovered_devices` AFTER awaiting the 14-second probe. By then the library had reset both → `currently_swept = set()` → the `if currently_swept:` gate skipped eviction entirely. The combined predicate I'd shipped in PR #328 was correct in design but never executed in practice.

### Bug B — single-shot probe can't distinguish residue from slow ACK

Library 0.5.19 already does 3 internal retries per address. On IKIKN's bus, 8110 (a real switch module) timed out all three:

```
10:04:21.525  Bus presence probe | addr=1CEC status=present attempt=1/3
10:04:28.530  Bus presence probe | addr=3D28 status=absent reason=timeout attempts=3
10:04:35.570  Bus presence probe | addr=8110 status=absent reason=timeout attempts=3
```

Because the bus was sustained-busy from discovery traffic. Even if Bug A were fixed, the previous predicate `keep = currently_swept ∪ present` would have kept both 8110 AND 3D28 — because 0.5.17+'s no-terminator sweep surfaces residue alongside real records, so 3D28 is in `currently_swept`.

## Fix

### Bug A
Capture sweep state at function entry, before any `await`:

```python
# BEFORE the probe await — library resets discovered_devices during it
currently_swept: set[str] = set()
if self.inventory_query_type == InventoryQueryType.PC_LINK:
    discovered = getattr(self.nikobus_discovery, "discovered_devices", None)
    if isinstance(discovered, dict):
        currently_swept = {...filter category=="Module"...}
```

### Bug B
HA-side outer retry loop with bus-quiet delay between attempts:

```python
for attempt in range(1, _PROBE_RETRY_ATTEMPTS + 1):
    manifest = await self.nikobus_discovery.detect_stale_inventory()
    present_anywhere |= {present from this attempt}
    checked_addrs   |= {checked in this attempt}
    if not (checked_addrs - present_anywhere):
        break    # early exit — everyone ACKed
    if attempt < _PROBE_RETRY_ATTEMPTS:
        await asyncio.sleep(_PROBE_RETRY_DELAY_S)  # bus-quiet wait

absent_everywhere = checked_addrs - present_anywhere
```

New predicate:

```python
keep = present_anywhere ∪ (currently_swept - absent_everywhere)
```

Outcomes on the two real-install regressions:

| Module | Attempt 1 | After 3 s wait | Attempt 2 | Verdict |
|---|---|---|---|---|
| IKIKN 1CEC (real, fast) | present | — | (early exit) | **kept** ✓ |
| IKIKN 8110 (real, slow) | absent | bus quiets | present | **kept** ✓ |
| IKIKN 3D28 (residue) | absent | — | absent | **evicted** ✓ |
| fdebrus C9A5 / 9105 / 8394 (real) | present | — | (early exit) | **kept** ✓ |

Defaults: 2 outer attempts, 3.0 s bus-quiet delay. Healthy installs early-exit after attempt 1, no real-world cost. Worst case on a fully-broken bus: ~25 s for a 6-module install.

## Tests

17/17 reconciliation tests pass in 0.26 s:

- **`test_retry_recovers_slow_module`** — IKIKN 8110 regression pin. Uses `manifest_sequence=[absent, present]` to simulate the bus quiescing between attempts. Asserts module kept + library called exactly twice.
- **`test_all_retries_failing_evicts_module_in_sweep`** — 3D28 case. Both attempts return absent → evicted even though in sweep.
- **`test_early_exit_when_first_attempt_clears_everyone`** — healthy install: only 1 probe call, no sleep, no retry.
- **`test_snapshot_captured_before_probe_await`** — Bug A regression pin. Uses `side_effect` to reset `inventory_query_type` + `discovered_devices` mid-probe; eviction still fires correctly because the snapshot was already captured.

Test fixture: `asyncio.sleep` patched class-wide (`asyncSetUp`) so retry tests don't actually sleep 3 s; `_make_coordinator_stub` accepts `manifest_sequence` for retry simulation.

## Live test plan (IKIKN install)

- [ ] Reload integration on 2.0.20. Expect log line: `Post-discovery reconciliation: probed=3 present_anywhere=2 absent_everywhere=1 swept=4 evicted=1 | buttons active=0 legacy_orphan=0 legacy_undecoded=51` (or similar — `swept=4` means snapshot worked, `evicted=1` means 3D28 was correctly identified).
- [ ] `Evicted modules (failed every probe attempt AND not kept by sweep): ['3D28']`.
- [ ] `nikobus.modules` JSON now contains 3 modules: 823D, 8110, 1CEC. No 3D28.
- [ ] No more `Error refreshing 3D28 group 1:` in subsequent polling cycles.

## Independence

Builds on PRs #324 / #325 / #326 / #327 / #328 (all merged). No file conflicts.

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_