### PR TITLE
Coalesce concurrent _handle_connection_lost calls (issue #337 race fix)

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -914,17 +914,42 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
     # ------------------------------------------------------------------
 
     async def _handle_connection_lost(self) -> None:
-        """Called by the listener when the connection drops."""
+        """Called by the listener when the connection drops, or by the
+        blackout-recovery path in ``_async_update_data``.
+
+        Coalesces concurrent calls. The current dedup check at the
+        bottom (``_reconnect_task is None or done``) only prevents
+        double-task-creation; it does NOT prevent ``nikobus_command.
+        stop()`` from running twice mid-reconnect. That second stop
+        races with the in-flight reconnect's ``connect()`` →
+        ``_handshake()``, producing the visible
+        ``Reconnect 1 failed: Cannot send: Not connected.`` error
+        users see in HA's notification UI (issue #337).
+
+        The race surfaces specifically when blackout-detection in
+        ``_async_update_data`` triggers ``_handle_connection_lost``
+        (call #1) → reconnect's fresh ``connect()`` opens a new FD →
+        old listener's pending ``read()`` fails with
+        ``IncompleteReadError`` → listener fires
+        ``on_connection_lost`` → ``_handle_connection_lost`` (call #2)
+        → second ``command.stop()`` corrupts the handshake. Coalescing
+        at function entry collapses #2 into a no-op.
+        """
         if self._stopping:
+            return
+        if self._reconnect_task is not None and not self._reconnect_task.done():
+            _LOGGER.debug(
+                "Reconnect already in progress — coalescing duplicate "
+                "connection-lost notification"
+            )
             return
         _LOGGER.warning("Nikobus connection lost — scheduling reconnect")
         self.async_update_listeners()
         if self.nikobus_command:
             await self.nikobus_command.stop()
-        if self._reconnect_task is None or self._reconnect_task.done():
-            self._reconnect_task = self.hass.async_create_background_task(
-                self._reconnect_loop(), name="nikobus_reconnect"
-            )
+        self._reconnect_task = self.hass.async_create_background_task(
+            self._reconnect_loop(), name="nikobus_reconnect"
+        )
 
     async def _reconnect_loop(self) -> None:
         """Exponential back-off reconnect loop."""

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.0.29",
+  "version": "2.0.30",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1542,6 +1542,85 @@ class TestBlackoutAutoRecovery(unittest.IsolatedAsyncioTestCase):
 
 
 # ---------------------------------------------------------------------------
+# Concurrent reconnect coalescing (issue #337 race fix)
+# ---------------------------------------------------------------------------
+
+class TestHandleConnectionLostCoalescing(unittest.IsolatedAsyncioTestCase):
+    """Pin the early-exit dedup so concurrent ``_handle_connection_lost``
+    calls don't race on ``nikobus_command.stop()`` mid-reconnect.
+
+    The race surfaces when blackout-detection triggers reconnect (call
+    #1) → reconnect's fresh ``connect()`` opens new FD → old listener's
+    pending ``read()`` fails → listener fires ``on_connection_lost`` →
+    ``_handle_connection_lost`` (call #2) → second ``command.stop()``
+    runs concurrently with the in-flight handshake, producing the
+    visible ``Reconnect 1 failed: Cannot send: Not connected.`` error.
+    """
+
+    def _make_coord(self, reconnect_task=None):
+        coord = MagicMock()
+        coord._stopping = False
+        coord._reconnect_task = reconnect_task
+        coord.nikobus_command = MagicMock()
+        coord.nikobus_command.stop = AsyncMock()
+        coord.async_update_listeners = MagicMock()
+        coord.hass = MagicMock()
+        # Capture the background-task creation; close coroutines so
+        # we don't get unawaited-coroutine warnings from the mock.
+        def _consume(coro=None, *, name=None):
+            if coro is not None and hasattr(coro, "close"):
+                coro.close()
+            task = MagicMock()
+            task.done = MagicMock(return_value=False)
+            return task
+        coord.hass.async_create_background_task = MagicMock(side_effect=_consume)
+        return coord
+
+    async def test_first_call_creates_reconnect_task(self):
+        coord = self._make_coord()
+
+        await NikobusDataCoordinator._handle_connection_lost(coord)
+
+        coord.nikobus_command.stop.assert_awaited_once()
+        coord.hass.async_create_background_task.assert_called_once()
+
+    async def test_concurrent_call_coalesces_to_noop(self):
+        # _reconnect_task already exists and is in-flight (not done).
+        in_flight = MagicMock()
+        in_flight.done = MagicMock(return_value=False)
+        coord = self._make_coord(reconnect_task=in_flight)
+
+        await NikobusDataCoordinator._handle_connection_lost(coord)
+
+        # Critical: command.stop() must NOT run a second time —
+        # that's what races with the in-flight handshake.
+        coord.nikobus_command.stop.assert_not_awaited()
+        # And no new reconnect task is created — coalesced.
+        coord.hass.async_create_background_task.assert_not_called()
+
+    async def test_done_reconnect_task_allows_new_reconnect(self):
+        # Previous reconnect completed → a NEW connection-lost event
+        # should start a fresh reconnect.
+        completed = MagicMock()
+        completed.done = MagicMock(return_value=True)
+        coord = self._make_coord(reconnect_task=completed)
+
+        await NikobusDataCoordinator._handle_connection_lost(coord)
+
+        coord.nikobus_command.stop.assert_awaited_once()
+        coord.hass.async_create_background_task.assert_called_once()
+
+    async def test_stopping_short_circuits(self):
+        coord = self._make_coord()
+        coord._stopping = True
+
+        await NikobusDataCoordinator._handle_connection_lost(coord)
+
+        coord.nikobus_command.stop.assert_not_awaited()
+        coord.hass.async_create_background_task.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Helper: _collect_button_linked_modules
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Why

PR #340's blackout auto-reconnect works as designed — the bus DOES heal — but produces a visible **`Reconnect 1 failed: Cannot send: Not connected.`** error notification in HA's UI before attempt 2 succeeds. Users read that error and conclude the integration is still broken.

From IKIKN's 2.0.29 system log:

```
22:30:41.519  Nikobus poll cycle: 3/3 commands timed out — bus silent.
              Triggering reconnect (issue #337).
22:30:41.519  Nikobus connection lost — scheduling reconnect (call #1)
22:30:41.527  Nikobus reconnect attempt 1 (delay 5s)…
22:30:41.542  Starting Nikobus handshake...
22:30:41.570  Listener loop error: Read error: 0 bytes read
22:30:41.574  Nikobus connection lost — scheduling reconnect (call #2)
22:30:41.??   Handshake failed: Cannot send: Not connected.
22:30:41.??   Reconnect 1 failed
22:30:46.751  Nikobus reconnect attempt 2 (delay 10s)…   ← clean run
22:30:48.377  Nikobus handshake completed
22:30:49.433  Nikobus reconnected after 2 attempt(s)
```

## Race mechanism

1. PR #340's blackout-detection in `_async_update_data` triggers `_handle_connection_lost` (call #1).
2. Call #1 runs `command.stop()`, creates `_reconnect_task`.
3. Reconnect's `connect()` opens a **new** serial FD.
4. The OLD listener's pending `read()` on the previous FD returns `IncompleteReadError` (kernel closed the supplanted FD).
5. Listener fires `on_connection_lost` → `_handle_connection_lost` (call #2).
6. **Call #2 runs `command.stop()` AGAIN, mid-handshake.**
7. The handshake's next `send()` finds `_is_connected == False` and raises `Cannot send: Not connected.`
8. Reconnect attempt 1 fails. Attempt 2 succeeds 5 s later because no second concurrent call interferes.

## Fix

The existing dedup (`_reconnect_task is None or done`) is at the **bottom** of `_handle_connection_lost` — it prevents double-task-creation but NOT the second `command.stop()`. Move dedup to the **front**:

```python
async def _handle_connection_lost(self) -> None:
    if self._stopping:
        return
    if self._reconnect_task is not None and not self._reconnect_task.done():
        _LOGGER.debug("Reconnect already in progress — coalescing call")
        return
    _LOGGER.warning("Nikobus connection lost — scheduling reconnect")
    ...
```

Second concurrent call early-exits without touching command/connection state. Single clean reconnect. **No "Reconnect 1 failed" notification.**

## Expected behaviour after this PR

```
T+0s    3/3 polls fail → blackout detected
T+0s    Call #1: schedules reconnect
T+0s    Reconnect attempt 1 starts → connect() → handshake
T+~ms   Call #2 from listener — early-exits (coalesced)
T+~2s   Handshake completes, reconnect succeeds cleanly
```

Total user-visible downtime: **~30 s for the polling cycle's 3 timeouts + ~2 s clean reconnect** (down from 30 s + ~10 s with bumpy reconnect). And critically: no error notification in HA's UI.

## Tests — 10 pass

4 new in `TestHandleConnectionLostCoalescing`:

- `test_first_call_creates_reconnect_task` — happy path: command stops, reconnect task created.
- `test_concurrent_call_coalesces_to_noop` — pin: when reconnect is in-flight, second call doesn't run `command.stop()` and doesn't create a duplicate task.
- `test_done_reconnect_task_allows_new_reconnect` — previous reconnect completed → next connection-lost event starts a fresh reconnect.
- `test_stopping_short_circuits` — shutdown path skips entirely.

Plus PR #340's 6 `TestBlackoutAutoRecovery` tests still pass — no regression.

```
$ python -m pytest tests/test_coordinator.py::TestHandleConnectionLostCoalescing \
    tests/test_coordinator.py::TestBlackoutAutoRecovery -q
..........                                                               [100%]
10 passed in 0.18s
```

## Diffstat

```
custom_components/nikobus/coordinator.py | 35 ++++++++++++--
custom_components/nikobus/manifest.json  |  2 +-
tests/test_coordinator.py                | 79 ++++++++++++++++++++++++++++++++
3 files changed, 110 insertions(+), 6 deletions(-)
```

Manifest 2.0.29 → 2.0.30.

Pairs with #340 — completes the auto-reconnect story for issue #337.

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_