### PR TITLE
Demote per-group poll-failure log from ERROR to DEBUG (issue #337)

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -612,7 +612,20 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                     raise
                 except Exception as err:
                     failed += 1
-                    _LOGGER.error("Error refreshing %s group %d: %s", normalized, g, err)
+                    # Per-group failures are noise on installs that
+                    # hit periodic bus-silent windows (issue #337) —
+                    # they show up as N separate ERROR entries in
+                    # HA's System Log panel even though the aggregate
+                    # WARNING "Nikobus poll cycle: N/N commands timed
+                    # out — bus silent. Triggering reconnect." in
+                    # ``_async_update_data`` already conveys the
+                    # actionable signal. Keep individual failures at
+                    # DEBUG for log-trace diagnostics; the WARNING +
+                    # the subsequent "scheduling reconnect" line are
+                    # what the user needs to see.
+                    _LOGGER.debug(
+                        "Error refreshing %s group %d: %s", normalized, g, err
+                    )
 
             await self.async_event_handler(
                 "nikobus_refreshed",

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.0.31",
+  "version": "2.0.32",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],


### PR DESCRIPTION
## Why

Recovery is silent at the bus level since 2.0.31 (PR #342), but HA's System Log panel still surfaces three ERROR entries every time the blackout-detection cycle fires:

```
Error refreshing 8110 group 1:
Error refreshing 8110 group 2:
Error refreshing 1CEC group 1:
```

Each per-group failure was logged at ERROR by `_refresh_module_type`. That made HA's UI display them as user-visible errors even though the integration auto-recovers cleanly and the aggregate WARNING already conveys the actionable signal:

```
Nikobus poll cycle: 3/3 commands timed out — bus silent. Triggering reconnect (issue #337).
Nikobus connection lost — scheduling reconnect
```

## Fix

Demote the per-group log from `_LOGGER.error` → `_LOGGER.debug`. The aggregate WARNING + the lifecycle WARNING remain. Individual per-group failures stay available at DEBUG for log-trace diagnostics.

## What's still ERROR-level after this PR

```
Error processing command $10121081...:
Failed to receive ACK and state for command after 3 attempts.
```

That's from `nikobus_connect.command:128` (library-side ERROR log). Out of our reach without a library change. Worth flagging in the upcoming library handoff: command timeouts are now expected behavior during keep-alive sleep windows, so the library log should probably demote to WARNING and let consumers decide if the timeout is actionable.

## Tests

No tests pinned the ERROR level. 10 reconnect-related tests still pass:

```
$ python -m pytest tests/test_coordinator.py::TestBlackoutAutoRecovery \
    tests/test_coordinator.py::TestHandleConnectionLostCoalescing -q
..........                                                               [100%]
10 passed in 0.15s
```

## Diffstat

```
custom_components/nikobus/coordinator.py | 15 ++++++++++++++-
custom_components/nikobus/manifest.json  |  2 +-
2 files changed, 15 insertions(+), 2 deletions(-)
```

Manifest 2.0.31 → 2.0.32.

After this lands, IKIKN should see **at most two WARNING entries per recovery cycle** in HA's System Log instead of three ERRORs + two WARNINGs. The remaining library ERROR can be eliminated via a follow-up library PR.

https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRcaJELECE3n5zP599mZU2)_