### PR TITLE
Drop unreachable hasattr guards + extract via_device registration helper

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -375,7 +375,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 self.nikobus_discovery.handle_device_address_inventory(message)
             else:
                 await self.nikobus_discovery.query_module_inventory(message[3:7])
-        elif hasattr(self.nikobus_discovery, "process_mode_button_press"):
+        else:
             await self.nikobus_discovery.process_mode_button_press(message)
 
     async def _discovery_frame_callback(self, message: str) -> None:
@@ -1239,12 +1239,6 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         field is the marker for HA UI / diagnostics.
         """
         if self.nikobus_discovery is None:
-            return
-        if not hasattr(self.nikobus_discovery, "detect_stale_inventory"):
-            _LOGGER.warning(
-                "nikobus-connect lacks detect_stale_inventory — install >= 0.5.20; "
-                "skipping post-discovery reconciliation"
-            )
             return
 
         # --- Sweep snapshot --------------------------------------------

--- a/custom_components/nikobus/cover.py
+++ b/custom_components/nikobus/cover.py
@@ -15,23 +15,20 @@ from homeassistant.components.cover import (
     CoverEntityFeature,
 )
 from homeassistant.core import Event, HomeAssistant, callback
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
-    BRAND,
     DEFAULT_COVER_DEBOUNCE_DELAY,
     DEFAULT_COVER_MOVEMENT_BUFFER,
     DEFAULT_COVER_OPERATION_TIME,
     DOMAIN,
     EVENT_BUTTON_PRESSED,
-    CATEGORY_OUTPUT_MODULES,
 )
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity
 from .nkbtravelcalculator import NikobusTravelCalculator
-from .router import build_unique_id, get_routing
+from .router import build_unique_id, get_routing, register_output_module_devices
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -76,20 +73,12 @@ async def async_setup_entry(
 ) -> None:
     """Set up Nikobus cover entities from a config entry."""
     coordinator: NikobusDataCoordinator = entry.runtime_data
-    device_registry = dr.async_get(hass)
     routing = get_routing(hass, entry, coordinator.dict_module_data)
+    specs = routing.get("cover", [])
+    register_output_module_devices(hass, entry, specs)
 
     entities = []
-    for spec in routing["cover"]:
-        device_registry.async_get_or_create(
-            config_entry_id=entry.entry_id,
-            identifiers={(DOMAIN, spec.address)},
-            manufacturer=BRAND,
-            name=spec.module_desc,
-            model=spec.module_model,
-            via_device=(DOMAIN, CATEGORY_OUTPUT_MODULES),
-        )
-
+    for spec in specs:
         op_time_up = _parse_operation_time(
             spec.operation_time_up,
             DEFAULT_COVER_OPERATION_TIME,

--- a/custom_components/nikobus/light.py
+++ b/custom_components/nikobus/light.py
@@ -8,14 +8,13 @@ from typing import Any
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
 from homeassistant.core import Event, HomeAssistant, callback
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .const import BRAND, CATEGORY_OUTPUT_MODULES, DOMAIN, EVENT_BUTTON_OPERATION
+from .const import DOMAIN, EVENT_BUTTON_OPERATION
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity
-from .router import build_unique_id, get_routing
+from .router import build_unique_id, get_routing, register_output_module_devices
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,24 +28,13 @@ async def async_setup_entry(
 ) -> None:
     """Set up Nikobus light entities from a config entry."""
     coordinator: NikobusDataCoordinator = entry.runtime_data
-    device_registry = dr.async_get(hass)
-    registered_addresses: set[str] = set()
     entities: list[LightEntity] = []
 
     routing = get_routing(hass, entry, coordinator.dict_module_data)
-    
-    for spec in routing.get("light", []):
-        if spec.address not in registered_addresses:
-            device_registry.async_get_or_create(
-                config_entry_id=entry.entry_id,
-                identifiers={(DOMAIN, spec.address)},
-                manufacturer=BRAND,
-                name=spec.module_desc,
-                model=spec.module_model,
-                via_device=(DOMAIN, CATEGORY_OUTPUT_MODULES),
-            )
-            registered_addresses.add(spec.address)
+    specs = routing.get("light", [])
+    register_output_module_devices(hass, entry, specs)
 
+    for spec in specs:
         if spec.kind == "dimmer_light":
             entities.append(
                 NikobusDimmerEntity(

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.0.27",
+  "version": "2.0.28",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/custom_components/nikobus/router.py
+++ b/custom_components/nikobus/router.py
@@ -4,18 +4,49 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any, Iterable, Mapping
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
-from .const import DOMAIN
+from .const import BRAND, CATEGORY_OUTPUT_MODULES, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+
+def register_output_module_devices(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    specs: Iterable["EntitySpec"],
+) -> None:
+    """Register one device per physical output module address.
+
+    Called from each output platform's ``async_setup_entry``. Deduplicates
+    by address so multi-channel modules only register once. The
+    ``via_device`` parent is the ``Output modules`` category device so the
+    integration UI nests this module under that group (PR #338).
+
+    Idempotent — ``device_registry.async_get_or_create`` returns the
+    existing record on subsequent calls with the same identifiers.
+    """
+    device_registry = dr.async_get(hass)
+    registered: set[str] = set()
+    for spec in specs:
+        if spec.address in registered:
+            continue
+        device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, spec.address)},
+            manufacturer=BRAND,
+            name=spec.module_desc,
+            model=spec.module_model,
+            via_device=(DOMAIN, CATEGORY_OUTPUT_MODULES),
+        )
+        registered.add(spec.address)
+
 _ROUTING_CACHE_KEY = "routing"
 
-# CLEANUP: Move static capabilities to module level so they are only created once in memory
 _CAPABILITIES = {
     "roller_module": {"cover", "switch", "light"},
     "switch_module": {"switch", "light"},

--- a/custom_components/nikobus/switch.py
+++ b/custom_components/nikobus/switch.py
@@ -8,14 +8,13 @@ from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import Event, HomeAssistant, callback
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .const import BRAND, CATEGORY_OUTPUT_MODULES, DOMAIN, EVENT_BUTTON_OPERATION
+from .const import DOMAIN, EVENT_BUTTON_OPERATION
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity
-from .router import build_unique_id, get_routing
+from .router import build_unique_id, get_routing, register_output_module_devices
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,24 +28,13 @@ async def async_setup_entry(
 ) -> None:
     """Set up Nikobus switch entities from a config entry."""
     coordinator: NikobusDataCoordinator = entry.runtime_data
-    device_registry = dr.async_get(hass)
-    registered_addresses: set[str] = set()
     entities: list[SwitchEntity] = []
 
     routing = get_routing(hass, entry, coordinator.dict_module_data)
-    
-    for spec in routing.get("switch", []):
-        if spec.address not in registered_addresses:
-            device_registry.async_get_or_create(
-                config_entry_id=entry.entry_id,
-                identifiers={(DOMAIN, spec.address)},
-                manufacturer=BRAND,
-                name=spec.module_desc,
-                model=spec.module_model,
-                via_device=(DOMAIN, CATEGORY_OUTPUT_MODULES),
-            )
-            registered_addresses.add(spec.address)
+    specs = routing.get("switch", [])
+    register_output_module_devices(hass, entry, specs)
 
+    for spec in specs:
         if spec.kind == "relay_switch":
             entities.append(
                 NikobusRelaySwitchEntity(


### PR DESCRIPTION
## Why

Code-audit cleanup. Three findings the audit flagged as HIGH-confidence cleanup, plus the MEDIUM refactor for the via_device duplication PR #338 introduced.

Skipped: the legacy migration paths (per your feedback — users still mid-migration).

## Changes

### 1. Drop unreachable `hasattr(detect_stale_inventory)` guard

`coordinator.py:1243` — removed. Manifest pins `nikobus-connect>=0.5.22` (since 2.0.26); the method shipped in 0.5.16. Guard never fires. The warning log line claiming `"install >= 0.5.20"` was also stale (we require 0.5.22).

### 2. Drop unreachable `hasattr(process_mode_button_press)` guard

`coordinator.py:378` — `elif hasattr(...)` → plain `else:`. Method present in library since pre-0.5.20; defensive guard added when the method was new and forgotten.

### 3. Drop stale `# CLEANUP:` comment in `router.py`

The dict it talked about moving "to module level" is already at module level. Comment misled readers into thinking work was pending.

### 4. Extract `register_output_module_devices` helper

PR #338 introduced three identical 12-line `via_device=CATEGORY_OUTPUT_MODULES` registration blocks across `switch.py` / `light.py` / `cover.py`. Collapsed into a single helper in `router.py`:

```python
def register_output_module_devices(hass, entry, specs):
    """Register one device per physical output module address.
    Deduplicates by address; idempotent via async_get_or_create."""
    device_registry = dr.async_get(hass)
    registered: set[str] = set()
    for spec in specs:
        if spec.address in registered:
            continue
        device_registry.async_get_or_create(
            config_entry_id=entry.entry_id,
            identifiers={(DOMAIN, spec.address)},
            manufacturer=BRAND,
            name=spec.module_desc,
            model=spec.module_model,
            via_device=(DOMAIN, CATEGORY_OUTPUT_MODULES),
        )
        registered.add(spec.address)
```

Each platform's setup loop calls it once and iterates the same `specs` for entity creation. Behavior unchanged — `async_get_or_create` is idempotent on `identifiers`, so the per-platform dedup set was already redundant; the helper preserves it for the perf-on-multi-channel-modules case.

**Side benefit on `cover.py`:** the pre-refactor code called `async_get_or_create` once per channel iteration with no dedup. The helper deduplicates, so multi-cover modules now go from N-calls-per-channel to one-call-per-address. Tiny perf improvement, registry log noise reduced.

## What's NOT in this PR

Per your guidance, the legacy migration paths stay:
- `_async_migrate_legacy_button_names` (v1 button schema → v2)
- `async_migrate_legacy_module_config` (pre-0.4.0 module config → HA Store)

Users still mid-migration, cost on hot path negligible.

## Tests

Pure code-shape change. 36 relevant reconciliation/repair tests pass:

```
$ python -m pytest tests/test_coordinator.py::TestReconcilePostDiscovery \
    tests/test_coordinator.py::TestSurfaceLegacyUndecodedButtons \
    tests/test_coordinator.py::TestPurgeInventoryAddresses -q
....................................                                     [100%]
36 passed in 0.56s
```

The 20 pre-existing `TestFeedbackCallback` / `TestSetByteArrayGroupState` failures on main are unchanged — unrelated to this PR.

## Diffstat

```
custom_components/nikobus/coordinator.py |  8 +------
custom_components/nikobus/cover.py       | 19 ++++------------
custom_components/nikobus/light.py       | 22 +++++--------------
custom_components/nikobus/manifest.json  |  2 +-
custom_components/nikobus/router.py      | 37 +++++++++++++++++++++++++++++---
custom_components/nikobus/switch.py      | 22 +++++--------------
6 files changed, 50 insertions(+), 60 deletions(-)
```

Net **-10 lines** + a reusable helper.

Manifest 2.0.27 → 2.0.28.

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_