### PR TITLE
Auto-reconnect on total polling-cycle blackout (issue #337)

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -530,20 +530,65 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
     # ------------------------------------------------------------------
 
     async def _async_update_data(self) -> None:
-        """Refresh latest data from the Nikobus system via polling."""
+        """Refresh latest data from the Nikobus system via polling.
+
+        Total-blackout auto-recovery: if every poll in a single cycle
+        fails (every output module times out), the bus is silent —
+        most likely PC-Link / FTDI idle sleep after the 120 s gap
+        between polls (issue #337). Trigger the same reconnect path
+        the user used to manually invoke (close + reopen + handshake)
+        so the integration self-heals.
+        """
         if self.discovery_running:
             return None
+        polled = 0
+        failures = 0
         try:
             for module_type in MODULE_TYPES:
                 if module_type in self.dict_module_data:
-                    await self._refresh_module_type(self.dict_module_data[module_type])
+                    polled_n, failed_n = await self._refresh_module_type(
+                        self.dict_module_data[module_type]
+                    )
+                    polled += polled_n
+                    failures += failed_n
             return None
         except NikobusDataError as err:
             _LOGGER.error("Error fetching Nikobus data: %s", err)
             raise UpdateFailed(f"Data refresh failed: {err}") from err
+        finally:
+            if (
+                polled > 0
+                and failures == polled
+                and not self._stopping
+            ):
+                _LOGGER.warning(
+                    "Nikobus poll cycle: %d/%d commands timed out — "
+                    "bus silent. Triggering reconnect (issue #337).",
+                    failures,
+                    polled,
+                )
+                # Background task — don't block the coordinator's
+                # refresh-cycle slot. ``_handle_connection_lost`` is
+                # idempotent (no-op if a reconnect task is already
+                # running) so retry-storms are prevented.
+                self.hass.async_create_background_task(
+                    self._handle_connection_lost(),
+                    name="nikobus_blackout_recovery",
+                )
 
-    async def _refresh_module_type(self, modules_dict: dict[str, Any]) -> None:
-        """Poll the bus for each module address in a collection."""
+    async def _refresh_module_type(
+        self, modules_dict: dict[str, Any]
+    ) -> tuple[int, int]:
+        """Poll each module, return (polled, failed) counts.
+
+        Per-module / per-group timeouts are still swallowed (logged
+        as ERROR) so a single transient failure doesn't block other
+        modules from refreshing in the same cycle. The aggregate
+        counts roll up to ``_async_update_data`` for blackout
+        detection.
+        """
+        polled = 0
+        failed = 0
         for address, module_data in modules_dict.items():
             normalized = str(address).upper()
             channels = module_data.get("channels", [])
@@ -551,6 +596,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             groups = (1,) if chan_count <= 6 else (1, 2)
 
             for g in groups:
+                polled += 1
                 try:
                     state_hex = await self.nikobus_command.get_output_state(normalized, g) or ""
                     if state_hex and len(state_hex) >= 12:
@@ -560,15 +606,19 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                             buf = bytearray(12)
                             self._module_states[normalized] = buf
                         buf[start : start + 6] = bytes.fromhex(state_hex[:12])
+                    else:
+                        failed += 1
                 except asyncio.CancelledError:
                     raise
                 except Exception as err:
+                    failed += 1
                     _LOGGER.error("Error refreshing %s group %d: %s", normalized, g, err)
 
             await self.async_event_handler(
                 "nikobus_refreshed",
                 {"impacted_module_address": normalized},
             )
+        return polled, failed
 
     # ------------------------------------------------------------------
     # State buffer accessors (delegate to library or direct buffer access)

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.0.28",
+  "version": "2.0.29",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1398,6 +1398,150 @@ class TestSurfaceLegacyUndecodedButtons(unittest.IsolatedAsyncioTestCase):
 
 
 # ---------------------------------------------------------------------------
+# Total-blackout auto-recovery (issue #337)
+# ---------------------------------------------------------------------------
+
+class TestBlackoutAutoRecovery(unittest.IsolatedAsyncioTestCase):
+    """Pin the polling-cycle blackout detection that triggers reconnect.
+
+    On idle-induced PC-Link / FTDI sleep, every poll in a single cycle
+    times out without the serial FD raising any error — the coordinator's
+    standard reconnect supervisor (which watches FD errors) doesn't
+    notice. This tests the new aggregate-failure path that detects
+    "all polls failed" and kicks ``_handle_connection_lost`` so the
+    integration self-heals.
+    """
+
+    def _make_coord(
+        self,
+        modules: dict[str, dict],
+        *,
+        get_output_state_side_effect=None,
+    ):
+        coord = MagicMock()
+        coord.discovery_running = False
+        coord._stopping = False
+        coord.dict_module_data = modules
+        coord._module_states = {}
+        coord.nikobus_command = MagicMock()
+        coord.nikobus_command.get_output_state = AsyncMock(
+            side_effect=get_output_state_side_effect
+        )
+        coord.async_event_handler = AsyncMock()
+        coord.hass = MagicMock()
+        coord._handle_connection_lost = AsyncMock()
+
+        # Capture the background-task callable so we can assert on it.
+        # Close the coroutine arg so Python doesn't warn about an
+        # unawaited ``_handle_connection_lost()`` call slot.
+        def _consume(coro=None, *, name=None):
+            if coro is not None and hasattr(coro, "close"):
+                coro.close()
+
+        coord.hass.async_create_background_task = MagicMock(
+            side_effect=_consume
+        )
+        # Bind real _refresh_module_type so the count-tracking logic
+        # actually runs against the mocked get_output_state. The
+        # unbound staticmethod-style call hands ``coord`` in as self.
+        coord._refresh_module_type = (
+            lambda md, _coord=coord:
+            NikobusDataCoordinator._refresh_module_type(_coord, md)
+        )
+        return coord
+
+    async def test_total_blackout_triggers_reconnect(self):
+        # Every poll fails → reconnect kicked.
+        from nikobus_connect.exceptions import NikobusTimeoutError
+        coord = self._make_coord(
+            modules={"switch_module": {
+                "8110": {"channels": [{}, {}, {}, {}, {}, {}, {}]},  # 7 channels → 2 groups
+                "1CEC": {"channels": [{}, {}, {}, {}]},               # 4 channels → 1 group
+            }},
+            get_output_state_side_effect=NikobusTimeoutError("timeout"),
+        )
+
+        await NikobusDataCoordinator._async_update_data(coord)
+
+        # 8110 has 7 channels → groups (1, 2) = 2 polls
+        # 1CEC has 4 channels → groups (1,)  = 1 poll
+        # Total = 3 polls, all failed → reconnect triggered.
+        coord.hass.async_create_background_task.assert_called_once()
+        # Verify the task is for connection recovery (background task
+        # name matches our new label).
+        call_kwargs = coord.hass.async_create_background_task.call_args.kwargs
+        self.assertEqual(call_kwargs.get("name"), "nikobus_blackout_recovery")
+
+    async def test_partial_failure_no_reconnect(self):
+        # 2 of 3 polls fail; 1 succeeds → blackout NOT triggered.
+        # ``side_effect=list`` consumes one entry per call.
+        from nikobus_connect.exceptions import NikobusTimeoutError
+        coord = self._make_coord(
+            modules={"switch_module": {
+                "8110": {"channels": [{}, {}, {}, {}, {}, {}, {}]},
+                "1CEC": {"channels": [{}, {}, {}, {}]},
+            }},
+            get_output_state_side_effect=[
+                "0000FFFF0000FFFE2245",        # success — 12-hex-char state
+                NikobusTimeoutError("timeout"),
+                NikobusTimeoutError("timeout"),
+            ],
+        )
+
+        await NikobusDataCoordinator._async_update_data(coord)
+
+        # Some polls succeeded — not a blackout. No reconnect.
+        coord.hass.async_create_background_task.assert_not_called()
+
+    async def test_all_polls_succeed_no_reconnect(self):
+        coord = self._make_coord(
+            modules={"switch_module": {
+                "8110": {"channels": [{}, {}, {}, {}]},
+            }},
+            get_output_state_side_effect=lambda *args, **kw: "0000FFFF000000",
+        )
+
+        await NikobusDataCoordinator._async_update_data(coord)
+
+        coord.hass.async_create_background_task.assert_not_called()
+
+    async def test_no_modules_no_reconnect(self):
+        # Empty install (e.g., user removed all output modules) →
+        # polled=0, so blackout check skips even though failures=0.
+        coord = self._make_coord(modules={"switch_module": {}})
+
+        await NikobusDataCoordinator._async_update_data(coord)
+
+        coord.hass.async_create_background_task.assert_not_called()
+
+    async def test_discovery_running_skips_polling(self):
+        coord = self._make_coord(
+            modules={"switch_module": {"8110": {"channels": [{}, {}]}}},
+        )
+        coord.discovery_running = True
+
+        await NikobusDataCoordinator._async_update_data(coord)
+
+        # Polling guard skipped the cycle entirely; no reconnect attempt.
+        coord.hass.async_create_background_task.assert_not_called()
+        coord.nikobus_command.get_output_state.assert_not_called()
+
+    async def test_stopping_does_not_trigger_reconnect(self):
+        # If the integration is shutting down, blackout-recovery
+        # should NOT kick — we're going away anyway.
+        from nikobus_connect.exceptions import NikobusTimeoutError
+        coord = self._make_coord(
+            modules={"switch_module": {"8110": {"channels": [{}, {}]}}},
+            get_output_state_side_effect=NikobusTimeoutError("timeout"),
+        )
+        coord._stopping = True
+
+        await NikobusDataCoordinator._async_update_data(coord)
+
+        coord.hass.async_create_background_task.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Helper: _collect_button_linked_modules
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Why

Issue #337 forensic chain wraps up. From IKIKN's debug log:

```
21:28:46  Setup complete, first polls succeeded ✓
21:30:46  Next scheduled poll fires (+120 s default refresh interval)
21:31:01  All 3 polls timed out (15 s = 3 internal retries × 5 s)
21:31:31  Next polling cycle, all 3 fail again
...       Stays broken until manual reload
```

This is **idle-induced PC-Link / FTDI sleep**. The bus is responsive at T+0 (cold-start polls work cleanly), goes silent in the 120 s gap before the next scheduled poll, and never recovers on its own. The integration's existing reconnect supervisor only watches for serial-FD errors — a "connection up but bus silent" condition isn't currently detected, so the user has to manually reload.

Manual reload restores it because `disconnect()` + fresh `connect()` re-asserts USB control transfers and wakes whatever's asleep — same sequence the auto-recovery now triggers.

## Fix

When **every poll in a single cycle** times out, treat the bus as silent and schedule the same reconnect path the user uses manually:

- `_refresh_module_type` returns `(polled, failed)` instead of swallowing per-group errors silently.
- `_async_update_data` aggregates the counts. When `failures == polled > 0`, calls `hass.async_create_background_task(self._handle_connection_lost(), name="nikobus_blackout_recovery")`.
- The reconnect loop already does fresh disconnect → connect → handshake → state refresh — exactly the manual-reload sequence.

## Design choices

**Background task vs inline await:** `_handle_connection_lost` blocks 5–15 s for reconnect. Backgrounding lets the refresh slot finish cleanly; the next refresh fires 2 min later, by which point reconnect should have completed.

**"All-failed" not "any-failed":** A single failed poll can be transient bus contention. All-failed is the unambiguous bus-dead signal. `_handle_connection_lost` is itself idempotent (no-op if a reconnect task is already running) so consecutive cycles can't trigger retry storms.

**Stopping guard:** `_stopping=True` short-circuits the recovery — don't kick recovery against a config entry that's being torn down.

## Tests — 42 pass

6 new in `TestBlackoutAutoRecovery`:

- `test_total_blackout_triggers_reconnect` — every poll times out → background task scheduled with name `"nikobus_blackout_recovery"`.
- `test_partial_failure_no_reconnect` — 1 of 3 polls succeed → no reconnect.
- `test_all_polls_succeed_no_reconnect` — happy path.
- `test_no_modules_no_reconnect` — empty install, blackout check skips.
- `test_discovery_running_skips_polling` — polling guard fires, no commands, no reconnect.
- `test_stopping_does_not_trigger_reconnect` — shutdown path doesn't kick recovery.

```
$ python -m pytest tests/test_coordinator.py::TestBlackoutAutoRecovery \
    tests/test_coordinator.py::TestReconcilePostDiscovery \
    tests/test_coordinator.py::TestSurfaceLegacyUndecodedButtons \
    tests/test_coordinator.py::TestPurgeInventoryAddresses -q
..........................................                               [100%]
42 passed in 0.54s
```

## Expected behaviour for IKIKN

| | Before | After |
|---|---|---|
| T+0 | Setup, polls work | Setup, polls work |
| T+2 min | All polls fail, integration broken | All polls fail → **"bus silent — triggering reconnect"** warning |
| T+~5 s after | — | Reconnect completes, fresh handshake, polls resume |
| T+4 min | Still broken | Next scheduled poll succeeds |
| User experience | **"needs reload every restart"** | No manual intervention needed |

If the underlying USB / PC-Link issue persists past one reconnect (unusual, would suggest hardware problem), each subsequent cycle would re-trigger. `_handle_connection_lost` is idempotent → no retry storms.

## What this doesn't fix

The **root cause** of the idle-sleep itself — that's likely USB autosuspend / FTDI power management on HAOS. A user-side `power/control = on` host workaround is documented possibility but out of scope for the integration. This PR makes the symptom self-healing regardless.

## Diffstat

```
custom_components/nikobus/coordinator.py |  58 ++++++++++++-
custom_components/nikobus/manifest.json  |   2 +-
tests/test_coordinator.py                | 144 +++++++++++++++++++++++++++++++
3 files changed, 199 insertions(+), 5 deletions(-)
```

Manifest 2.0.28 → 2.0.29.

Closes #337 (pending IKIKN validation on his install).

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_