### PR TITLE
Progress UI: cap inventory bar at /92 + probe-phase status messages

### DIFF
--- a/custom_components/nikobus/const.py
+++ b/custom_components/nikobus/const.py
@@ -43,6 +43,13 @@ DISCOVERY_SUB_PHASE_INVENTORY: Final[str] = "inventory"
 DISCOVERY_SUB_PHASE_IDENTITY: Final[str] = "identity"
 DISCOVERY_SUB_PHASE_REGISTER_SCAN: Final[str] = "register_scan"
 DISCOVERY_SUB_PHASE_FINALIZING: Final[str] = "finalizing"
+# Post-discovery residue probe + eviction (HA-side, fires from
+# ``_reconcile_post_discovery``). The library's discovery itself is
+# done by this point, but the integration still has 5-15 s of work
+# (bus probe + retries + eviction); a distinct sub-phase keeps the
+# diagnostic status meaningful rather than freezing on the last
+# inventory frame.
+DISCOVERY_SUB_PHASE_PROBING: Final[str] = "probing"
 DISCOVERY_SUB_PHASE_FINISHED: Final[str] = "finished"
 DISCOVERY_SUB_PHASE_ERROR: Final[str] = "error"
 

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -42,6 +42,7 @@ from .const import (
     DISCOVERY_SUB_PHASE_IDENTITY,
     DISCOVERY_SUB_PHASE_IDLE,
     DISCOVERY_SUB_PHASE_INVENTORY,
+    DISCOVERY_SUB_PHASE_PROBING,
     DISCOVERY_SUB_PHASE_REGISTER_SCAN,
     DISCOVERY_WEIGHT_FINALIZING,
     DISCOVERY_WEIGHT_IDENTITY,
@@ -396,6 +397,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         DISCOVERY_SUB_PHASE_IDENTITY: DISCOVERY_PHASE_PC_LINK,
         DISCOVERY_SUB_PHASE_REGISTER_SCAN: DISCOVERY_PHASE_MODULE_SCAN,
         DISCOVERY_SUB_PHASE_FINALIZING: DISCOVERY_PHASE_MODULE_SCAN,
+        DISCOVERY_SUB_PHASE_PROBING: DISCOVERY_PHASE_PC_LINK,
         DISCOVERY_SUB_PHASE_FINISHED: DISCOVERY_PHASE_FINISHED,
         DISCOVERY_SUB_PHASE_ERROR: DISCOVERY_PHASE_ERROR,
     }
@@ -475,6 +477,18 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             self.discovery_register_current = (
                 int(register) if register is not None else None
             )
+            # PC-Link inventory walks 0xA4..0xFF = 92 frames (with the
+            # 0.5.13+ all-FF early-stop kicking in well before the end).
+            # The library reports ``register_total`` as the full 0x10..
+            # 0xFF (240) register space, which inflates the bar to ~1/3
+            # of true progress. Cap to 92 for the inventory phase so the
+            # percentage matches what the library actually scans.
+            if sub_phase == DISCOVERY_SUB_PHASE_INVENTORY:
+                effective_register_total = 92
+            elif register_total:
+                effective_register_total = register_total
+            else:
+                effective_register_total = 240
             self._update_discovery_state(
                 phase=legacy_phase,
                 message=message,
@@ -482,7 +496,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 modules_done=max(0, module_index - 1),
                 modules_total=module_total,
                 registers_done=registers_done,
-                registers_total=register_total or 240,
+                registers_total=effective_register_total,
             )
         except Exception as err:  # pragma: no cover - defensive
             _LOGGER.debug("Discovery progress handler error: %s", err)
@@ -1127,11 +1141,32 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         # discovery traffic. We re-call detect_stale_inventory after a
         # bus-quiet delay; a module counts as "present" if it ACKed in
         # ANY outer attempt.
+        #
+        # Status messages: the user otherwise stares at the last
+        # inventory-frame string for the full 5-15 s of probe work.
+        # Push a PROBING sub_phase + descriptive message at every state
+        # transition; snap registers_done = registers_total so the bar
+        # reads 100% (inventory done) rather than freezing at the
+        # early-stop register.
+        self.discovery_sub_phase = DISCOVERY_SUB_PHASE_PROBING
+        self._update_discovery_state(
+            phase=DISCOVERY_PHASE_PC_LINK,
+            message="Inventory complete — preparing module probe…",
+            registers_done=self.discovery_registers_total,
+        )
+
         present_anywhere: set[str] = set()
         checked_addrs: set[str] = set()
         manifest: dict = {}
 
         for attempt in range(1, _PROBE_RETRY_ATTEMPTS + 1):
+            self._update_discovery_state(
+                phase=DISCOVERY_PHASE_PC_LINK,
+                message=(
+                    f"Probing modules for residue "
+                    f"(attempt {attempt}/{_PROBE_RETRY_ATTEMPTS})…"
+                ),
+            )
             try:
                 manifest = await self.nikobus_discovery.detect_stale_inventory()
             except Exception as err:  # pragma: no cover - defensive
@@ -1158,12 +1193,21 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             if not (checked_addrs - present_anywhere):
                 break
             if attempt < _PROBE_RETRY_ATTEMPTS:
+                unconfirmed = len(checked_addrs - present_anywhere)
                 _LOGGER.debug(
                     "detect_stale_inventory attempt %d: %d module(s) still "
                     "unconfirmed; waiting %.1fs for bus to quiesce before retry",
                     attempt,
-                    len(checked_addrs - present_anywhere),
+                    unconfirmed,
                     _PROBE_RETRY_DELAY_S,
+                )
+                self._update_discovery_state(
+                    phase=DISCOVERY_PHASE_PC_LINK,
+                    message=(
+                        f"{unconfirmed} module(s) slow to respond — "
+                        f"waiting {_PROBE_RETRY_DELAY_S:.0f}s for bus to "
+                        f"quieten before retry…"
+                    ),
                 )
                 await asyncio.sleep(_PROBE_RETRY_DELAY_S)
 
@@ -1174,6 +1218,10 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         checked_last = manifest.get("checked") or []
 
         # --- Eviction --------------------------------------------------
+        self._update_discovery_state(
+            phase=DISCOVERY_PHASE_PC_LINK,
+            message="Reconciling discovered inventory…",
+        )
         modules = self.module_storage.data.setdefault("nikobus_module", {})
         evicted: list[str] = []
         if currently_swept:
@@ -1182,6 +1230,11 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 if str(addr).upper() not in keep:
                     modules.pop(addr, None)
                     evicted.append(str(addr).upper())
+        if evicted:
+            self._update_discovery_state(
+                phase=DISCOVERY_PHASE_PC_LINK,
+                message=f"Evicted {len(evicted)} stale module(s); finalizing…",
+            )
 
         # --- Button bucketing ----------------------------------------
         remaining = {str(a).upper() for a in modules.keys()}
@@ -1232,8 +1285,13 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
     async def _handle_discovery_finished(self) -> None:
         """Signal discovery completion; optionally reload the config entry."""
         self.discovery_running = False
-        self.discovery_sub_phase = DISCOVERY_SUB_PHASE_FINISHED
         self.discovery_register_current = None
+        # Don't set ``sub_phase = FINISHED`` here — the reconciliation
+        # step that follows still has 5-15 s of bus probe + eviction
+        # work, and freezes the diagnostic message on the last inventory
+        # frame if we mark "finished" too early. The reconciler pushes
+        # its own ``DISCOVERY_SUB_PHASE_PROBING`` status updates; we
+        # land on FINISHED only after it returns.
 
         # Residue defence: snapshot the sweep state BEFORE awaiting the
         # probe (library resets it during the await), then probe with
@@ -1242,6 +1300,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         # probe attempt AND aren't kept by the snapshotted sweep.
         await self._reconcile_post_discovery()
 
+        self.discovery_sub_phase = DISCOVERY_SUB_PHASE_FINISHED
         self._update_discovery_state(
             phase=DISCOVERY_PHASE_FINISHED,
             message=(

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.0.20",
+  "version": "2.0.21",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -912,6 +912,94 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
         self.assertIn("AABB", coord.module_storage.data["nikobus_module"])
         self.assertNotIn("3D28", coord.module_storage.data["nikobus_module"])
 
+    async def test_status_messages_track_probe_progress(self):
+        # During the probe phase the diagnostic message used to freeze
+        # on the last inventory frame ("PC Link inventory: 27/240
+        # registers, 23 device(s) found") for the full 5-15 s window.
+        # Verify _reconcile_post_discovery now pushes descriptive
+        # messages at every state transition: probe preparation, each
+        # retry attempt, the bus-quiet wait, and reconciliation.
+        absent_then_present = [
+            {
+                "checked": ["8110"],
+                "present_modules": [],
+                "absent_modules": ["8110"],
+                "orphaned_buttons": [],
+            },
+            {
+                "checked": ["8110"],
+                "present_modules": ["8110"],
+                "absent_modules": [],
+                "orphaned_buttons": [],
+            },
+        ]
+        coord = self._make_coordinator_stub(
+            modules={"8110": {"module_type": "switch_module"}},
+            manifest_sequence=absent_then_present,
+            inventory_query_type=InventoryQueryType.PC_LINK,
+            discovered_devices={"8110": {"category": "Module"}},
+        )
+
+        await coord._reconcile_post_discovery()
+
+        messages = [
+            call.kwargs.get("message")
+            for call in coord._update_discovery_state.call_args_list
+            if call.kwargs.get("message") is not None
+        ]
+        # Probe-phase progression: preparation → attempt 1 → bus-quiet
+        # wait → attempt 2 → reconciling. (No eviction message because
+        # 8110 ACKed on attempt 2 → no stale modules.)
+        self.assertTrue(
+            any("Inventory complete" in m for m in messages),
+            f"missing preparation message; got {messages}",
+        )
+        self.assertTrue(
+            any("attempt 1/2" in m for m in messages),
+            f"missing attempt 1 message; got {messages}",
+        )
+        self.assertTrue(
+            any("slow to respond" in m and "quieten" in m for m in messages),
+            f"missing bus-quiet wait message; got {messages}",
+        )
+        self.assertTrue(
+            any("attempt 2/2" in m for m in messages),
+            f"missing attempt 2 message; got {messages}",
+        )
+        self.assertTrue(
+            any("Reconciling" in m for m in messages),
+            f"missing reconciling message; got {messages}",
+        )
+
+    async def test_status_message_reports_eviction_count(self):
+        # When the predicate evicts at least one module, the user should
+        # see the count surfaced in the diagnostic message rather than
+        # finding it only in the log.
+        absent_manifest = {
+            "checked": ["3D28"],
+            "present_modules": [],
+            "absent_modules": ["3D28"],
+            "orphaned_buttons": [],
+        }
+        coord = self._make_coordinator_stub(
+            modules={"3D28": {"module_type": "switch_module"}},
+            manifest_sequence=[absent_manifest, absent_manifest],
+            inventory_query_type=InventoryQueryType.PC_LINK,
+            discovered_devices={"3D28": {"category": "Module"}},
+        )
+
+        await coord._reconcile_post_discovery()
+
+        messages = [
+            call.kwargs.get("message")
+            for call in coord._update_discovery_state.call_args_list
+            if call.kwargs.get("message") is not None
+        ]
+        self.assertTrue(
+            any("Evicted 1 stale module" in m for m in messages),
+            f"missing eviction count message; got {messages}",
+        )
+
     async def test_module_only_in_probe_present_is_kept(self):
         # Edge case: module wired and ACKing the bus, but not in the
         # current PC-Link project (so absent from the sweep). Combined


### PR DESCRIPTION
## Why

This commit was originally in PR #329's branch but didn't survive the merge — main landed only the snapshot+retry fix. Two cosmetic gaps from the diagnostic-card screenshot are still open:

### Issue 1 — bar inflated to /240

Card displayed `PC Link inventory: 27/240 registers, 23 device(s) found` at 10.0%. PC-Link inventory only walks `0xA4..0xFF` = **92 frames**. `start_pc_link_inventory` knows this and sets `registers_total=92` at scan start (`coordinator.py:1391`), but the library's `DiscoveryProgress` event reports `register_total=240` (the broader 0x10..0xFF address space), and `_handle_discovery_progress` accepted that value and overwrote our 92.

With the 0.5.13+ all-FF early-stop in play, a typical install rarely walks past register `0x30`, so the bar showed `~12/240 = 5%` when discovery was actually about done. The user perceived "stuck at 10%" because the denominator was 2.6× too big.

### Issue 2 — status frozen during the probe phase

Library fires `on_discovery_finished` ~1 ms after the last inventory frame; `_reconcile_post_discovery` then runs for 5–15 s (probe + retries + eviction) without pushing any status update. The user stared at `PC Link inventory: 27/240 registers, 23 device(s) found` until the final `Discovery finished` landed.

## Fix

**Cap `effective_register_total` at 92** when `sub_phase == INVENTORY`, regardless of what the library reports. Per-module register scans (`REGISTER_SCAN`) keep using the library-reported value, falling back to 240 only when the library emits nothing.

**Add `DISCOVERY_SUB_PHASE_PROBING`** and push descriptive messages at every state transition inside `_reconcile_post_discovery`:

```
Inventory complete — preparing module probe…
Probing modules for residue (attempt 1/2)…
N module(s) slow to respond — waiting 3s for bus to quieten…
Probing modules for residue (attempt 2/2)…
Reconciling discovered inventory…
Evicted N stale module(s); finalizing…    (only when N > 0)
```

The bar is snapped to `registers_total` at probe entry so it reads 100% (inventory done) rather than freezing at whatever register the all-FF early-stop fired on.

`_handle_discovery_finished` no longer marks `sub_phase = FINISHED` before the reconciler runs — that ordering made the reconciler implicitly the "finished" phase to the diagnostic sensor, which is the root cause of the frozen-message bug. The assignment moves to after the reconciler returns, so `PROBING` is visible during the actual probe window.

## What the user sees now

Before:
```
Discovery progress  10.0%
Disco...  PC Link inventory: 27/240 registers, 23 device(s) found
```

After (same scan state):
```
Discovery progress  29.3%
Disco...  PC Link inventory: 27/92 registers, 23 device(s) found
```

After inventory completes, during the 5–15 s probe window:
```
Discovery progress  100%
Disco...  Probing modules for residue (attempt 1/2)…
   ↓ 3s wait if anything timed out
Disco...  2 module(s) slow to respond — waiting 3s for bus to quieten…
Disco...  Probing modules for residue (attempt 2/2)…
Disco...  Reconciling discovered inventory…
Disco...  Evicted 1 stale module(s); finalizing…    [only if eviction happened]
Disco...  Discovery finished — 59 records decoded.
```

## Tests

19/19 reconciliation tests pass in 0.5 s:

- **`test_status_messages_track_probe_progress`** — asserts the full message sequence (preparation → attempt 1 → bus-quiet wait → attempt 2 → reconciling) reaches `_update_discovery_state`.
- **`test_status_message_reports_eviction_count`** — pins that the evicted count is surfaced in the diagnostic message, not only in the log.

```
$ python -m pytest tests/test_coordinator.py::TestReconcilePostDiscovery -q
...................                                                      [100%]
19 passed in 0.50s
```

Manifest bumped 2.0.20 → 2.0.21.

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_