### PR TITLE
Adopt nikobus-connect 0.5.21 — drop removed timeout kwargs (issue #319)

### DIFF
--- a/custom_components/nikobus/__init__.py
+++ b/custom_components/nikobus/__init__.py
@@ -51,15 +51,25 @@ SERVICE_PURGE_STALE_INVENTORY: Final = "purge_stale_inventory"
 # the module absent. Worst-case wall-clock budget is roughly
 # ``len(switch+dimmer+roller modules) * timeout`` — at the default 0.6 s
 # an 8-module install needs about five seconds.
-DEFAULT_DETECT_PROBE_TIMEOUT: Final[float] = 0.6
+DEFAULT_DETECT_OUTER_ATTEMPTS: Final[int] = 1
+DEFAULT_DETECT_OUTER_DELAY: Final[float] = 0.0
 
 SCAN_MODULE_SCHEMA = vol.Schema({vol.Optional("module_address", default=""): cv.string})
 SEND_BUTTON_PRESS_SCHEMA = vol.Schema({
     vol.Required("address"): cv.string,
 })
 DETECT_STALE_INVENTORY_SCHEMA = vol.Schema({
-    vol.Optional("timeout", default=DEFAULT_DETECT_PROBE_TIMEOUT): vol.All(
-        vol.Coerce(float), vol.Range(min=0.1, max=5.0)
+    # nikobus-connect 0.5.21 removed the per-probe ``timeout`` kwarg in
+    # favour of letting each probe run its natural ~15 s budget (3 inner
+    # attempts × 5 s). Tunable knobs are now the outer-loop pair:
+    #  * ``outer_attempts`` — how many full sweep passes (default 1)
+    #  * ``outer_delay``    — bus-quiet wait between passes (default 0)
+    # Slow installs (IKIKN-class) opt into 2-pass with a 3 s gap.
+    vol.Optional("outer_attempts", default=DEFAULT_DETECT_OUTER_ATTEMPTS): vol.All(
+        vol.Coerce(int), vol.Range(min=1, max=3)
+    ),
+    vol.Optional("outer_delay", default=DEFAULT_DETECT_OUTER_DELAY): vol.All(
+        vol.Coerce(float), vol.Range(min=0.0, max=10.0)
     ),
 })
 PURGE_STALE_INVENTORY_SCHEMA = vol.Schema({
@@ -160,12 +170,16 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 translation_key="discovery_already_running",
             )
 
-        timeout = float(call.data.get("timeout", DEFAULT_DETECT_PROBE_TIMEOUT))
+        outer_attempts = int(call.data.get("outer_attempts", DEFAULT_DETECT_OUTER_ATTEMPTS))
+        outer_delay = float(call.data.get("outer_delay", DEFAULT_DETECT_OUTER_DELAY))
         _LOGGER.info(
-            "Detecting stale Nikobus inventory (probe timeout=%.2fs)", timeout
+            "Detecting stale Nikobus inventory (outer_attempts=%d outer_delay=%.1fs)",
+            outer_attempts,
+            outer_delay,
         )
         manifest: dict = await coordinator.nikobus_discovery.detect_stale_inventory(
-            timeout=timeout
+            outer_attempts=outer_attempts,
+            outer_delay=outer_delay,
         )
         absent = manifest.get("absent_modules") or []
         orphaned = manifest.get("orphaned_buttons") or []

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.5.20"
+    "nikobus-connect>=0.5.21"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }

--- a/custom_components/nikobus/services.yaml
+++ b/custom_components/nikobus/services.yaml
@@ -16,15 +16,24 @@ send_button_press:
 
 detect_stale_inventory:
   fields:
-    timeout:
-      example: 0.6
+    outer_attempts:
+      example: 1
       required: false
-      default: 0.6
+      default: 1
       selector:
         number:
-          min: 0.1
-          max: 5.0
-          step: 0.1
+          min: 1
+          max: 3
+          step: 1
+    outer_delay:
+      example: 0
+      required: false
+      default: 0
+      selector:
+        number:
+          min: 0
+          max: 10
+          step: 0.5
           unit_of_measurement: "s"
 
 purge_stale_inventory:


### PR DESCRIPTION
## Why

nikobus-connect 0.5.21 ([PR #56](https://github.com/fdebrus/nikobus-connect/pull/56)) removed the per-probe `timeout`, `max_attempts`, and `retry_delay` kwargs. The 2026-05-12 IKIKN log proved the 0.5.18–0.5.20 retry layering was actively harmful — an absent module's command pipeline retry (15 s) blocked subsequent probes, the outer 2 s cap cancelled them, and the stale-skip discarded them on pop. Real modules (IKIKN's `8110`) never reached the wire.

Upstream fix: remove the outer wrap entirely. Trust the command pipeline's own 3-attempt retry. Each probe runs its natural ~15 s budget. A slow probe delays subsequent probes but doesn't starve them.

## Migration on the HA side

The coordinator already calls `detect_stale_inventory(outer_attempts=2, outer_delay=3.0)` from PR #332 — those kwargs are **kept** in 0.5.21, no change needed.

The break is in the `nikobus.detect_stale_inventory` **service handler** (`__init__.py`), which was still passing the removed `timeout=` kwarg. Without this PR it `TypeError`s on the first invocation post-upgrade.

### Service migration

```yaml
# Before
detect_stale_inventory:
  fields:
    timeout: {min: 0.1, max: 5.0, default: 0.6}

# After
detect_stale_inventory:
  fields:
    outer_attempts: {min: 1, max: 3, default: 1}
    outer_delay:    {min: 0,   max: 10,  default: 0}
```

```python
# Before
manifest = await discovery.detect_stale_inventory(timeout=timeout)

# After
manifest = await discovery.detect_stale_inventory(
    outer_attempts=outer_attempts,
    outer_delay=outer_delay,
)
```

Default behaviour is single-pass (`outer_attempts=1, outer_delay=0`) — the library guidance says that's correct for clean installs. IKIKN-class slow installs opt into `outer_attempts=2, outer_delay=3.0` for defence-in-depth.

### Constants

- Drop `DEFAULT_DETECT_PROBE_TIMEOUT = 0.6`
- Add `DEFAULT_DETECT_OUTER_ATTEMPTS = 1` and `DEFAULT_DETECT_OUTER_DELAY = 0.0`

## Hard break, no deprecation shim

Automations that invoke `nikobus.detect_stale_inventory` with `timeout` will now fail schema validation (`vol.Invalid`). This is the right place for the break: it surfaces in the HA service-call log, not as a cryptic library `TypeError` deeper down. The service is debug-oriented (returns the manifest; doesn't mutate storage), so the blast radius is small.

## Tests

No test coverage for the service handler itself; reconciliation tests still 19/19 — coordinator's call site was already using the kept kwargs.

```
$ python -m pytest tests/test_coordinator.py::TestReconcilePostDiscovery -q
...................                                                      [100%]
19 passed
```

## Validation on IKIKN

Expected log after deployment:

```
Bus presence probe | addr=1CEC status=present outer=1/1
Bus presence probe | addr=3D28 status=absent reason=NikobusTimeoutError outer_passes=1
Bus presence probe | addr=8110 status=present outer=1/1
Post-discovery reconciliation: probed=3 present=2 absent=1 swept=4 evicted=1
Evicted modules (absent_modules from probe): ['3D28']
```

If `8110` still false-negatives, the next escalation is listener-driven bus-quiet gating (library session offered to add it).

Manifest: `nikobus-connect>=0.5.21`, version 2.0.23 → 2.0.24.

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_