### PR TITLE
Stop listener before reconnect to prevent disconnect-during-handshake (issue #337)

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -947,6 +947,22 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self.async_update_listeners()
         if self.nikobus_command:
             await self.nikobus_command.stop()
+        if self.nikobus_listener:
+            # Stop the listener BEFORE the reconnect runs. If we leave
+            # it running, its pending ``read()`` on the old reader
+            # will fire when ``connect()`` opens a new FD — the kernel
+            # closes the supplanted reader and the read raises
+            # ``IncompleteReadError``. The library's ``connection.read()``
+            # catches that and calls ``self.disconnect()``, which sets
+            # ``_is_connected = False`` on the SHARED connection object
+            # mid-handshake. The handshake's next ``send()`` then
+            # raises ``Cannot send: Not connected.`` and the reconnect
+            # attempt fails (issue #337 follow-up to PR #341).
+            #
+            # In the listener-initiated path (real read error), the
+            # listener has already exited via its own ``break`` and
+            # ``stop()`` is a no-op. Safe in both paths.
+            await self.nikobus_listener.stop()
         self._reconnect_task = self.hass.async_create_background_task(
             self._reconnect_loop(), name="nikobus_reconnect"
         )

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.0.30",
+  "version": "2.0.31",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1563,6 +1563,8 @@ class TestHandleConnectionLostCoalescing(unittest.IsolatedAsyncioTestCase):
         coord._reconnect_task = reconnect_task
         coord.nikobus_command = MagicMock()
         coord.nikobus_command.stop = AsyncMock()
+        coord.nikobus_listener = MagicMock()
+        coord.nikobus_listener.stop = AsyncMock()
         coord.async_update_listeners = MagicMock()
         coord.hass = MagicMock()
         # Capture the background-task creation; close coroutines so
@@ -1582,6 +1584,12 @@ class TestHandleConnectionLostCoalescing(unittest.IsolatedAsyncioTestCase):
         await NikobusDataCoordinator._handle_connection_lost(coord)
 
         coord.nikobus_command.stop.assert_awaited_once()
+        # Listener MUST be stopped before the reconnect runs — its
+        # pending read() on the old reader would otherwise fail when
+        # connect() opens a new FD, and the library's read() handler
+        # calls disconnect() which sets _is_connected=False
+        # mid-handshake.
+        coord.nikobus_listener.stop.assert_awaited_once()
         coord.hass.async_create_background_task.assert_called_once()
 
     async def test_concurrent_call_coalesces_to_noop(self):
@@ -1592,9 +1600,10 @@ class TestHandleConnectionLostCoalescing(unittest.IsolatedAsyncioTestCase):
 
         await NikobusDataCoordinator._handle_connection_lost(coord)
 
-        # Critical: command.stop() must NOT run a second time —
-        # that's what races with the in-flight handshake.
+        # Critical: command.stop() AND listener.stop() must NOT run a
+        # second time — both would race with the in-flight handshake.
         coord.nikobus_command.stop.assert_not_awaited()
+        coord.nikobus_listener.stop.assert_not_awaited()
         # And no new reconnect task is created — coalesced.
         coord.hass.async_create_background_task.assert_not_called()
 


### PR DESCRIPTION
## Why

PR #341's coalescing was correct but **incomplete**. 2.0.30 system log shows the dedup IS working — `Nikobus connection lost — scheduling reconnect` only fires **1 time** (vs 2 in 2.0.29). But the user still sees `Reconnect 1 failed: Cannot send: Not connected.` in HA's UI.

The race is deeper than I diagnosed. Tracing 2.0.30:

```
22:57:15  blackout detected → _handle_connection_lost (call #1, ONLY one ✓)
22:57:15  reconnect attempt 1 starts → connection.connect() opens NEW serial FD
22:57:15  OLD listener's pending read() on the previous FD fails
          (kernel closed the supplanted reader)
22:57:15  Read failed: 0 bytes read              ← from connection.read()
22:57:15  ← connection.read() catches IncompleteReadError and calls
            self.disconnect(), which sets _is_connected = False on
            the SHARED connection object
22:57:15  Handshake (mid-flow) sends next byte → _is_connected=False
22:57:15  Handshake failed: Cannot send: Not connected.
22:57:15  Reconnect 1 failed
```

The library's `connection.read()` on `IncompleteReadError` calls `self.disconnect()` on the shared connection object. Even though `connect()` has already replaced `_reader` / `_writer` with new ones, the disconnect flips `_is_connected = False` mid-handshake.

## Fix

Stop the listener BEFORE the reconnect runs, in `_handle_connection_lost`. The listener's `stop()` cancels the pending `read()` task and awaits it:

```python
if self.nikobus_listener:
    await self.nikobus_listener.stop()
```

After this, no read can fire on the supplanted FD → no `IncompleteReadError` → no spurious `disconnect()` → handshake completes cleanly.

In the listener-initiated path (real read error fires `on_connection_lost`), the listener has already exited via its own `break` before our handler runs. `stop()` is a no-op. Safe in both paths.

## Tests — 10 pass

`TestHandleConnectionLostCoalescing` updated: stub `nikobus_listener.stop` in the fixture, assert it's called in the happy path / NOT called in the coalesced path.

```
$ python -m pytest tests/test_coordinator.py::TestHandleConnectionLostCoalescing \
    tests/test_coordinator.py::TestBlackoutAutoRecovery -q
..........                                                               [100%]
10 passed in 0.25s
```

## Expected behaviour for IKIKN

```
T+0      Setup, polls work
T+~135s  Polls fail (3/3)
T+~150s  blackout detected → _handle_connection_lost
T+~150s  command.stop()
T+~150s  listener.stop()                          ← NEW
T+~150s  reconnect attempt 1 → connect() opens fresh FD
T+~150s  Handshake bytes flow without interference (no old listener)
T+~152s  Handshake completes
T+~152s  listener.start() (in _reconnect_loop)
T+~152s  Reconnected after 1 attempt(s)
```

**No `Reconnect 1 failed` notification in HA's UI.** Recovery time drops from ~10 s (with bumpy retry) to ~2 s.

## Diffstat

```
custom_components/nikobus/coordinator.py | 16 ++++++++++++++++
custom_components/nikobus/manifest.json  |  2 +-
tests/test_coordinator.py                | 13 +++++++++++--
3 files changed, 28 insertions(+), 3 deletions(-)
```

Manifest 2.0.30 → 2.0.31.

Completes the auto-reconnect story for issue #337 — pairs with #340 (blackout detection) + #341 (call coalescing).

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_