### PR TITLE
Legacy-undecoded button Repairs flow (issue #319 follow-up)

### DIFF
--- a/custom_components/nikobus/const.py
+++ b/custom_components/nikobus/const.py
@@ -64,6 +64,12 @@ DISCOVERY_WEIGHT_FINALIZING: Final[int] = 5
 # =============================================================================
 ISSUE_NO_BUTTONS_CONFIGURED: Final[str] = "no_buttons_configured"
 ISSUE_STALE_INVENTORY_PRESENT: Final[str] = "stale_inventory_present"
+# Surfaced after Stage-2 scan-all when one or more buttons still have
+# no decoded ``linked_modules``. We can't programmatically distinguish
+# "intentionally unwired (HA automation trigger)" from "residue from a
+# previous owner" — both look identical from the bus signal. Push the
+# decision to the user via a Repairs flow.
+ISSUE_LEGACY_UNDECODED_BUTTONS: Final[str] = "legacy_undecoded_buttons"
 
 # =============================================================================
 # Configuration Keys

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -49,6 +49,7 @@ from .const import (
     DISCOVERY_WEIGHT_INVENTORY,
     DISCOVERY_WEIGHT_REGISTER_SCAN,
     DOMAIN,
+    ISSUE_LEGACY_UNDECODED_BUTTONS,
     ISSUE_NO_BUTTONS_CONFIGURED,
     RECONNECT_DELAY_INITIAL,
     RECONNECT_DELAY_MAX,
@@ -130,6 +131,15 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self.discovery_module_address: str | None = None
         self.inventory_query_type: InventoryQueryType | None = None
         self._reload_task = None
+        # Was the most recent ``start_module_scan`` a scan-all (every
+        # module's register table read)? Set by ``start_module_scan``;
+        # read by ``_reconcile_post_discovery`` to decide whether to
+        # surface the ``legacy_undecoded_buttons`` Repairs issue.
+        # ``legacy_undecoded`` is only a meaningful signal after the
+        # decoder has had a chance to read EVERY module's link table —
+        # before that, almost every button reads as ``legacy_undecoded``
+        # by default (no module's register table has been decoded yet).
+        self._last_module_scan_was_full: bool = False
 
         # --- Discovery progress tracking (for UI) ---
         # `discovery_phase` stays on the legacy enum for backward-compat with
@@ -1061,6 +1071,51 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                     linked.add(str(addr).upper())
         return linked
 
+    def _surface_legacy_undecoded_buttons(
+        self, buttons: dict[str, Any]
+    ) -> None:
+        """Create or clear the ``legacy_undecoded_buttons`` Repairs issue.
+
+        Called from ``_reconcile_post_discovery`` *only* after a Stage-2
+        scan-all completes — that's the moment ``legacy_undecoded`` is
+        meaningful (every module's register table was just decoded; any
+        button still without ``linked_modules`` is either intentionally
+        unwired and used as an HA automation trigger, or residue from a
+        previous owner). HA cannot tell those two apart without user
+        input, so the Repairs flow renders the candidate list and lets
+        the user pick which to remove.
+
+        Issue auto-clears when the candidate list becomes empty (next
+        scan-all). Recoverable: purged buttons reappear on the next
+        PC-Link inventory if they're still in the project.
+        """
+        legacy_addrs = sorted(
+            str(addr).upper()
+            for addr, phys in buttons.items()
+            if isinstance(phys, dict)
+            and phys.get("status") == "legacy_undecoded"
+        )
+        issue_id = (
+            f"{ISSUE_LEGACY_UNDECODED_BUTTONS}_{self.config_entry.entry_id}"
+        )
+        if not legacy_addrs:
+            ir.async_delete_issue(self.hass, DOMAIN, issue_id)
+            return
+
+        ir.async_create_issue(
+            self.hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=True,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key=ISSUE_LEGACY_UNDECODED_BUTTONS,
+            translation_placeholders={"count": str(len(legacy_addrs))},
+            data={
+                "entry_id": self.config_entry.entry_id,
+                "addresses": legacy_addrs,
+            },
+        )
+
     async def _reconcile_post_discovery(
         self,
         discovered_devices: dict | None = None,
@@ -1182,6 +1237,18 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 status = "active"
             phys["status"] = status
             bucket_counts[status] += 1
+
+        # Surface the legacy-undecoded Repairs issue only after a
+        # Stage-2 scan-all, when the verdict is meaningful (every
+        # output module's register table was just read, so a button
+        # still without ``linked_modules`` is genuinely either
+        # intentionally unwired or residue — and HA can't distinguish
+        # the two without user input).
+        if (
+            inventory_query_type != InventoryQueryType.PC_LINK
+            and self._last_module_scan_was_full
+        ):
+            self._surface_legacy_undecoded_buttons(buttons)
 
         # Persist. Both stores save unconditionally so the ``status``
         # field on buttons + the eviction on modules land on disk.
@@ -1377,6 +1444,10 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             )
         self._discovery_auto_reload = auto_reload
         self._discovery_finished_event.clear()
+        # PC-Link inventory is not a register scan — reset the flag so
+        # a stale ``True`` from a prior scan-all doesn't fire the
+        # legacy-buttons Repairs issue with Stage-1-only data.
+        self._last_module_scan_was_full = False
         # PC Link inventory scans register range 0xA4-0xFF = 92 frames.
         # The library aborts the sweep at the first all-FF response
         # (nikobus-connect 0.5.13+), so this is a soft upper bound.
@@ -1426,6 +1497,10 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 translation_domain=DOMAIN,
                 translation_key="discovery_already_running",
             )
+
+        # Tracked for ``_reconcile_post_discovery`` — only after a
+        # scan-all is ``legacy_undecoded`` a trustworthy signal.
+        self._last_module_scan_was_full = module_address is None
 
         if module_address:
             target = module_address.strip().upper()

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/custom_components/nikobus/repairs.py
+++ b/custom_components/nikobus/repairs.py
@@ -4,12 +4,19 @@ from __future__ import annotations
 
 from typing import Any
 
+import voluptuous as vol
 from homeassistant.components.repairs import RepairsFlow
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.selector import (
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
 
-from .const import DOMAIN
+from .const import DOMAIN, ISSUE_LEGACY_UNDECODED_BUTTONS
 from .coordinator import NikobusDataCoordinator
 
 
@@ -41,6 +48,117 @@ class NoButtonsConfiguredRepairFlow(RepairsFlow):
         return self.async_create_entry(title="", data={})
 
 
+class LegacyUndecodedButtonsRepairFlow(RepairsFlow):
+    """Let the user choose which legacy_undecoded buttons to remove.
+
+    Surfaced after Stage-2 scan-all when one or more buttons have no
+    decoded ``linked_modules``. We cannot programmatically tell apart:
+
+      * Wall buttons intentionally unwired in the PC-Link project and
+        used solely as HA automation triggers (KEEP).
+      * Residue from a previous owner / removed hardware (PURGE).
+
+    The flow renders the candidate set as a markdown table and asks the
+    user to pick which addresses to remove. Recoverable: a re-run of
+    PC-Link inventory re-adds anything currently in the project.
+    """
+
+    def __init__(self, entry_id: str, addresses: list[str]) -> None:
+        """Store the entry id and the candidate addresses surfaced by the issue."""
+        self._entry_id = entry_id
+        self._candidates = [str(a).upper() for a in addresses]
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Show the candidate list with a multi-select."""
+        coordinator = _coordinator(self.hass, self._entry_id)
+        if coordinator is None:
+            return self.async_abort(reason="not_loaded")
+
+        buttons = (coordinator.dict_button_data or {}).get("nikobus_button", {})
+        # Filter candidates to those still in the store AND still
+        # ``legacy_undecoded`` — the user may have manually purged some
+        # via the service in the meantime, or another scan may have
+        # decoded their links.
+        still_legacy = [
+            addr
+            for addr in self._candidates
+            if isinstance(buttons.get(addr), dict)
+            and buttons[addr].get("status") == "legacy_undecoded"
+        ]
+        if not still_legacy:
+            return self.async_abort(reason="no_candidates")
+
+        if user_input is not None:
+            selected = [
+                str(addr).upper() for addr in (user_input.get("addresses") or [])
+            ]
+            if selected:
+                await coordinator.purge_inventory_addresses(selected)
+            return self.async_create_entry(title="", data={})
+
+        options = [
+            SelectOptionDict(
+                value=addr, label=self._format_label(addr, buttons[addr])
+            )
+            for addr in still_legacy
+        ]
+        schema = vol.Schema(
+            {
+                vol.Optional("addresses", default=[]): SelectSelector(
+                    SelectSelectorConfig(
+                        multiple=True,
+                        mode=SelectSelectorMode.LIST,
+                        options=options,
+                    )
+                ),
+            }
+        )
+        return self.async_show_form(
+            step_id="init",
+            data_schema=schema,
+            description_placeholders={
+                "count": str(len(still_legacy)),
+                "candidates": self._render_table(still_legacy, buttons),
+            },
+        )
+
+    @staticmethod
+    def _format_label(address: str, phys: dict[str, Any]) -> str:
+        """Compact one-line label for the multi-select dropdown entry."""
+        btype = phys.get("type") or "Unknown type"
+        model = phys.get("model") or ""
+        description = phys.get("description") or ""
+        # Strip the auto-appended ``#N<addr>`` so labels read cleanly.
+        if description.endswith(f"#N{address}"):
+            description = description[: -len(f"#N{address}")].rstrip()
+        bits = [address, btype]
+        if model and model.lower() != "unknown":
+            bits.append(model)
+        if description and description not in bits:
+            bits.append(description)
+        return " — ".join(bits)
+
+    @staticmethod
+    def _render_table(addresses: list[str], buttons: dict[str, Any]) -> str:
+        """Markdown table of candidates injected into the form description."""
+        rows = ["| Address | Type | Model | Description |",
+                "|---|---|---|---|"]
+        for addr in addresses:
+            phys = buttons.get(addr) or {}
+            btype = phys.get("type") or "Unknown"
+            model = phys.get("model") or "—"
+            description = phys.get("description") or ""
+            # Strip the auto-suffix and any pipe chars that would break
+            # the table layout.
+            if description.endswith(f"#N{addr}"):
+                description = description[: -len(f"#N{addr}")].rstrip()
+            description = description.replace("|", "/") or "—"
+            rows.append(f"| `{addr}` | {btype} | {model} | {description} |")
+        return "\n".join(rows)
+
+
 async def async_create_fix_flow(
     hass: HomeAssistant,
     issue_id: str,
@@ -48,6 +166,9 @@ async def async_create_fix_flow(
 ) -> RepairsFlow:
     """Return the appropriate repair flow for the given issue id."""
     entry_id = (data or {}).get("entry_id", "")
+    if issue_id.startswith(ISSUE_LEGACY_UNDECODED_BUTTONS):
+        addresses = (data or {}).get("addresses") or []
+        return LegacyUndecodedButtonsRepairFlow(entry_id, addresses)
     return NoButtonsConfiguredRepairFlow(entry_id)
 
 

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -102,6 +102,24 @@
                     }
                 }
             }
+        },
+        "legacy_undecoded_buttons": {
+            "title": "{count} Nikobus button(s) without decoded links",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Review legacy Nikobus buttons",
+                        "description": "These {count} button(s) exist in your store but no module register table references them after a full Stage-2 scan. They are one of:\n\n  - Wall buttons used only for Home Assistant automations (no PC-Link action) — keep.\n  - Residue from a previous owner or removed hardware — purge.\n\nTo recover any purged button, run **Discover modules & buttons** again — the library re-adds anything currently in the PC-Link project.\n\n{candidates}\n\nLeave the list empty and submit to keep everything.",
+                        "data": {
+                            "addresses": "Buttons to remove"
+                        }
+                    }
+                },
+                "abort": {
+                    "not_loaded": "The Nikobus integration is not loaded; reload the entry and retry.",
+                    "no_candidates": "No legacy buttons remain — nothing to do."
+                }
+            }
         }
     },
     "exceptions": {

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -161,6 +161,24 @@
                     }
                 }
             }
+        },
+        "legacy_undecoded_buttons": {
+            "title": "{count} bouton(s) Nikobus sans liens décodés",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Examiner les boutons Nikobus hérités",
+                        "description": "Ces {count} bouton(s) figurent dans votre stockage mais aucune table de registre de module ne s'y réfère après un scan complet de phase 2. Il s'agit soit :\n\n  - de boutons muraux utilisés uniquement pour des automatisations Home Assistant (sans action PC-Link) — à conserver ;\n  - de résidus d'un précédent propriétaire ou de matériel supprimé — à purger.\n\nPour récupérer un bouton purgé, relancez **Découvrir les modules et boutons** — la bibliothèque réinsère tout ce qui figure encore dans le projet PC-Link.\n\n{candidates}\n\nLaissez la liste vide et soumettez pour tout conserver.",
+                        "data": {
+                            "addresses": "Boutons à supprimer"
+                        }
+                    }
+                },
+                "abort": {
+                    "not_loaded": "L'intégration Nikobus n'est pas chargée ; rechargez l'entrée puis réessayez.",
+                    "no_candidates": "Aucun bouton hérité ne reste — rien à faire."
+                }
+            }
         }
     },
     "exceptions": {

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -161,6 +161,24 @@
                     }
                 }
             }
+        },
+        "legacy_undecoded_buttons": {
+            "title": "{count} Nikobus-knop(pen) zonder gedecodeerde koppelingen",
+            "fix_flow": {
+                "step": {
+                    "init": {
+                        "title": "Verouderde Nikobus-knoppen beoordelen",
+                        "description": "Deze {count} knop(pen) staan in je opslag, maar geen enkele modulebestand verwijst ernaar na een volledige fase-2-scan. Het gaat om:\n\n  - Wandknoppen die alleen worden gebruikt voor Home Assistant-automatiseringen (geen PC-Link-actie) — behouden.\n  - Resten van een vorige eigenaar of verwijderde hardware — opschonen.\n\nOm een gewiste knop te herstellen, voer **Modules en knoppen ontdekken** opnieuw uit — de bibliotheek voegt alles wat nog in het PC-Link-project staat opnieuw toe.\n\n{candidates}\n\nLaat de lijst leeg en bevestig om alles te behouden.",
+                        "data": {
+                            "addresses": "Te verwijderen knoppen"
+                        }
+                    }
+                },
+                "abort": {
+                    "not_loaded": "De Nikobus-integratie is niet geladen; herlaad het item en probeer opnieuw.",
+                    "no_candidates": "Geen verouderde knoppen meer — niets te doen."
+                }
+            }
         }
     },
     "exceptions": {

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -557,6 +557,7 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
         has_method: bool = True,
         inventory_query_type=None,
         discovered_devices: dict | None = None,
+        last_module_scan_was_full: bool = False,
     ):
         coord = MagicMock()
         coord.module_storage = MagicMock()
@@ -574,6 +575,10 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
         # Default to None so the eviction branch is inert in existing
         # tests; explicit PC_LINK + dict opt-in for the new tests below.
         coord.inventory_query_type = inventory_query_type
+        # Stage-2 scan-all completion gate for the legacy-undecoded
+        # Repairs issue. Default False — the issue only surfaces when
+        # the caller explicitly opts in via ``last_module_scan_was_full``.
+        coord._last_module_scan_was_full = last_module_scan_was_full
         if has_method:
             coord.nikobus_discovery = MagicMock()
             default_manifest = manifest or {
@@ -1066,6 +1071,156 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
         await coord._reconcile_post_discovery()
 
         self.assertIn("AABB", coord.module_storage.data["nikobus_module"])
+
+    # ------------------------------------------------------------------
+    # Stage-2 scan-all → legacy_undecoded buttons Repairs issue
+    # ------------------------------------------------------------------
+
+    async def test_legacy_undecoded_repairs_surfaces_after_scan_all(self):
+        # After a Stage-2 scan-all, ``legacy_undecoded`` is a meaningful
+        # signal: every output module's register table was just read,
+        # so a button with no decoded ``linked_modules`` is either
+        # intentionally unwired (HA automation trigger) or residue —
+        # HA can't tell them apart, so it surfaces a Repairs issue and
+        # lets the user choose. We assert the helper is called with the
+        # button dict so the Repairs issue gets created downstream.
+        coord = self._make_coordinator_stub(
+            modules={},
+            buttons={"1843B4": {
+                "type": "Bus push button, 4 control buttons",
+                "model": "05-346",
+            }},
+            manifest={
+                "checked": [], "present_modules": [],
+                "absent_modules": [], "orphaned_buttons": [],
+            },
+            inventory_query_type=InventoryQueryType.MODULE,
+            last_module_scan_was_full=True,
+        )
+
+        await coord._reconcile_post_discovery()
+
+        coord._surface_legacy_undecoded_buttons.assert_called_once()
+
+    async def test_legacy_undecoded_repairs_NOT_surfaced_after_pc_link(self):
+        # After Stage-1 (PC-Link inventory), almost every button reads
+        # as ``legacy_undecoded`` by default — no module register table
+        # has been decoded yet. Surfacing the issue here would propose
+        # purging every button on a fresh install. Gate it on the
+        # scan-all flag.
+        coord = self._make_coordinator_stub(
+            modules={},
+            buttons={"1843B4": {
+                "type": "Bus push button, 4 control buttons",
+            }},
+            manifest={
+                "checked": [], "present_modules": [],
+                "absent_modules": [], "orphaned_buttons": [],
+            },
+            inventory_query_type=InventoryQueryType.PC_LINK,
+            discovered_devices={"AABB": {"category": "Module"}},
+            last_module_scan_was_full=False,
+        )
+
+        await coord._reconcile_post_discovery()
+
+        coord._surface_legacy_undecoded_buttons.assert_not_called()
+
+    async def test_legacy_undecoded_repairs_NOT_surfaced_after_single_module_scan(self):
+        # Single-module register scan only updates ``linked_modules``
+        # for buttons referenced by that one module. Other buttons may
+        # still read as ``legacy_undecoded`` simply because we haven't
+        # scanned their controlling module — not because they're
+        # residue. The verdict is only trustworthy after scan-all.
+        coord = self._make_coordinator_stub(
+            modules={},
+            buttons={"1843B4": {
+                "type": "Bus push button, 4 control buttons",
+            }},
+            manifest={
+                "checked": [], "present_modules": [],
+                "absent_modules": [], "orphaned_buttons": [],
+            },
+            inventory_query_type=InventoryQueryType.MODULE,
+            last_module_scan_was_full=False,
+        )
+
+        await coord._reconcile_post_discovery()
+
+        coord._surface_legacy_undecoded_buttons.assert_not_called()
+
+
+class TestSurfaceLegacyUndecodedButtons(unittest.IsolatedAsyncioTestCase):
+    """Direct tests for ``_surface_legacy_undecoded_buttons``.
+
+    Asserts the create/delete contract on the HA issue registry so the
+    Repairs UI shows up exactly when (and with what data) we expect.
+    """
+
+    def _coord_stub(self) -> MagicMock:
+        coord = MagicMock()
+        coord.hass = MagicMock()
+        coord.config_entry = MagicMock()
+        coord.config_entry.entry_id = "entry_test"
+        return coord
+
+    @patch("custom_components.nikobus.coordinator.ir.async_create_issue")
+    @patch("custom_components.nikobus.coordinator.ir.async_delete_issue")
+    def test_creates_issue_when_legacy_undecoded_buttons_present(
+        self, mock_delete, mock_create
+    ):
+        coord = self._coord_stub()
+        buttons = {
+            "1843B4": {"status": "legacy_undecoded",
+                       "type": "Bus push button"},
+            "0C2387": {"status": "legacy_undecoded",
+                       "type": "RF transmitter"},
+            "10152B": {"status": "active"},  # must be filtered out
+            "AABBCC": {"status": "legacy_orphan"},  # also filtered out
+        }
+
+        NikobusDataCoordinator._surface_legacy_undecoded_buttons(coord, buttons)
+
+        mock_delete.assert_not_called()
+        mock_create.assert_called_once()
+        call_kwargs = mock_create.call_args.kwargs
+        self.assertEqual(call_kwargs["is_fixable"], True)
+        self.assertEqual(
+            call_kwargs["translation_key"], "legacy_undecoded_buttons"
+        )
+        self.assertEqual(
+            call_kwargs["translation_placeholders"], {"count": "2"}
+        )
+        # Addresses sorted, uppercase, only the two legacy_undecoded entries.
+        self.assertEqual(
+            call_kwargs["data"]["addresses"], ["0C2387", "1843B4"]
+        )
+        self.assertEqual(
+            call_kwargs["data"]["entry_id"], "entry_test"
+        )
+
+    @patch("custom_components.nikobus.coordinator.ir.async_create_issue")
+    @patch("custom_components.nikobus.coordinator.ir.async_delete_issue")
+    def test_deletes_issue_when_no_legacy_undecoded_remain(
+        self, mock_delete, mock_create
+    ):
+        coord = self._coord_stub()
+        # All buttons are decoded or have surviving links — issue
+        # should be cleared if it was previously open.
+        buttons = {
+            "1843B4": {"status": "active"},
+            "0C2387": {"status": "legacy_orphan"},
+        }
+
+        NikobusDataCoordinator._surface_legacy_undecoded_buttons(coord, buttons)
+
+        mock_create.assert_not_called()
+        mock_delete.assert_called_once()
+        # Same issue_id is used for both create and delete so they
+        # target the same Repairs entry.
+        delete_args = mock_delete.call_args
+        self.assertIn("legacy_undecoded_buttons", delete_args.args[2])
+        self.assertIn("entry_test", delete_args.args[2])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

After the module-eviction story stabilised, button residue is the remaining open thread on #319. The discussion concluded:

- `legacy_undecoded` after **Stage-2 scan-all** IS a meaningful signal (every module's register table just got read; any button without `linked_modules` is genuinely either intentionally unwired or residue).
- But HA cannot programmatically distinguish "wall button used purely for HA automation triggers" from "residue from a previous owner" — buttons are passive on the bus, no `is this button physically present?` probe exists.
- `legacy_orphan` (button has decoded links, all linked modules just got evicted) only catches cases where the module was once-decoded then later removed — **doesn't help fresh installs of pre-owned hardware** (IKIKN's exact case, where 3D28 was already gone before the user ever ran Stage-2).

So push the decision to the user via HA's native Repairs flow.

## What changes

### Trigger: Stage-2 scan-all completion only

| Operation | `_last_module_scan_was_full` | Issue surfaced? |
|---|---|---|
| `start_pc_link_inventory` | reset to False | No (every button is legacy_undecoded by default) |
| `start_module_scan(None)` (scan-all) | True | **Yes** — gate fires |
| `start_module_scan("8110")` (single) | False | No (verdict is partial) |

### Issue surface

`_surface_legacy_undecoded_buttons` in coordinator. Symmetric create/delete with the existing `no_buttons_configured` pattern:

- Non-empty `legacy_undecoded` set → `ir.async_create_issue` with sorted addresses + count placeholder.
- Empty set → `ir.async_delete_issue` (auto-clears once user has purged everything they wanted gone).

### Repairs flow (`LegacyUndecodedButtonsRepairFlow`)

Single step, no double-confirmation, no scary "this is permanent" copy — because it isn't permanent. Recovery is just re-running Discover.

```
These {count} button(s) exist in your store but no module register
table references them after a full Stage-2 scan. They are one of:

  - Wall buttons used only for HA automations (no PC-Link action) — keep.
  - Residue from a previous owner or removed hardware — purge.

To recover any purged button, run Discover modules & buttons again —
the library re-adds anything currently in the PC-Link project.

| Address  | Type                          | Model    | Description    |
|----------|-------------------------------|----------|----------------|
| `1843B4` | Bus push button, 4 ctrl       | 05-346   | Living room    |
| `0C2387` | Mini hand-held RF transmitter | 05-311   | Remote         |
| …        | …                             | …        | …              |

[multi-select list]   [Submit]
```

Submit empty → keep everything. Submit with selection → `coordinator.purge_inventory_addresses` → entities drop via existing reload path.

Candidate set is re-filtered at flow open against the live store, so stale addresses (manually purged in the meantime) don't appear.

### Translations

en / fr / nl all updated. Title format: `{count} Nikobus button(s) without decoded links`.

### Dispatcher in `repairs.py`

`async_create_fix_flow` dispatches by issue-id prefix:
- `legacy_undecoded_buttons_*` → `LegacyUndecodedButtonsRepairFlow`
- everything else → existing `NoButtonsConfiguredRepairFlow`

## Deliberately NOT included

- **`legacy_orphan` auto-evict.** Rarely fires (requires module was once-decoded then later evicted); on fresh installs of pre-owned PC-Links the residue was never decoded, so the bucket stays empty. If it ever materially fires, the same Repairs flow can be extended to handle it.
- **Press-history heuristic.** Possible future iteration. Needs new state (last-seen-press timestamp per button) and a baseline period before it's reliable.

## Tests — 24/24 pass in 0.50 s

- `test_legacy_undecoded_repairs_surfaces_after_scan_all` — gate fires post-scan-all.
- `test_legacy_undecoded_repairs_NOT_surfaced_after_pc_link` — gate suppresses on Stage-1 only.
- `test_legacy_undecoded_repairs_NOT_surfaced_after_single_module_scan` — gate suppresses on partial scans.
- New `TestSurfaceLegacyUndecodedButtons` class with two direct helper tests:
  - Creates issue with right `is_fixable`, `translation_key`, count placeholder, sorted addresses (filters out `active` / `legacy_orphan`).
  - Deletes issue against the same issue_id when set is empty.

## Validation on IKIKN

1. Reload integration on 2.0.25.
2. Run **Discover modules & buttons** (Stage-1) — 51 buttons surface, all `legacy_undecoded`. **No Repairs issue yet.**
3. Run **Scan all module links** (Stage-2 scan-all) — decoder runs against 8110 / 1CEC. Real wall-button links get populated.
4. Expect Repairs issue: "N Nikobus button(s) without decoded links".
5. Open Fix flow → review table → select known-residue addresses → submit → entities disappear.
6. Anything still in PC-Link project comes back on the next Stage-1 run; genuine residue stays gone.

## Diffstat

```
custom_components/nikobus/const.py             |   6 +
custom_components/nikobus/coordinator.py       |  75 ++++++
custom_components/nikobus/manifest.json        |   2 +-
custom_components/nikobus/repairs.py           | 123 ++++++++++-
custom_components/nikobus/translations/en.json |  18 +
custom_components/nikobus/translations/fr.json |  18 +
custom_components/nikobus/translations/nl.json |  18 +
tests/test_coordinator.py                      | 155 +++++++++++++
8 files changed, 413 insertions(+), 2 deletions(-)
```

Manifest 2.0.24 → 2.0.25.

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_