### PR TITLE
Adopt nikobus-connect 0.5.22 record_source residue filter (issue #319)

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -78,6 +78,21 @@ MODULE_TYPES = ("switch_module", "dimmer_module", "roller_module")
 _PROBE_OUTER_ATTEMPTS = 2
 _PROBE_OUTER_DELAY_S = 3.0
 
+# nikobus-connect 0.5.22+ tags every decoded output record with a
+# ``record_source`` field naming the scan source. ``output_module_table``
+# means the link lives in the actual switch/dimmer/roller module's own
+# table — current programming, authoritative. The two registry sources
+# below are PC-Link / PC-Logic flash registry memory; their records may
+# be residue from a previous owner's programming that was never cleared
+# by the current owner's DIN-button learn-mode re-pairing.
+#
+# A button whose EVERY output record is registry-sourced means no output
+# module currently knows about it — strong residue signal on installs
+# without PC-Logic. On installs WITH PC-Logic, a registry-only button
+# could be a legitimate PC-Logic scene trigger; the classifier gates the
+# residue verdict on ``_has_pc_logic_module`` to avoid that FP.
+_REGISTRY_SOURCES = frozenset({"pc_link_registry", "pc_logic_registry"})
+
 
 class NikobusDataCoordinator(DataUpdateCoordinator[None]):
     """Coordinator for managing asynchronous updates and connections to Nikobus."""
@@ -1071,19 +1086,83 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                     linked.add(str(addr).upper())
         return linked
 
+    @staticmethod
+    def _collect_button_outputs(phys: dict[str, Any]) -> list[dict[str, Any]]:
+        """Flatten every output record under every op-point of a button.
+
+        Returned dicts are the decoder's per-output records (channel,
+        mode, payload, button_address, plus nikobus-connect 0.5.22+'s
+        ``record_source``). Used by the registry-only residue check.
+        """
+        outputs: list[dict[str, Any]] = []
+        op_points = phys.get("operation_points") or {}
+        if not isinstance(op_points, dict):
+            return outputs
+        for op_point in op_points.values():
+            if not isinstance(op_point, dict):
+                continue
+            for link in op_point.get("linked_modules") or []:
+                if not isinstance(link, dict):
+                    continue
+                for out in link.get("outputs") or []:
+                    if isinstance(out, dict):
+                        outputs.append(out)
+        return outputs
+
+    @staticmethod
+    def _all_outputs_registry_sourced(outputs: list[dict[str, Any]]) -> bool:
+        """True iff every output has ``record_source`` in the registry set.
+
+        Returns False if ``outputs`` is empty, or if any output is
+        missing the field. Pre-0.5.22 records (no ``record_source``)
+        are treated as source-unknown and fall through to the existing
+        classifier — backward compat without data migration.
+        """
+        if not outputs:
+            return False
+        return all(
+            out.get("record_source") in _REGISTRY_SOURCES
+            for out in outputs
+        )
+
+    def _has_pc_logic_module(self) -> bool:
+        """True if the install has at least one PC-Logic module in the store.
+
+        Gates the registry-only residue verdict: with PC-Logic absent,
+        a button whose every output is registry-sourced is unambiguous
+        residue (no real button-to-output link exists anywhere). With
+        PC-Logic present, the same shape could be a legitimate
+        PC-Logic-only scene trigger — fall through to the existing
+        classifier and let the user adjudicate.
+        """
+        modules = self.module_storage.data.get("nikobus_module", {})
+        if not isinstance(modules, dict):
+            return False
+        return any(
+            isinstance(m, dict) and m.get("module_type") == "pc_logic"
+            for m in modules.values()
+        )
+
     def _surface_legacy_undecoded_buttons(
         self, buttons: dict[str, Any]
     ) -> None:
         """Create or clear the ``legacy_undecoded_buttons`` Repairs issue.
 
         Called from ``_reconcile_post_discovery`` *only* after a Stage-2
-        scan-all completes — that's the moment ``legacy_undecoded`` is
-        meaningful (every module's register table was just decoded; any
-        button still without ``linked_modules`` is either intentionally
-        unwired and used as an HA automation trigger, or residue from a
-        previous owner). HA cannot tell those two apart without user
-        input, so the Repairs flow renders the candidate list and lets
-        the user pick which to remove.
+        scan-all completes — that's when both legacy buckets are
+        meaningful:
+
+          * ``legacy_undecoded`` — no decoded links across any op-point.
+            Either intentionally unwired (HA-trigger pattern) or
+            residue from a previous owner. HA cannot tell those apart.
+          * ``legacy_orphan`` — has decoded links but either (a) every
+            link points to an evicted module, or (b) every output
+            record is registry-sourced with no PC-Logic in the install
+            (residue programming from a previous owner that the
+            current owner's DIN-button re-pairing didn't clear).
+
+        Both buckets warrant user review before purge. The Repairs
+        flow renders the combined candidate list with a multi-select.
 
         Issue auto-clears when the candidate list becomes empty (next
         scan-all). Recoverable: purged buttons reappear on the next
@@ -1093,7 +1172,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             str(addr).upper()
             for addr, phys in buttons.items()
             if isinstance(phys, dict)
-            and phys.get("status") == "legacy_undecoded"
+            and phys.get("status") in ("legacy_undecoded", "legacy_orphan")
         )
         issue_id = (
             f"{ISSUE_LEGACY_UNDECODED_BUTTONS}_{self.config_entry.entry_id}"
@@ -1225,13 +1304,34 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         remaining = {str(a).upper() for a in modules.keys()}
         bucket_counts = {"active": 0, "legacy_orphan": 0, "legacy_undecoded": 0}
         buttons = self.dict_button_data.setdefault("nikobus_button", {})
+        # Topology gate for the registry-only residue check. With no
+        # PC-Logic in the install, a button whose every output record
+        # is sourced from PC-Link / PC-Logic registry memory has NO
+        # output module recording the link — strong residue signal.
+        # With PC-Logic present, the same shape could be a legitimate
+        # scene trigger; defer to the existing classifier.
+        has_pc_logic = self._has_pc_logic_module()
         for phys in buttons.values():
             if not isinstance(phys, dict):
                 continue
             linked = self._collect_button_linked_modules(phys)
-            if not linked:
+            outputs = self._collect_button_outputs(phys)
+            if not outputs:
+                # No decoded links anywhere — pre-Stage-2 default OR
+                # intentionally unwired button (HA-trigger pattern).
                 status = "legacy_undecoded"
+            elif (
+                not has_pc_logic
+                and self._all_outputs_registry_sourced(outputs)
+            ):
+                # nikobus-connect 0.5.22 residue filter: every output
+                # comes from PC-Link / PC-Logic registry, and there's
+                # no PC-Logic module to potentially justify a scene
+                # trigger. Unambiguous residue programming from a
+                # previous owner — surface for purge.
+                status = "legacy_orphan"
             elif not (linked & remaining):
+                # All decoded-target modules were evicted by the probe.
                 status = "legacy_orphan"
             else:
                 status = "active"

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.0.25",
+  "version": "2.0.26",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.5.21"
+    "nikobus-connect>=0.5.22"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }

--- a/custom_components/nikobus/repairs.py
+++ b/custom_components/nikobus/repairs.py
@@ -49,18 +49,25 @@ class NoButtonsConfiguredRepairFlow(RepairsFlow):
 
 
 class LegacyUndecodedButtonsRepairFlow(RepairsFlow):
-    """Let the user choose which legacy_undecoded buttons to remove.
+    """Let the user choose which legacy buttons to remove.
 
-    Surfaced after Stage-2 scan-all when one or more buttons have no
-    decoded ``linked_modules``. We cannot programmatically tell apart:
+    Surfaced after Stage-2 scan-all when one or more buttons land in
+    a legacy bucket:
 
-      * Wall buttons intentionally unwired in the PC-Link project and
-        used solely as HA automation triggers (KEEP).
-      * Residue from a previous owner / removed hardware (PURGE).
+      * ``legacy_undecoded`` — no decoded links across any op-point.
+        Either intentionally unwired (HA-trigger pattern, KEEP) or
+        residue with no surviving link records (PURGE).
+      * ``legacy_orphan`` — has decoded links but either every linked
+        module was just evicted, or (with nikobus-connect 0.5.22+)
+        every output record is sourced from PC-Link / PC-Logic
+        registry memory with no PC-Logic in the install (i.e.,
+        residue programming from a previous owner that DIN-button
+        re-pairing didn't clear).
 
-    The flow renders the candidate set as a markdown table and asks the
-    user to pick which addresses to remove. Recoverable: a re-run of
-    PC-Link inventory re-adds anything currently in the project.
+    The flow renders the combined candidate set as a markdown table
+    and asks the user to pick which addresses to remove. Recoverable:
+    a re-run of PC-Link inventory + Stage-2 re-adds anything currently
+    in the project.
     """
 
     def __init__(self, entry_id: str, addresses: list[str]) -> None:
@@ -77,15 +84,15 @@ class LegacyUndecodedButtonsRepairFlow(RepairsFlow):
             return self.async_abort(reason="not_loaded")
 
         buttons = (coordinator.dict_button_data or {}).get("nikobus_button", {})
-        # Filter candidates to those still in the store AND still
-        # ``legacy_undecoded`` — the user may have manually purged some
-        # via the service in the meantime, or another scan may have
-        # decoded their links.
+        # Filter candidates to those still in the store AND still in
+        # one of the legacy buckets — the user may have manually purged
+        # some via the service in the meantime, or another scan may
+        # have decoded their links.
         still_legacy = [
             addr
             for addr in self._candidates
             if isinstance(buttons.get(addr), dict)
-            and buttons[addr].get("status") == "legacy_undecoded"
+            and buttons[addr].get("status") in ("legacy_undecoded", "legacy_orphan")
         ]
         if not still_legacy:
             return self.async_abort(reason="no_candidates")
@@ -140,22 +147,30 @@ class LegacyUndecodedButtonsRepairFlow(RepairsFlow):
             bits.append(description)
         return " — ".join(bits)
 
-    @staticmethod
-    def _render_table(addresses: list[str], buttons: dict[str, Any]) -> str:
+    _REASON_LABELS = {
+        "legacy_undecoded": "no decoded links",
+        "legacy_orphan": "residue / stale links",
+    }
+
+    @classmethod
+    def _render_table(cls, addresses: list[str], buttons: dict[str, Any]) -> str:
         """Markdown table of candidates injected into the form description."""
-        rows = ["| Address | Type | Model | Description |",
-                "|---|---|---|---|"]
+        rows = ["| Address | Type | Model | Reason | Description |",
+                "|---|---|---|---|---|"]
         for addr in addresses:
             phys = buttons.get(addr) or {}
             btype = phys.get("type") or "Unknown"
             model = phys.get("model") or "—"
+            reason = cls._REASON_LABELS.get(phys.get("status"), "—")
             description = phys.get("description") or ""
             # Strip the auto-suffix and any pipe chars that would break
             # the table layout.
             if description.endswith(f"#N{addr}"):
                 description = description[: -len(f"#N{addr}")].rstrip()
             description = description.replace("|", "/") or "—"
-            rows.append(f"| `{addr}` | {btype} | {model} | {description} |")
+            rows.append(
+                f"| `{addr}` | {btype} | {model} | {reason} | {description} |"
+            )
         return "\n".join(rows)
 
 

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -104,12 +104,12 @@
             }
         },
         "legacy_undecoded_buttons": {
-            "title": "{count} Nikobus button(s) without decoded links",
+            "title": "{count} Nikobus button(s) flagged as legacy",
             "fix_flow": {
                 "step": {
                     "init": {
                         "title": "Review legacy Nikobus buttons",
-                        "description": "These {count} button(s) exist in your store but no module register table references them after a full Stage-2 scan. They are one of:\n\n  - Wall buttons used only for Home Assistant automations (no PC-Link action) — keep.\n  - Residue from a previous owner or removed hardware — purge.\n\nTo recover any purged button, run **Discover modules & buttons** again — the library re-adds anything currently in the PC-Link project.\n\n{candidates}\n\nLeave the list empty and submit to keep everything.",
+                        "description": "These {count} button(s) are flagged as legacy after a full Stage-2 scan. The Reason column explains why each one was flagged:\n\n  - **no decoded links** — no output module references this button. Either a wall button used only for Home Assistant automations (KEEP), or residue from a previous owner (PURGE).\n  - **residue / stale links** — the button's links live only in PC-Link / PC-Logic registry memory with no current output module recording them, or every linked module was evicted. Typically residue programming from a previous owner that DIN-button re-pairing didn't clear (PURGE).\n\nTo recover any purged button, re-run **Discover modules & buttons** and then **Scan all module links** — the library re-adds anything currently in the project.\n\n{candidates}\n\nLeave the list empty and submit to keep everything.",
                         "data": {
                             "addresses": "Buttons to remove"
                         }

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -163,12 +163,12 @@
             }
         },
         "legacy_undecoded_buttons": {
-            "title": "{count} bouton(s) Nikobus sans liens décodés",
+            "title": "{count} bouton(s) Nikobus signalé(s) comme hérité(s)",
             "fix_flow": {
                 "step": {
                     "init": {
                         "title": "Examiner les boutons Nikobus hérités",
-                        "description": "Ces {count} bouton(s) figurent dans votre stockage mais aucune table de registre de module ne s'y réfère après un scan complet de phase 2. Il s'agit soit :\n\n  - de boutons muraux utilisés uniquement pour des automatisations Home Assistant (sans action PC-Link) — à conserver ;\n  - de résidus d'un précédent propriétaire ou de matériel supprimé — à purger.\n\nPour récupérer un bouton purgé, relancez **Découvrir les modules et boutons** — la bibliothèque réinsère tout ce qui figure encore dans le projet PC-Link.\n\n{candidates}\n\nLaissez la liste vide et soumettez pour tout conserver.",
+                        "description": "Ces {count} bouton(s) sont signalés comme hérités après un scan complet de phase 2. La colonne Raison explique pourquoi :\n\n  - **no decoded links** — aucun module de sortie ne référence ce bouton. Soit un bouton mural utilisé uniquement pour des automatisations Home Assistant (à conserver), soit un résidu d'un précédent propriétaire (à purger).\n  - **residue / stale links** — les liens du bouton existent uniquement dans la mémoire de registre PC-Link / PC-Logic sans qu'aucun module de sortie actuel ne les enregistre, ou tous les modules liés ont été évincés. Typiquement une programmation résiduelle d'un précédent propriétaire que l'appairage DIN-button n'a pas effacée (à purger).\n\nPour récupérer un bouton purgé, relancez **Découvrir les modules et boutons** puis **Scanner les liens de tous les modules** — la bibliothèque réinsère tout ce qui figure encore dans le projet.\n\n{candidates}\n\nLaissez la liste vide et soumettez pour tout conserver.",
                         "data": {
                             "addresses": "Boutons à supprimer"
                         }

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -163,12 +163,12 @@
             }
         },
         "legacy_undecoded_buttons": {
-            "title": "{count} Nikobus-knop(pen) zonder gedecodeerde koppelingen",
+            "title": "{count} Nikobus-knop(pen) gemarkeerd als verouderd",
             "fix_flow": {
                 "step": {
                     "init": {
                         "title": "Verouderde Nikobus-knoppen beoordelen",
-                        "description": "Deze {count} knop(pen) staan in je opslag, maar geen enkele modulebestand verwijst ernaar na een volledige fase-2-scan. Het gaat om:\n\n  - Wandknoppen die alleen worden gebruikt voor Home Assistant-automatiseringen (geen PC-Link-actie) — behouden.\n  - Resten van een vorige eigenaar of verwijderde hardware — opschonen.\n\nOm een gewiste knop te herstellen, voer **Modules en knoppen ontdekken** opnieuw uit — de bibliotheek voegt alles wat nog in het PC-Link-project staat opnieuw toe.\n\n{candidates}\n\nLaat de lijst leeg en bevestig om alles te behouden.",
+                        "description": "Deze {count} knop(pen) zijn als verouderd gemarkeerd na een volledige fase-2-scan. De kolom Reden legt uit waarom:\n\n  - **no decoded links** — geen output-module verwijst naar deze knop. Ofwel een wandknop die alleen wordt gebruikt voor Home Assistant-automatiseringen (behouden), ofwel resten van een vorige eigenaar (opschonen).\n  - **residue / stale links** — de koppelingen van de knop bestaan alleen in het PC-Link-/PC-Logic-registergeheugen zonder dat een huidige output-module ze opslaat, of elke gekoppelde module is verwijderd. Doorgaans residuele programmering van een vorige eigenaar die door DIN-button-koppeling niet is gewist (opschonen).\n\nOm een gewiste knop te herstellen, voer **Modules en knoppen ontdekken** opnieuw uit en daarna **Modulelinks scannen** — de bibliotheek voegt alles wat nog in het project staat opnieuw toe.\n\n{candidates}\n\nLaat de lijst leeg en bevestig om alles te behouden.",
                         "data": {
                             "addresses": "Te verwijderen knoppen"
                         }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -604,6 +604,18 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
         coord._collect_button_linked_modules = staticmethod(
             NikobusDataCoordinator._collect_button_linked_modules
         )
+        # Wire the 0.5.22 record_source helpers so the bucketing path
+        # uses real implementations instead of MagicMock returns (which
+        # would be truthy and skew the classifier).
+        coord._collect_button_outputs = staticmethod(
+            NikobusDataCoordinator._collect_button_outputs
+        )
+        coord._all_outputs_registry_sourced = staticmethod(
+            NikobusDataCoordinator._all_outputs_registry_sourced
+        )
+        coord._has_pc_logic_module = (
+            lambda self_=coord: NikobusDataCoordinator._has_pc_logic_module(self_)
+        )
         # Bind ``_reconcile_post_discovery`` to forward the sweep state
         # the way ``_handle_discovery_finished`` does in production:
         # via the kwargs that nikobus-connect 0.5.20 passes through
@@ -1149,6 +1161,161 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
 
         coord._surface_legacy_undecoded_buttons.assert_not_called()
 
+    # ------------------------------------------------------------------
+    # nikobus-connect 0.5.22 record_source classification
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _button_with_outputs(*records: dict) -> dict:
+        """Construct a button whose 1A op-point has ``linked_modules``
+        carrying ``records`` as its outputs."""
+        return {
+            "type": "Bus push button",
+            "operation_points": {
+                "1A": {
+                    "bus_address": "AABBCC",
+                    "linked_modules": [
+                        {"module_address": "8110", "outputs": list(records)},
+                    ],
+                }
+            },
+        }
+
+    async def test_registry_only_outputs_classified_as_legacy_orphan_when_no_pc_logic(self):
+        # IKIKN scenario: every output record for this button is
+        # sourced from PC-Link / PC-Logic registry, and the install
+        # has NO PC-Logic module. Unambiguous residue programming
+        # from a previous owner — bucket as legacy_orphan.
+        coord = self._make_coordinator_stub(
+            modules={"8110": {"module_type": "switch_module"}},
+            buttons={"3C4CE8": self._button_with_outputs(
+                {"channel": 11, "mode": "M07",
+                 "payload": "0A...", "button_address": "3C4CE8",
+                 "record_source": "pc_link_registry"},
+            )},
+            manifest={
+                "checked": ["8110"],
+                "present_modules": ["8110"],
+                "absent_modules": [], "orphaned_buttons": [],
+            },
+            inventory_query_type=InventoryQueryType.MODULE,
+            last_module_scan_was_full=True,
+        )
+
+        await coord._reconcile_post_discovery()
+
+        self.assertEqual(
+            coord.dict_button_data["nikobus_button"]["3C4CE8"]["status"],
+            "legacy_orphan",
+        )
+
+    async def test_registry_only_outputs_stay_active_when_pc_logic_present(self):
+        # Same button shape, but the install has a PC-Logic module.
+        # The registry-only output could be a legitimate PC-Logic
+        # scene trigger; defer to the existing classifier. With
+        # linked target (8110) surviving the probe, the button is
+        # ``active`` and the user can adjudicate manually if needed.
+        coord = self._make_coordinator_stub(
+            modules={
+                "8110": {"module_type": "switch_module"},
+                "940C": {"module_type": "pc_logic"},
+            },
+            buttons={"3C4CE8": self._button_with_outputs(
+                {"channel": 11, "mode": "M07",
+                 "payload": "0A...", "button_address": "3C4CE8",
+                 "record_source": "pc_link_registry"},
+            )},
+            manifest={
+                "checked": ["8110"],
+                "present_modules": ["8110"],
+                "absent_modules": [], "orphaned_buttons": [],
+            },
+            inventory_query_type=InventoryQueryType.MODULE,
+            last_module_scan_was_full=True,
+        )
+
+        await coord._reconcile_post_discovery()
+
+        self.assertEqual(
+            coord.dict_button_data["nikobus_button"]["3C4CE8"]["status"],
+            "active",
+        )
+
+    async def test_mixed_record_sources_classified_active(self):
+        # One output is sourced from the output module's own table
+        # (authoritative current programming), another from PC-Link
+        # registry (potentially residue). At least one real link
+        # exists → button is active regardless of PC-Logic presence.
+        coord = self._make_coordinator_stub(
+            modules={"8110": {"module_type": "switch_module"}},
+            buttons={"AABBCC": self._button_with_outputs(
+                {"channel": 5, "mode": "M05",
+                 "payload": "FF34F4...", "button_address": "AABBCC",
+                 "record_source": "output_module_table"},
+                {"channel": 11, "mode": "M07",
+                 "payload": "0A...", "button_address": "AABBCC",
+                 "record_source": "pc_link_registry"},
+            )},
+            manifest={
+                "checked": ["8110"],
+                "present_modules": ["8110"],
+                "absent_modules": [], "orphaned_buttons": [],
+            },
+            inventory_query_type=InventoryQueryType.MODULE,
+            last_module_scan_was_full=True,
+        )
+
+        await coord._reconcile_post_discovery()
+
+        self.assertEqual(
+            coord.dict_button_data["nikobus_button"]["AABBCC"]["status"],
+            "active",
+        )
+
+    async def test_record_source_absent_falls_through_to_existing_classifier(self):
+        # Pre-0.5.22 data: outputs have no ``record_source`` field.
+        # Treat as source-unknown and let the existing
+        # linked-vs-remaining check decide. With linked module 8110
+        # surviving, this button is ``active`` — same behavior as
+        # before 0.5.22 adoption.
+        coord = self._make_coordinator_stub(
+            modules={"8110": {"module_type": "switch_module"}},
+            buttons={"AABBCC": self._button_with_outputs(
+                {"channel": 5, "mode": "M05",
+                 "payload": "FF34F4...", "button_address": "AABBCC"},
+                # No record_source key — pre-0.5.22 record shape.
+            )},
+            manifest={
+                "checked": ["8110"],
+                "present_modules": ["8110"],
+                "absent_modules": [], "orphaned_buttons": [],
+            },
+            inventory_query_type=InventoryQueryType.MODULE,
+            last_module_scan_was_full=True,
+        )
+
+        await coord._reconcile_post_discovery()
+
+        self.assertEqual(
+            coord.dict_button_data["nikobus_button"]["AABBCC"]["status"],
+            "active",
+        )
+
+    async def test_has_pc_logic_module_helper(self):
+        # Direct unit test of the topology gate.
+        coord_no_pc_logic = self._make_coordinator_stub(
+            modules={"8110": {"module_type": "switch_module"}},
+        )
+        coord_with_pc_logic = self._make_coordinator_stub(
+            modules={
+                "8110": {"module_type": "switch_module"},
+                "940C": {"module_type": "pc_logic"},
+            },
+        )
+
+        self.assertFalse(coord_no_pc_logic._has_pc_logic_module())
+        self.assertTrue(coord_with_pc_logic._has_pc_logic_module())
+
 
 class TestSurfaceLegacyUndecodedButtons(unittest.IsolatedAsyncioTestCase):
     """Direct tests for ``_surface_legacy_undecoded_buttons``.
@@ -1166,17 +1333,22 @@ class TestSurfaceLegacyUndecodedButtons(unittest.IsolatedAsyncioTestCase):
 
     @patch("custom_components.nikobus.coordinator.ir.async_create_issue")
     @patch("custom_components.nikobus.coordinator.ir.async_delete_issue")
-    def test_creates_issue_when_legacy_undecoded_buttons_present(
+    def test_creates_issue_for_both_legacy_buckets(
         self, mock_delete, mock_create
     ):
+        # Both ``legacy_undecoded`` and ``legacy_orphan`` are surfaced
+        # together for user review: undecoded = no links anywhere,
+        # orphan = residue programming or fully-evicted targets. Both
+        # warrant a "purge or keep?" decision.
         coord = self._coord_stub()
         buttons = {
             "1843B4": {"status": "legacy_undecoded",
                        "type": "Bus push button"},
             "0C2387": {"status": "legacy_undecoded",
                        "type": "RF transmitter"},
+            "AABBCC": {"status": "legacy_orphan",
+                       "type": "Bus push button"},
             "10152B": {"status": "active"},  # must be filtered out
-            "AABBCC": {"status": "legacy_orphan"},  # also filtered out
         }
 
         NikobusDataCoordinator._surface_legacy_undecoded_buttons(coord, buttons)
@@ -1189,11 +1361,13 @@ class TestSurfaceLegacyUndecodedButtons(unittest.IsolatedAsyncioTestCase):
             call_kwargs["translation_key"], "legacy_undecoded_buttons"
         )
         self.assertEqual(
-            call_kwargs["translation_placeholders"], {"count": "2"}
+            call_kwargs["translation_placeholders"], {"count": "3"}
         )
-        # Addresses sorted, uppercase, only the two legacy_undecoded entries.
+        # Addresses sorted, uppercase. Both buckets present, ``active``
+        # filtered out.
         self.assertEqual(
-            call_kwargs["data"]["addresses"], ["0C2387", "1843B4"]
+            call_kwargs["data"]["addresses"],
+            ["0C2387", "1843B4", "AABBCC"],
         )
         self.assertEqual(
             call_kwargs["data"]["entry_id"], "entry_test"
@@ -1201,15 +1375,15 @@ class TestSurfaceLegacyUndecodedButtons(unittest.IsolatedAsyncioTestCase):
 
     @patch("custom_components.nikobus.coordinator.ir.async_create_issue")
     @patch("custom_components.nikobus.coordinator.ir.async_delete_issue")
-    def test_deletes_issue_when_no_legacy_undecoded_remain(
+    def test_deletes_issue_when_no_legacy_buttons_remain(
         self, mock_delete, mock_create
     ):
+        # All buttons in ``active`` — neither legacy bucket has any
+        # entry. The Repairs issue should be cleared if previously open.
         coord = self._coord_stub()
-        # All buttons are decoded or have surviving links — issue
-        # should be cleared if it was previously open.
         buttons = {
             "1843B4": {"status": "active"},
-            "0C2387": {"status": "legacy_orphan"},
+            "0C2387": {"status": "active"},
         }
 
         NikobusDataCoordinator._surface_legacy_undecoded_buttons(coord, buttons)


### PR DESCRIPTION
## Why

nikobus-connect 0.5.22 ([PR #57](https://github.com/fdebrus/nikobus-connect/pull/57)) tags every decoded output record with a `record_source` field naming the scan source:

| Value | Source | Reliability |
|---|---|---|
| `output_module_table` | Switch / dimmer / roller module's own table | Current programming, authoritative |
| `pc_link_registry` | PC-Link flash registry memory | May be residue from a previous owner |
| `pc_logic_registry` | PC-Logic flash registry memory | Same |
| *(absent)* | Pre-0.5.22 data | Source unknown — don't classify on it |

This closes the IKIKN forensic chain. The 25 phantom-active buttons in IKIKN's install all have outputs marked `pc_link_registry`; the 17 real buttons each have at least one `output_module_table` record. Clean structural discriminator — no more guessing.

## Classification change

Bucketing in `_reconcile_post_discovery` now runs in this order:

1. **No outputs anywhere** → `legacy_undecoded` *(unchanged)*
2. **All outputs registry-sourced AND no PC-Logic in install** → `legacy_orphan` *(new — IKIKN fix)*
3. **All linked targets evicted** → `legacy_orphan` *(unchanged)*
4. **Otherwise** → `active` *(unchanged)*

Topology gate (no PC-Logic) prevents the FP on installs with PC-Logic, where a registry-only output could be a legitimate scene trigger. The check fires **before** the linked-vs-remaining check — IKIKN's phantoms have surviving linked targets (1CEC, 8110), so the old classifier marked them `active`.

## Repairs flow extended

`_surface_legacy_undecoded_buttons` now collects **both** `legacy_undecoded` AND `legacy_orphan` candidates. The flow's table gains a `Reason` column so users can see *why* each button was flagged:

```
| Address  | Type             | Model   | Reason                  | Description |
|----------|------------------|---------|-------------------------|-------------|
| `3C4CE8` | Bus push button  | 05-346  | residue / stale links   | …           |
| `100144` | 8-button w/ LEDs | 05-078  | no decoded links        | …           |
```

Issue id `legacy_undecoded_buttons` and translation key kept stable to avoid orphaning existing Repairs entries during upgrade. Translation strings (en / fr / nl) updated to describe both bucket types and the recover-via-rediscovery path.

## Expected behaviour on IKIKN

```
Before: active=41 (14 real + 25 phantom) + legacy_undecoded=10
After:  active=14 + legacy_orphan=25 + legacy_undecoded=12
        (the 12 = 3 valid HA-Hue triggers + 9 phantom-undecoded)
```

Repairs issue title goes from "10 button(s) without decoded links" → "37 button(s) flagged as legacy".

## Behaviour on installs WITH PC-Logic (e.g. fdebrus's own 940C)

Topology gate skips the registry-only check. Buttons with `pc_link_registry`-sourced outputs fall through to the existing classifier — if their linked output modules survive the probe, they stay `active`. User can elevate / purge per-button via the existing service if a real residue case is found. The library handoff floated a separate `legacy_registry_only` bucket as a future iteration; for now the conservative path is taken.

## Tests — 29 reconciliation tests pass in 0.63 s

Five new:

- **`test_registry_only_outputs_classified_as_legacy_orphan_when_no_pc_logic`** — IKIKN's exact scenario.
- **`test_registry_only_outputs_stay_active_when_pc_logic_present`** — topology gate suppresses the FP.
- **`test_mixed_record_sources_classified_active`** — one `output_module_table` + one `pc_link_registry` → `active`.
- **`test_record_source_absent_falls_through_to_existing_classifier`** — pre-0.5.22 records keep existing classification (backward compat without data migration).
- **`test_has_pc_logic_module_helper`** — direct unit test of the topology gate.

Two existing updated:

- **`test_creates_issue_for_both_legacy_buckets`** (renamed) — surfaces include `legacy_orphan` now.
- **`test_deletes_issue_when_no_legacy_buttons_remain`** (renamed) — must use only `active` to leave both legacy buckets empty.

Stub wired with the three new helpers so MagicMock doesn't skew classification.

## Validation on IKIKN

1. Reload integration on 2.0.26.
2. Run **Discover modules & buttons**.
3. Run **Scan all module links**.
4. Expected: `active=14 legacy_orphan=25 legacy_undecoded=12` in the reconciliation log.
5. Repairs issue title: "37 Nikobus button(s) flagged as legacy".
6. Open Fix flow → see Reason column → pick the 34 residue (25 + 9, leave the 3 real HA-Hue triggers) → submit.
7. Post-cleanup: `active=14 legacy_undecoded=3`.

## Diffstat

```
custom_components/nikobus/coordinator.py       | 118 +++++++++++++--
custom_components/nikobus/manifest.json        |   4 +-
custom_components/nikobus/repairs.py           |  59 +++++---
custom_components/nikobus/translations/en.json |   4 +-
custom_components/nikobus/translations/fr.json |   4 +-
custom_components/nikobus/translations/nl.json |   4 +-
tests/test_coordinator.py                      | 192 +++++++++++++++++++++++--
7 files changed, 337 insertions(+), 48 deletions(-)
```

Manifest 2.0.25 → 2.0.26.

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_