### PR TITLE
Snapshot at merge + extend polling guard through reconcile (issue #319)

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -131,6 +131,13 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self.discovery_module_address: str | None = None
         self.inventory_query_type: InventoryQueryType | None = None
         self._reload_task = None
+        # Captured during _async_on_module_save when the library merges
+        # newly-discovered modules into the store. ``_reconcile_post_discovery``
+        # uses this snapshot instead of reading ``discovered_devices`` after
+        # ``on_discovery_finished`` fires — by which point the library has
+        # already cleared the dict (issue #319: 2.0.20 IKIKN log showed
+        # ``swept=0`` because the snapshot was taken too late).
+        self._last_pc_link_sweep: set[str] = set()
 
         # --- Discovery progress tracking (for UI) ---
         # `discovery_phase` stays on the legacy enum for backward-compat with
@@ -1036,7 +1043,29 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self.dict_module_data.update(grouped)
 
     async def _async_on_module_save(self) -> None:
-        """Persist the Store after discovery/user edits, then refresh derived views."""
+        """Persist the Store after discovery/user edits, then refresh derived views.
+
+        Also snapshots the PC-Link sweep when this fires from a PC-Link
+        inventory cycle. The library invokes this callback right after
+        ``merge_discovered_modules`` and BEFORE clearing its internal
+        ``discovered_devices`` / ``inventory_query_type`` state, so this
+        is the last moment we can capture the sweep set. Reading those
+        attributes from ``on_discovery_finished`` is too late (the
+        library has already cleared them — issue #319: 2.0.20 IKIKN log
+        showed ``swept=0`` even with a snapshot at callback entry).
+        """
+        if (
+            self.inventory_query_type == InventoryQueryType.PC_LINK
+            and self.nikobus_discovery is not None
+        ):
+            discovered = getattr(self.nikobus_discovery, "discovered_devices", None)
+            if isinstance(discovered, dict):
+                self._last_pc_link_sweep = {
+                    str(addr).upper()
+                    for addr, dev in discovered.items()
+                    if isinstance(dev, dict) and dev.get("category") == "Module"
+                }
+
         await self.module_storage.async_save()
         self._rebuild_dict_module_data()
         # Clear the cached router spec so newly-discovered modules show up.
@@ -1119,20 +1148,16 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             )
             return
 
-        # --- Snapshot BEFORE the probe await --------------------------
-        # The library resets ``inventory_query_type`` and/or
-        # ``discovered_devices`` while ``detect_stale_inventory`` runs,
-        # so we capture the sweep state up-front. Reading them after
-        # the probe yields an empty set on every install (issue #319).
-        currently_swept: set[str] = set()
-        if self.inventory_query_type == InventoryQueryType.PC_LINK:
-            discovered = getattr(self.nikobus_discovery, "discovered_devices", None)
-            if isinstance(discovered, dict):
-                currently_swept = {
-                    str(addr).upper()
-                    for addr, dev in discovered.items()
-                    if isinstance(dev, dict) and dev.get("category") == "Module"
-                }
+        # --- Sweep snapshot --------------------------------------------
+        # Read the snapshot captured by ``_async_on_module_save`` during
+        # the library's merge step. We can NOT read
+        # ``discovered_devices`` here — the library clears it before
+        # firing ``on_discovery_finished``, so even snapshotting at
+        # callback entry yields an empty set (issue #319: 2.0.20 IKIKN
+        # log showed ``swept=0`` despite that fix). Capturing in the
+        # save callback is earlier in the library's call chain, so the
+        # dict is still populated.
+        currently_swept: set[str] = set(self._last_pc_link_sweep)
 
         # --- Probe with HA-side retries -------------------------------
         # The library does N internal retries per probe (attempts=3 in
@@ -1284,22 +1309,26 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
 
     async def _handle_discovery_finished(self) -> None:
         """Signal discovery completion; optionally reload the config entry."""
-        self.discovery_running = False
         self.discovery_register_current = None
-        # Don't set ``sub_phase = FINISHED`` here — the reconciliation
-        # step that follows still has 5-15 s of bus probe + eviction
-        # work, and freezes the diagnostic message on the last inventory
-        # frame if we mark "finished" too early. The reconciler pushes
-        # its own ``DISCOVERY_SUB_PHASE_PROBING`` status updates; we
-        # land on FINISHED only after it returns.
+        # Don't unset ``discovery_running`` or set ``sub_phase = FINISHED``
+        # here — the reconciliation step that follows still has 5-15 s
+        # of bus probe + eviction work, and clearing the polling guard
+        # (``_async_update_data`` early-returns when
+        # ``discovery_running`` is True) lets the normal poll cycle
+        # hammer the bus alongside the probe. On heavily-loaded buses
+        # (issue #319 IKIKN 2.0.20 log) that contention false-
+        # negatived even ``1CEC`` on the retry attempt despite a clean
+        # ACK on attempt 1. We land on FINISHED + clear
+        # ``discovery_running`` only after the reconciler returns.
 
-        # Residue defence: snapshot the sweep state BEFORE awaiting the
-        # probe (library resets it during the await), then probe with
-        # HA-side retries so slow-but-real modules get a second chance
-        # once the bus has quiesced. Evict only modules that fail every
-        # probe attempt AND aren't kept by the snapshotted sweep.
+        # Residue defence: combined sweep snapshot (captured in
+        # ``_async_on_module_save``) + HA-side retry loop so slow-but-
+        # real modules get a second chance once the bus has quiesced.
+        # Evict only modules that fail every probe attempt AND aren't
+        # kept by the snapshotted sweep.
         await self._reconcile_post_discovery()
 
+        self.discovery_running = False
         self.discovery_sub_phase = DISCOVERY_SUB_PHASE_FINISHED
         self._update_discovery_state(
             phase=DISCOVERY_PHASE_FINISHED,
@@ -1437,6 +1466,11 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             )
         self._discovery_auto_reload = auto_reload
         self._discovery_finished_event.clear()
+        # Reset the sweep snapshot so a fresh PC-Link cycle doesn't OR
+        # with a stale set from a previous run. Repopulated by
+        # ``_async_on_module_save`` once the library merges this scan's
+        # discovered_devices.
+        self._last_pc_link_sweep = set()
         # PC Link inventory scans register range 0xA4-0xFF = 92 frames.
         # The library aborts the sweep at the first all-FF response
         # (nikobus-connect 0.5.13+), so this is a soft upper bound.

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.0.21",
+  "version": "2.0.22",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -594,7 +594,26 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
             coord.nikobus_discovery.discovered_devices = (
                 dict(discovered_devices) if discovered_devices is not None else None
             )
+
+        # Mimic what ``_async_on_module_save`` does at library merge
+        # time: capture the modules-only sweep into a coordinator-owned
+        # snapshot. ``_reconcile_post_discovery`` reads THIS, never
+        # ``discovered_devices`` directly (issue #319: the library
+        # clears discovered_devices before firing on_discovery_finished,
+        # so reading it from the post-discovery callback is too late).
+        if (
+            inventory_query_type == InventoryQueryType.PC_LINK
+            and discovered_devices is not None
+        ):
+            coord._last_pc_link_sweep = {
+                str(addr).upper()
+                for addr, dev in discovered_devices.items()
+                if isinstance(dev, dict) and dev.get("category") == "Module"
+            }
         else:
+            coord._last_pc_link_sweep = set()
+
+        if not has_method:
             # Library lacks the method (older nikobus-connect): the spec
             # requires graceful skip-with-warning.
             class _OldDiscovery:
@@ -868,13 +887,15 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
         self.assertIn("AABB", coord.module_storage.data["nikobus_module"])
         self.assertIn("CCDD", coord.module_storage.data["nikobus_module"])
 
-    async def test_snapshot_captured_before_probe_await(self):
-        # Bug A regression pin (issue #319 — IKIKN's 2.0.19 log showed
-        # ``swept=0``). The library resets discovered_devices /
-        # inventory_query_type DURING the long detect_stale_inventory
-        # await. Our snapshot must capture the sweep state BEFORE
-        # awaiting the probe; otherwise the eviction gate sees an
-        # empty currently_swept and no eviction fires.
+    async def test_reconcile_uses_last_pc_link_sweep_not_discovered_devices(self):
+        # Issue #319 regression pin — 2.0.20 IKIKN log showed swept=0
+        # even with a snapshot at callback entry, because the library
+        # clears ``discovered_devices`` BEFORE firing
+        # ``on_discovery_finished``. The fix moved capture to
+        # ``_async_on_module_save`` (earlier in the library's call
+        # chain). ``_reconcile_post_discovery`` must read
+        # ``_last_pc_link_sweep`` and NEVER touch ``discovered_devices``,
+        # so eviction works even when the library has wiped the dict.
         coord = self._make_coordinator_stub(
             modules={"AABB": {"module_type": "switch_module"},
                      "3D28": {"module_type": "switch_module"}},
@@ -884,33 +905,80 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
                 "absent_modules": ["3D28"],
                 "orphaned_buttons": [],
             },
-            inventory_query_type=InventoryQueryType.PC_LINK,
-            discovered_devices={"AABB": {"category": "Module"},
-                                "3D28": {"category": "Module"}},
+            inventory_query_type=None,  # library-cleared by callback time
+            discovered_devices={},      # library-cleared by callback time
         )
-
-        # Simulate the library resetting state during the probe await.
-        async def reset_during_probe(*_a, **_kw):
-            coord.inventory_query_type = None
-            coord.nikobus_discovery.discovered_devices = {}
-            return {
-                "checked": ["AABB", "3D28"],
-                "present_modules": ["AABB"],
-                "absent_modules": ["3D28"],
-                "orphaned_buttons": [],
-            }
-
-        coord.nikobus_discovery.detect_stale_inventory = AsyncMock(
-            side_effect=reset_during_probe
-        )
+        # _async_on_module_save captured the sweep earlier:
+        coord._last_pc_link_sweep = {"AABB", "3D28"}
 
         await coord._reconcile_post_discovery()
 
-        # Snapshot was taken before the await, so currently_swept
-        # contained 3D28 and AABB. Probe says 3D28 absent everywhere →
-        # 3D28 evicted. AABB is in present_anywhere → kept.
+        # Probe says 3D28 absent → absent_everywhere. Predicate uses
+        # the captured sweep snapshot, NOT the empty discovered_devices,
+        # so 3D28 is correctly evicted; AABB is in present_anywhere.
         self.assertIn("AABB", coord.module_storage.data["nikobus_module"])
         self.assertNotIn("3D28", coord.module_storage.data["nikobus_module"])
+
+    async def test_async_on_module_save_captures_sweep_during_pc_link(self):
+        # Direct pin on the library-merge capture path. When the
+        # library invokes ``on_module_save`` during a PC-Link inventory
+        # cycle, we must snapshot ``discovered_devices`` (modules
+        # only) into ``_last_pc_link_sweep`` — that's the only moment
+        # the library's dict is still populated.
+        coord = MagicMock()
+        coord.inventory_query_type = InventoryQueryType.PC_LINK
+        coord.nikobus_discovery = MagicMock()
+        coord.nikobus_discovery.discovered_devices = {
+            "823D": {"category": "Module", "module_type": "pc_link"},
+            "8110": {"category": "Module", "module_type": "switch_module"},
+            "1CEC": {"category": "Module", "module_type": "switch_module"},
+            "3D28": {"category": "Module", "module_type": "switch_module"},
+            "1843B4": {"category": "Button"},  # must be filtered out
+        }
+        coord.module_storage = MagicMock()
+        coord.module_storage.async_save = AsyncMock()
+        coord._rebuild_dict_module_data = MagicMock()
+        coord.config_entry = MagicMock()
+        coord.config_entry.entry_id = "entry_test"
+        coord.hass = MagicMock()
+        coord.hass.data = {}
+        coord._last_pc_link_sweep = set()
+
+        await NikobusDataCoordinator._async_on_module_save(coord)
+
+        self.assertEqual(
+            coord._last_pc_link_sweep,
+            {"823D", "8110", "1CEC", "3D28"},
+        )
+
+    async def test_async_on_module_save_does_not_capture_during_module_scan(self):
+        # Per-module register scans must NOT clobber the snapshot —
+        # their ``discovered_devices`` only covers a single address,
+        # so capturing here would shrink the sweep to one entry and
+        # cause every other module to be evicted on the next reconcile.
+        coord = MagicMock()
+        coord.inventory_query_type = InventoryQueryType.MODULE
+        coord.nikobus_discovery = MagicMock()
+        coord.nikobus_discovery.discovered_devices = {
+            "8110": {"category": "Module", "module_type": "switch_module"},
+        }
+        coord.module_storage = MagicMock()
+        coord.module_storage.async_save = AsyncMock()
+        coord._rebuild_dict_module_data = MagicMock()
+        coord.config_entry = MagicMock()
+        coord.config_entry.entry_id = "entry_test"
+        coord.hass = MagicMock()
+        coord.hass.data = {}
+        # Snapshot from a previous PC-Link cycle:
+        coord._last_pc_link_sweep = {"823D", "8110", "1CEC", "3D28"}
+
+        await NikobusDataCoordinator._async_on_module_save(coord)
+
+        # Untouched.
+        self.assertEqual(
+            coord._last_pc_link_sweep,
+            {"823D", "8110", "1CEC", "3D28"},
+        )
 
     async def test_status_messages_track_probe_progress(self):
         # During the probe phase the diagnostic message used to freeze


### PR DESCRIPTION
## Why

The 2.0.20 IKIKN log (after PRs #329/#330) showed that BOTH fixes missed their target on a real heavily-loaded install:

```
22:15:50.058 Post-discovery reconciliation: probed=3 present_anywhere=1
             absent_everywhere=2 swept=0 evicted=0 | buttons ...
```

`swept=0` again, and even `1CEC` (which ACKed cleanly on attempt 1) failed every retry on attempt 2. Forensics revealed two layered bugs.

### Bug 1 — snapshot was still too late

PR #329 captured `discovered_devices` at the top of `_handle_discovery_finished`. The 2.0.20 log proved the library clears `inventory_query_type` / `discovered_devices` between the DUMP and the `on_discovery_finished` callback firing — not during our await:

```
22:15:11.740  DUMP OF DISCOVERED DEVICES: {823D, 8110, 1CEC, 3D28, ...}
22:15:11.740  PC Link inventory phase completed.
              ↓ library reset HERE (inside _finalize_inventory_phase)
22:15:11.741  Discovery finished                  ← _handle_discovery_finished
              ↓ snapshot runs → already empty
```

Even snapshotting at callback entry yields `set()`. **Fix:** hook into `_async_on_module_save` instead — that callback fires earlier in the library's call chain, right after `merge_discovered_modules` and **before** the state reset. `discovered_devices` is still populated at that point.

### Bug 2 — polling cycle hammered the bus during the probe

`_handle_discovery_finished` set `self.discovery_running = False` on entry, BEFORE `_reconcile_post_discovery`. That unblocked `_async_update_data`'s polling guard:

```python
async def _async_update_data(self) -> None:
    if self.discovery_running:
        return None  # poll cycle skipped during discovery
```

Smoking gun in the log at 22:15:27.380, mid-3-second-sleep between probe attempts:

```
22:15:26.025  Stale-inventory probe complete (attempt 1: 1 ACK, 2 timeouts)
22:15:26.025  Waiting 3.0s for bus to quiesce before retry
22:15:27.380  Processing command: $1012283D892E31  ← polling, NOT the probe
22:15:36.031  Bus presence probe | addr=1CEC status=absent reason=timeout
              (1CEC failed attempt 2 despite ACKing attempt 1)
```

The polling cycle queued `$1012` GETs to every known module the moment the guard cleared. By attempt 2 the bus was fully saturated by polling commands fighting with our probe. The retry strategy was **actively counterproductive** — each retry gave the polling cycle more chances to interleave.

**Fix:** keep `discovery_running = True` until `_reconcile_post_discovery` returns, so polling stays gated for the full probe + eviction window. Note: this only blocks HA's auto-poll loop; the listener and command pipeline keep running, so the probe's ACK/answer flow is unaffected.

## Bonus finding (library-side, reported but not fixed here)

In the same log, `1CEC`'s second-attempt probe showed:

```
22:15:29.027  Queueing $1012EC1C67FDFB         ← library probe attempt 1
22:15:31.529  Queueing $1012EC1C67FDFB → SUPPRESSED (duplicate)  ← attempt 2
22:15:34.030  Queueing $1012EC1C67FDFB → SUPPRESSED (duplicate)  ← attempt 3
22:15:36.031  Bus presence probe | addr=1CEC status=absent reason=timeout attempts=3
```

`attempts=3` is misleading — only one `$1012` actually went on the wire. The library's internal `attempts=3` retry mechanism re-queues but the queue's dedup logic drops the duplicates. With our fix the queue is empty when the probe runs (no polling competition), so the library's retry mechanism works as designed and the bug stops mattering for us. Worth fixing upstream too.

## Changes

- `_async_on_module_save`: when `inventory_query_type == PC_LINK`, snapshot the modules-only filtered `discovered_devices` into a new `self._last_pc_link_sweep: set[str]` attribute. Per-module scans are gated out so a Stage-2 register scan doesn't shrink the snapshot to one address.
- `start_pc_link_inventory`: clear `_last_pc_link_sweep` at cycle start so a fresh scan doesn't OR with stale data from a previous run.
- `_reconcile_post_discovery`: read from `_last_pc_link_sweep` instead of `self.nikobus_discovery.discovered_devices`. The latter is now considered library-internal and not consumer-safe to read after merge.
- `_handle_discovery_finished`: move `self.discovery_running = False` and `sub_phase = FINISHED` to AFTER `_reconcile_post_discovery` returns. Comment explains the bus-contention rationale.

## Tests (21 reconciliation tests, all green in 0.99 s)

- `test_async_on_module_save_captures_sweep_during_pc_link` — direct pin on the new capture path. Verifies modules-only filter (buttons in `discovered_devices` are excluded).
- `test_async_on_module_save_does_not_capture_during_module_scan` — gates against per-module scans clobbering the snapshot.
- `test_reconcile_uses_last_pc_link_sweep_not_discovered_devices` — pins the new contract: even with `discovered_devices = {}` and `inventory_query_type = None` (simulating the library's reset), eviction still works because we read the captured snapshot instead.
- `_make_coordinator_stub` now mirrors `_async_on_module_save`: populates `coord._last_pc_link_sweep` from `discovered_devices` during PC_LINK in setup. Existing tests keep passing without change.

## Expected outcome on IKIKN's next reload

```
Post-discovery reconciliation: probed=3 present_anywhere=2 absent_everywhere=1 swept=4 evicted=1 | buttons active=0 legacy_orphan=0 legacy_undecoded=51
Evicted modules (failed every probe attempt AND not kept by sweep): ['3D28']
```

`swept=4` means the snapshot survived the library reset. `present_anywhere=2` means `1CEC` and `8110` both ACKed without polling contention. `absent_everywhere=1` is `3D28` which genuinely isn't on the bus. `evicted=1` is `3D28` going away.

Manifest 2.0.21 → 2.0.22.

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_