### PR TITLE
Add manual-config fallback for pre-Gen3 / Gen2 PC-Link installs

### DIFF
--- a/custom_components/nikobus/__init__.py
+++ b/custom_components/nikobus/__init__.py
@@ -24,7 +24,7 @@ from homeassistant.components import (
     sensor,
 )
 
-from .const import DOMAIN, HUB_IDENTIFIER
+from .const import CONF_MANUAL_CONFIG, DOMAIN, HUB_IDENTIFIER
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .exceptions import NikobusConnectionError, NikobusDataError, NikobusError
 
@@ -285,7 +285,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: NikobusConfigEntry) -> b
     await _async_cleanup_orphan_entities(hass, entry, coordinator)
 
     # 7. One-shot: migrate legacy per-button descriptions to device name_by_user.
-    await _async_migrate_legacy_button_names(hass)
+    #    Skipped in manual-config mode: the legacy file is the live source
+    #    of truth there, so the migration's rename-on-success step would
+    #    delete the user's only inventory snapshot.
+    manual_config = entry.options.get(
+        CONF_MANUAL_CONFIG, entry.data.get(CONF_MANUAL_CONFIG, False)
+    )
+    if not manual_config:
+        await _async_migrate_legacy_button_names(hass)
 
     # 8. Surface repair issues for actionable misconfigurations.
     coordinator.refresh_repair_issues()

--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.selector import (
 from .const import (
     CONF_CONNECTION_STRING,
     CONF_HAS_FEEDBACK_MODULE,
+    CONF_MANUAL_CONFIG,
     CONF_PRIOR_GEN3,
     CONF_REFRESH_INTERVAL,
     DOMAIN,
@@ -179,6 +180,10 @@ def _hardware_schema(defaults: dict[str, Any]) -> vol.Schema:
         vol.Optional(
             CONF_PRIOR_GEN3,
             default=defaults.get(CONF_PRIOR_GEN3, False),
+        ): bool,
+        vol.Optional(
+            CONF_MANUAL_CONFIG,
+            default=defaults.get(CONF_MANUAL_CONFIG, False),
         ): bool,
     })
 
@@ -346,6 +351,10 @@ class NikobusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(
                     CONF_PRIOR_GEN3,
                     default=defaults.get(CONF_PRIOR_GEN3, False),
+                ): bool,
+                vol.Optional(
+                    CONF_MANUAL_CONFIG,
+                    default=defaults.get(CONF_MANUAL_CONFIG, False),
                 ): bool,
                 vol.Optional(
                     CONF_REFRESH_INTERVAL,

--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -411,13 +411,18 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
         menu. Keeping a single entry point avoids the "two ways to do
         the same thing" UX and the progress-flow flakiness that
         accompanied the options-flow path.
+
+        ``configure_modules`` is hidden in manual-config mode: the v1
+        JSON files are the declarative source of truth there, so any
+        change made through the UI would be wiped on the next reload.
+        Users wanting to customise a channel edit the file directly.
         """
+        menu_options = ["hardware"]
+        if not self._current().get(CONF_MANUAL_CONFIG, False):
+            menu_options.append("configure_modules")
         return self.async_show_menu(
             step_id="init",
-            menu_options=[
-                "hardware",
-                "configure_modules",
-            ],
+            menu_options=menu_options,
         )
 
     # --- Hardware settings (existing flow) ---------------------------------

--- a/custom_components/nikobus/const.py
+++ b/custom_components/nikobus/const.py
@@ -114,6 +114,20 @@ CONF_CONNECTION_STRING: Final[str] = "connection_string"
 CONF_REFRESH_INTERVAL: Final[str] = "refresh_interval"
 CONF_HAS_FEEDBACK_MODULE: Final[str] = "has_feedbackmodule"
 CONF_PRIOR_GEN3: Final[str] = "prior_gen3"
+# Manual-config mode: skip the one-shot v1-file rename migrations and
+# re-apply ``nikobus_module_config.json`` / ``nikobus_button_config.json``
+# into the Store on every startup. Intended for users whose hardware
+# (pre-Gen3 / Gen2 PC-Link, see nikobus-connect 0.5.24 CHANGELOG section
+# "What this does NOT fix") cannot be auto-discovered and who relied on
+# v1-style YAML/JSON declarations.
+CONF_MANUAL_CONFIG: Final[str] = "manual_config"
+
+# Filenames used by the manual-config path. Both are read on startup
+# when ``manual_config`` is true; the ``.migrated`` fallback is honoured
+# so users who upgraded to v2 (which renamed these files) can flip the
+# toggle without first un-renaming anything.
+MANUAL_MODULE_CONFIG_FILENAME: Final[str] = "nikobus_module_config.json"
+MANUAL_BUTTON_CONFIG_FILENAME: Final[str] = "nikobus_button_config.json"
 
 # =============================================================================
 # Serial Connection

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -27,6 +27,7 @@ from nikobus_connect.exceptions import NikobusConnectionError, NikobusDataError,
 from .const import (
     CONF_CONNECTION_STRING,
     CONF_HAS_FEEDBACK_MODULE,
+    CONF_MANUAL_CONFIG,
     CONF_PRIOR_GEN3,
     CONF_REFRESH_INTERVAL,
     DEVICE_ADDRESS_INVENTORY,
@@ -57,6 +58,7 @@ from .const import (
 )
 from .nkbactuator import NikobusActuator
 from .nkbconfig import NikobusConfig
+from .nkbmanual import async_apply_manual_config
 from .nkbmigration import async_migrate_legacy_module_config
 from .nkbstorage import NikobusButtonStorage, NikobusModuleStorage
 
@@ -106,6 +108,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self._refresh_interval = _opts.get(CONF_REFRESH_INTERVAL, config_entry.data.get(CONF_REFRESH_INTERVAL, 120))
         self._has_feedback_module = _opts.get(CONF_HAS_FEEDBACK_MODULE, config_entry.data.get(CONF_HAS_FEEDBACK_MODULE, False))
         self._prior_gen3 = _opts.get(CONF_PRIOR_GEN3, config_entry.data.get(CONF_PRIOR_GEN3, False))
+        self._manual_config = _opts.get(CONF_MANUAL_CONFIG, config_entry.data.get(CONF_MANUAL_CONFIG, False))
 
         super().__init__(
             hass,
@@ -238,12 +241,32 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         try:
             # Module data now lives in .storage/nikobus.modules. On first
             # startup after upgrading to 0.4.0, migrate any legacy
-            # nikobus_module_config.json into the store, then rename it.
+            # nikobus_module_config.json into the store, then rename it —
+            # unless the user opted into manual-config mode, in which case
+            # the legacy file is the live source of truth and must NOT
+            # be renamed away.
             await self.module_storage.async_load()
-            await async_migrate_legacy_module_config(self.hass, self.module_storage)
+            if not self._manual_config:
+                await async_migrate_legacy_module_config(self.hass, self.module_storage)
             self._rebuild_dict_module_data()
 
             self.dict_button_data = await self.button_storage.async_load()
+
+            # Manual-config: re-apply v1 JSON files into the live stores
+            # on every startup so users on pre-Gen3 / Gen2 hardware (whose
+            # button-link data the Gen3 decoder doesn't parse) can keep
+            # their inventory declarative. See nikobus-connect 0.5.24
+            # CHANGELOG "What this does NOT fix" for context.
+            if self._manual_config:
+                changed = await async_apply_manual_config(
+                    self.hass,
+                    self.module_storage,
+                    self.dict_button_data,
+                )
+                if changed:
+                    await self.module_storage.async_save()
+                    await self.button_storage.async_save()
+                    self._rebuild_dict_module_data()
             self.dict_scene_data = await self.nikobus_config.load_json_data(
                 "nikobus_scene_config.json", "scene"
             )

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.0.32",
+  "version": "2.0.33",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/custom_components/nikobus/nkbmanual.py
+++ b/custom_components/nikobus/nkbmanual.py
@@ -121,14 +121,55 @@ async def _apply_module_config(
     return len(flat), path
 
 
-def _build_button_entry(bus_address: str, description: str) -> dict[str, Any]:
-    """Build a v2 button record from a single v1 entry.
+def _extract_physical_info(
+    entry: dict[str, Any],
+) -> tuple[str, str, int, str, str] | None:
+    """Pull the physical-button identity out of a v1 button entry.
 
-    Each v1 entry becomes a single-key physical button (``channels=1``)
-    so the v2 router's bus-address lookup finds it. ``bus_address`` is
-    used as both the dict key and the ``operation_points["1A"]``
-    address — the router only cares about the latter for routing, but
-    keying by it gives a stable, collision-free physical identity.
+    The v1 layout is per-operation-point: each list entry is one key
+    press, and entries that share ``linked_button[0].address`` are
+    different keys of the same physical button. Returns
+    ``(physical_addr, key_label, channels, type, model)`` when the
+    entry carries that data, else ``None`` for entries that don't
+    belong to a real bus device (IR-only / scene-trigger / virtual /
+    auto-generated ``DISCOVERED -`` placeholders).
+    """
+    linked = entry.get("linked_button")
+    if not isinstance(linked, list) or not linked:
+        return None
+    info = linked[0]
+    if not isinstance(info, dict):
+        return None
+    phys = str(info.get("address") or "").strip().upper()
+    key = str(info.get("key") or "").strip().upper()
+    channels = info.get("channels")
+    if not phys or not key or not isinstance(channels, int):
+        return None
+    type_str = str(info.get("type") or "").strip() or "Button"
+    model = str(info.get("model") or "").strip()
+    return phys, key, channels, type_str, model
+
+
+def _new_physical_record(
+    physical_addr: str, type_str: str, model: str, channels: int
+) -> dict[str, Any]:
+    return {
+        "type": type_str,
+        "model": model,
+        "channels": channels,
+        "description": f"{type_str} ({physical_addr})",
+        "operation_points": {},
+    }
+
+
+def _single_key_fallback(bus_address: str, description: str) -> dict[str, Any]:
+    """Build a 1-channel synthetic record for an unlinked v1 entry.
+
+    Used for IR/virtual/scene entries that have no ``linked_button``
+    block. The v2 router routes by ``operation_points[*].bus_address``,
+    so a single op-point on a synthetic physical record (keyed by the
+    bus address itself) is enough to make those entries fire HA
+    events the way they did in v1.
     """
     label = description or f"#N{bus_address}"
     return {
@@ -148,19 +189,21 @@ def _build_button_entry(bus_address: str, description: str) -> dict[str, Any]:
 
 async def _apply_button_config(
     hass: HomeAssistant, button_data: dict[str, Any]
-) -> tuple[int, str | None]:
+) -> tuple[int, int, str | None]:
     """Replace the button store with ``nikobus_button_config.json``.
 
     Fully declarative: ``button_data["nikobus_button"]`` is wiped and
     rebuilt from the file. ``button_data`` is the live reference the
     coordinator passes (same object as ``button_storage.data``), so a
     subsequent ``async_save`` persists the result.
+
+    Returns ``(physical_buttons, total_op_points, source_path)``.
     """
     path, payload = await _read_json_with_fallback(
         hass, MANUAL_BUTTON_CONFIG_FILENAME
     )
     if path is None or not isinstance(payload, dict):
-        return 0, None
+        return 0, 0, None
 
     raw = payload.get("nikobus_button")
     # v1 files store a list of entries; the v1 NikobusConfig loader
@@ -178,15 +221,45 @@ async def _apply_button_config(
                 legacy_iter.append(merged)
 
     new_buttons: dict[str, Any] = {}
+    op_points_total = 0
+
     for entry in legacy_iter:
-        address = str(entry.get("address") or "").strip().upper()
-        if not address:
+        bus_address = str(entry.get("address") or "").strip().upper()
+        if not bus_address:
             continue
         description = str(entry.get("description") or "").strip()
-        new_buttons[address] = _build_button_entry(address, description)
+
+        physical = _extract_physical_info(entry)
+        if physical is not None:
+            phys_addr, key_label, channels, type_str, model = physical
+            phys_entry = new_buttons.get(phys_addr)
+            if phys_entry is None:
+                phys_entry = _new_physical_record(
+                    phys_addr, type_str, model, channels
+                )
+                new_buttons[phys_addr] = phys_entry
+            # Op-point conflict (two entries claiming same key on the
+            # same physical) — last entry wins. The file is the truth.
+            phys_entry["operation_points"][key_label] = {
+                "bus_address": bus_address,
+                "description": description
+                or f"Push button {key_label} #N{bus_address}",
+                "linked_modules": [],
+            }
+            op_points_total += 1
+        else:
+            # Unlinked entry — IR/virtual/scene/placeholder. Don't
+            # clobber a properly-grouped physical button that happens
+            # to use this bus address as its physical key.
+            if bus_address in new_buttons:
+                continue
+            new_buttons[bus_address] = _single_key_fallback(
+                bus_address, description
+            )
+            op_points_total += 1
 
     button_data["nikobus_button"] = new_buttons
-    return len(new_buttons), path
+    return len(new_buttons), op_points_total, path
 
 
 async def async_apply_manual_config(
@@ -219,7 +292,9 @@ async def async_apply_manual_config(
         module_path = None
 
     try:
-        buttons_loaded, button_path = await _apply_button_config(hass, button_data)
+        buttons_loaded, op_points_total, button_path = await _apply_button_config(
+            hass, button_data
+        )
     except asyncio.CancelledError:
         raise
     except Exception:  # noqa: BLE001
@@ -228,6 +303,7 @@ async def async_apply_manual_config(
             MANUAL_BUTTON_CONFIG_FILENAME,
         )
         buttons_loaded = 0
+        op_points_total = 0
         button_path = None
 
     if module_path is None and button_path is None:
@@ -242,11 +318,13 @@ async def async_apply_manual_config(
 
     _LOGGER.info(
         "Manual-config applied (declarative): modules=%d (source=%s) "
-        "buttons=%d (source=%s). Reload the integration after editing "
-        "either file to apply changes.",
+        "buttons=%d physical / %d operation-points (source=%s). "
+        "Reload the integration after editing either file to apply "
+        "changes.",
         modules_loaded,
         module_path or "—",
         buttons_loaded,
+        op_points_total,
         button_path or "—",
     )
     return True

--- a/custom_components/nikobus/nkbmanual.py
+++ b/custom_components/nikobus/nkbmanual.py
@@ -1,28 +1,35 @@
 """Manual-configuration loader for installs auto-discovery cannot crack.
 
 Some PC-Link generations (pre-Gen3 / Gen2) store button-link data in a
-format the Gen3-calibrated decoder in ``nikobus-connect`` does not parse
-— see the 0.5.24 CHANGELOG section "What this does NOT fix". For those
-installs the user enables ``manual_config`` in the config flow; the
-integration then treats the legacy v1 files
+format the Gen3-calibrated decoder in ``nikobus-connect`` does not
+parse — see the 0.5.24 CHANGELOG section "What this does NOT fix".
+For those installs the user enables ``manual_config`` in the config
+flow; the integration then treats the legacy v1 files
 (``nikobus_module_config.json`` / ``nikobus_button_config.json``) as
-the source of truth and re-applies them into the v2 stores on every
-startup.
+the **source of truth** and re-applies them into the v2 stores on
+every startup.
 
-Two key differences from the one-shot migration in ``nkbmigration.py``:
+Pre-v2 semantics: the files are fully declarative. Whatever lives in
+them is what HA exposes after the next reload — additions, edits,
+renames, removals. There is no merge with options-flow state; users
+who want to customise a channel's entity type, LED triggers, travel
+times, or description do so by editing the file. The options-flow
+"Customise a module" path is hidden in manual mode so it does not
+present a UI whose changes get wiped on the next reload.
 
-  * No rename. The source files stay put so they survive across
-    restarts (and remain editable by the user).
+Two practical notes:
+
+  * No rename. The source files stay put across reloads.
   * The button file is consumed for routing data, not just for
     user-facing names. Each v1 entry becomes a single-key physical
-    button whose ``operation_points["1A"]`` carries the v1 bus address
-    — the router matches bus addresses, so single-key shape is enough
-    to route presses to HA entities.
+    button whose ``operation_points["1A"]`` carries the v1 bus
+    address — the v2 router matches bus addresses, so single-key
+    shape is enough to route presses to HA entities.
 
-If the user already upgraded to v2 once before flipping the toggle, the
-v1 file will have been renamed to ``<name>.migrated`` by the one-shot
-migration. This loader falls back to the ``.migrated`` suffix so the
-toggle works without manual file renaming.
+If the user already upgraded to v2 once before flipping the toggle,
+the v1 file will have been renamed to ``<name>.migrated`` by the
+one-shot migration. This loader falls back to the ``.migrated``
+suffix so the toggle works without manual file renaming.
 """
 
 from __future__ import annotations
@@ -46,19 +53,6 @@ from .nkbstorage import NikobusModuleStorage
 _LOGGER = logging.getLogger(__name__)
 
 _MIGRATED_SUFFIX = ".migrated"
-
-# Fields the user can edit via the options flow that must survive a
-# re-apply on top of what the YAML defines. Mirrors
-# ``nkbmigration._USER_CHANNEL_FIELDS`` plus a couple of extras the
-# library can also write back during a successful auto-discovery sweep
-# (which manual-mode users may still run by hand from the device button).
-_PRESERVED_CHANNEL_FIELDS: tuple[str, ...] = (
-    "entity_type",
-    "led_on",
-    "led_off",
-    "operation_time_up",
-    "operation_time_down",
-)
 
 
 async def _read_json_with_fallback(
@@ -89,168 +83,84 @@ async def _read_json_with_fallback(
     return None, None
 
 
-def _merge_manual_module(
-    store_entry: dict[str, Any] | None, yaml_entry: dict[str, Any]
-) -> dict[str, Any]:
-    """Deep-merge a YAML module entry onto an existing Store entry.
-
-    YAML wins for every field it sets at the module level. Per channel,
-    YAML fields override but options-flow-only fields
-    (``entity_type``, ``led_on/off``, ``operation_time_*``) are
-    preserved when the YAML doesn't carry them — so a user can refine a
-    YAML-declared module via the options flow without having those
-    edits reverted on the next startup.
-    """
-    if not isinstance(store_entry, dict):
-        store_entry = {}
-
-    merged = dict(store_entry)
-    for key, value in yaml_entry.items():
-        if key == "channels":
-            continue
-        merged[key] = value
-
-    yaml_channels = yaml_entry.get("channels") or []
-    store_channels = store_entry.get("channels") or []
-    if not isinstance(yaml_channels, list):
-        yaml_channels = []
-    if not isinstance(store_channels, list):
-        store_channels = []
-
-    out_channels: list[dict[str, Any]] = []
-    for idx, yaml_ch in enumerate(yaml_channels):
-        store_ch = (
-            store_channels[idx] if idx < len(store_channels) else {}
-        )
-        if not isinstance(store_ch, dict):
-            store_ch = {}
-        if not isinstance(yaml_ch, dict):
-            out_channels.append(store_ch)
-            continue
-        combined = dict(yaml_ch)
-        for field in _PRESERVED_CHANNEL_FIELDS:
-            if field not in combined and field in store_ch:
-                combined[field] = store_ch[field]
-        out_channels.append(combined)
-
-    # Channels beyond the YAML's length are preserved verbatim — the
-    # user may have run a successful auto-discovery sweep that added
-    # rows the YAML hasn't been updated for yet.
-    if len(store_channels) > len(yaml_channels):
-        out_channels.extend(
-            ch if isinstance(ch, dict) else {} for ch in store_channels[len(yaml_channels):]
-        )
-    merged["channels"] = out_channels
-
-    # Manual mode does not own a device_type byte; surface a marker on
-    # ``discovered_info`` so diagnostics can tell apart YAML-sourced
-    # rows from auto-discovered ones.
-    discovered_info = merged.get("discovered_info")
+def _tag_manual_source(entry: dict[str, Any]) -> None:
+    """Mark a module entry as manual-config-sourced for diagnostics."""
+    discovered_info = entry.get("discovered_info")
     if not isinstance(discovered_info, dict):
         discovered_info = {}
     discovered_info["source"] = "manual_config"
-    merged["discovered_info"] = discovered_info
-    return merged
+    entry["discovered_info"] = discovered_info
 
 
 async def _apply_module_config(
     hass: HomeAssistant, store: NikobusModuleStorage
-) -> tuple[int, int, str | None]:
-    """Apply ``nikobus_module_config.json`` into the module store.
+) -> tuple[int, str | None]:
+    """Replace the module store with ``nikobus_module_config.json``.
 
-    Returns ``(modules_applied, modules_added, source_path)``.
+    Fully declarative: anything not in the file is removed from the
+    store. Returns ``(modules_in_file, source_path)`` — ``(0, None)``
+    when no file is found, ``(0, path)`` when the file parsed but
+    contained no convertible entries (in which case the caller should
+    decide whether to wipe the store anyway).
     """
     path, payload = await _read_json_with_fallback(
         hass, MANUAL_MODULE_CONFIG_FILENAME
     )
     if path is None or not isinstance(payload, dict):
-        return 0, 0, None
+        return 0, None
 
     flat = convert_legacy_to_flat(payload)
-    if not flat:
-        return 0, 0, path
+    for entry in flat.values():
+        _tag_manual_source(entry)
 
-    modules = store.data.setdefault("nikobus_module", {})
-    if not isinstance(modules, dict):
-        modules = {}
-        store.data["nikobus_module"] = modules
-
-    added = 0
-    for address, yaml_entry in flat.items():
-        addr_upper = str(address).upper()
-        existing = modules.get(addr_upper)
-        if existing is None:
-            added += 1
-        modules[addr_upper] = _merge_manual_module(existing, yaml_entry)
-
-    return len(flat), added, path
+    # Wholesale replacement. Removing an entry from the file removes
+    # it from the store on the next reload — pre-v2 declarative
+    # semantics. Options-flow edits do not survive (the file is the
+    # truth).
+    store.data["nikobus_module"] = flat
+    return len(flat), path
 
 
-def _build_button_entry(
-    bus_address: str,
-    description: str,
-    existing: dict[str, Any] | None,
-) -> dict[str, Any]:
+def _build_button_entry(bus_address: str, description: str) -> dict[str, Any]:
     """Build a v2 button record from a single v1 entry.
 
-    Each v1 entry becomes a single-key physical button (channels=1) so
-    the v2 router's bus-address lookup finds it. ``bus_address`` is
+    Each v1 entry becomes a single-key physical button (``channels=1``)
+    so the v2 router's bus-address lookup finds it. ``bus_address`` is
     used as both the dict key and the ``operation_points["1A"]``
     address — the router only cares about the latter for routing, but
     keying by it gives a stable, collision-free physical identity.
     """
-    op_desc = description or f"#N{bus_address}"
-    phys_desc = description or f"#N{bus_address}"
-
-    entry: dict[str, Any] = dict(existing or {})
-    entry["type"] = entry.get("type") or "Manual button"
-    entry.setdefault("model", "")
-    entry["channels"] = 1
-    # Don't clobber a description the user may have set via HA's device
-    # registry rename machinery — but do replace the auto-generated
-    # ``#NXXXXXX`` placeholder when the YAML now carries a real label.
-    current_desc = entry.get("description")
-    if not current_desc or current_desc.endswith(f"#N{bus_address}"):
-        entry["description"] = phys_desc
-
-    op_points = entry.setdefault("operation_points", {})
-    if not isinstance(op_points, dict):
-        op_points = {}
-        entry["operation_points"] = op_points
-
-    op_point = op_points.setdefault("1A", {})
-    if not isinstance(op_point, dict):
-        op_point = {}
-        op_points["1A"] = op_point
-    op_point["bus_address"] = bus_address
-    current_op_desc = op_point.get("description")
-    if not current_op_desc or current_op_desc.endswith(f"#N{bus_address}"):
-        op_point["description"] = op_desc
-    op_point.setdefault("linked_modules", [])
-    # Drop any other op-points the auto-discovery sweep may have
-    # populated for this physical record — manual mode owns the shape
-    # of buttons it declares, and a stray op-point would cause the
-    # button platform to emit phantom entities.
-    for stale_key in [k for k in op_points if k != "1A"]:
-        op_points.pop(stale_key, None)
-    return entry
+    label = description or f"#N{bus_address}"
+    return {
+        "type": "Manual button",
+        "model": "",
+        "channels": 1,
+        "description": label,
+        "operation_points": {
+            "1A": {
+                "bus_address": bus_address,
+                "description": label,
+                "linked_modules": [],
+            }
+        },
+    }
 
 
 async def _apply_button_config(
     hass: HomeAssistant, button_data: dict[str, Any]
-) -> tuple[int, int, str | None]:
-    """Apply ``nikobus_button_config.json`` into the button store.
+) -> tuple[int, str | None]:
+    """Replace the button store with ``nikobus_button_config.json``.
 
-    Returns ``(buttons_applied, buttons_added, source_path)``. Mutates
-    ``button_data`` in place — the coordinator passes the live
-    ``button_storage.data`` reference, so a subsequent ``async_save``
-    picks up these changes.
+    Fully declarative: ``button_data["nikobus_button"]`` is wiped and
+    rebuilt from the file. ``button_data`` is the live reference the
+    coordinator passes (same object as ``button_storage.data``), so a
+    subsequent ``async_save`` persists the result.
     """
     path, payload = await _read_json_with_fallback(
         hass, MANUAL_BUTTON_CONFIG_FILENAME
     )
     if path is None or not isinstance(payload, dict):
-        return 0, 0, None
+        return 0, None
 
     raw = payload.get("nikobus_button")
     # v1 files store a list of entries; the v1 NikobusConfig loader
@@ -266,28 +176,17 @@ async def _apply_button_config(
                 merged = dict(entry)
                 merged.setdefault("address", addr)
                 legacy_iter.append(merged)
-    if not legacy_iter:
-        return 0, 0, path
 
-    buttons = button_data.setdefault("nikobus_button", {})
-    if not isinstance(buttons, dict):
-        buttons = {}
-        button_data["nikobus_button"] = buttons
-
-    added = 0
-    applied = 0
+    new_buttons: dict[str, Any] = {}
     for entry in legacy_iter:
         address = str(entry.get("address") or "").strip().upper()
         if not address:
             continue
         description = str(entry.get("description") or "").strip()
-        existing = buttons.get(address)
-        if existing is None:
-            added += 1
-        buttons[address] = _build_button_entry(address, description, existing)
-        applied += 1
+        new_buttons[address] = _build_button_entry(address, description)
 
-    return applied, added, path
+    button_data["nikobus_button"] = new_buttons
+    return len(new_buttons), path
 
 
 async def async_apply_manual_config(
@@ -297,57 +196,57 @@ async def async_apply_manual_config(
 ) -> bool:
     """Apply the v1 module + button config files into the v2 stores.
 
-    Returns ``True`` if any change was made (and a save is therefore
-    warranted), ``False`` otherwise. Errors on either file are logged
-    and swallowed — the integration must still come up so the user can
-    review the logs and fix the file.
+    Manual-config mode is fully declarative: the files are the source
+    of truth, and the stores are rewritten to match on every call.
+    Removing an entry from the file removes the corresponding entity
+    on the next reload.
+
+    Returns ``True`` if at least one of the files was present and
+    parseable (so the coordinator should persist the result). Errors
+    on either file are logged and swallowed so the integration still
+    comes up.
     """
     try:
-        modules_applied, modules_added, module_path = await _apply_module_config(
-            hass, module_store
-        )
+        modules_loaded, module_path = await _apply_module_config(hass, module_store)
     except asyncio.CancelledError:
         raise
     except Exception:  # noqa: BLE001
         _LOGGER.exception(
-            "Manual-config: error applying %s; continuing without module overlay",
+            "Manual-config: error applying %s; module store left unchanged",
             MANUAL_MODULE_CONFIG_FILENAME,
         )
-        modules_applied = modules_added = 0
+        modules_loaded = 0
         module_path = None
 
     try:
-        buttons_applied, buttons_added, button_path = await _apply_button_config(
-            hass, button_data
-        )
+        buttons_loaded, button_path = await _apply_button_config(hass, button_data)
     except asyncio.CancelledError:
         raise
     except Exception:  # noqa: BLE001
         _LOGGER.exception(
-            "Manual-config: error applying %s; continuing without button overlay",
+            "Manual-config: error applying %s; button store left unchanged",
             MANUAL_BUTTON_CONFIG_FILENAME,
         )
-        buttons_applied = buttons_added = 0
+        buttons_loaded = 0
         button_path = None
 
-    if not (modules_applied or buttons_applied):
-        _LOGGER.info(
-            "Manual-config: neither %s nor %s yielded entries; "
-            "auto-discovery (if it works for this hardware) remains available "
-            "via the device button.",
+    if module_path is None and button_path is None:
+        _LOGGER.warning(
+            "Manual-config enabled but neither %s nor %s was found in %s. "
+            "Place at least one file there and reload the integration.",
             MANUAL_MODULE_CONFIG_FILENAME,
             MANUAL_BUTTON_CONFIG_FILENAME,
+            hass.config.path(""),
         )
         return False
 
     _LOGGER.info(
-        "Manual-config applied: modules=%d (new=%d, source=%s) "
-        "buttons=%d (new=%d, source=%s)",
-        modules_applied,
-        modules_added,
+        "Manual-config applied (declarative): modules=%d (source=%s) "
+        "buttons=%d (source=%s). Reload the integration after editing "
+        "either file to apply changes.",
+        modules_loaded,
         module_path or "—",
-        buttons_applied,
-        buttons_added,
+        buttons_loaded,
         button_path or "—",
     )
     return True

--- a/custom_components/nikobus/nkbmanual.py
+++ b/custom_components/nikobus/nkbmanual.py
@@ -1,0 +1,353 @@
+"""Manual-configuration loader for installs auto-discovery cannot crack.
+
+Some PC-Link generations (pre-Gen3 / Gen2) store button-link data in a
+format the Gen3-calibrated decoder in ``nikobus-connect`` does not parse
+— see the 0.5.24 CHANGELOG section "What this does NOT fix". For those
+installs the user enables ``manual_config`` in the config flow; the
+integration then treats the legacy v1 files
+(``nikobus_module_config.json`` / ``nikobus_button_config.json``) as
+the source of truth and re-applies them into the v2 stores on every
+startup.
+
+Two key differences from the one-shot migration in ``nkbmigration.py``:
+
+  * No rename. The source files stay put so they survive across
+    restarts (and remain editable by the user).
+  * The button file is consumed for routing data, not just for
+    user-facing names. Each v1 entry becomes a single-key physical
+    button whose ``operation_points["1A"]`` carries the v1 bus address
+    — the router matches bus addresses, so single-key shape is enough
+    to route presses to HA entities.
+
+If the user already upgraded to v2 once before flipping the toggle, the
+v1 file will have been renamed to ``<name>.migrated`` by the one-shot
+migration. This loader falls back to the ``.migrated`` suffix so the
+toggle works without manual file renaming.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from typing import Any
+
+from aiofiles import open as aio_open
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    MANUAL_BUTTON_CONFIG_FILENAME,
+    MANUAL_MODULE_CONFIG_FILENAME,
+)
+from .nkbmigration import convert_legacy_to_flat
+from .nkbstorage import NikobusModuleStorage
+
+_LOGGER = logging.getLogger(__name__)
+
+_MIGRATED_SUFFIX = ".migrated"
+
+# Fields the user can edit via the options flow that must survive a
+# re-apply on top of what the YAML defines. Mirrors
+# ``nkbmigration._USER_CHANNEL_FIELDS`` plus a couple of extras the
+# library can also write back during a successful auto-discovery sweep
+# (which manual-mode users may still run by hand from the device button).
+_PRESERVED_CHANNEL_FIELDS: tuple[str, ...] = (
+    "entity_type",
+    "led_on",
+    "led_off",
+    "operation_time_up",
+    "operation_time_down",
+)
+
+
+async def _read_json_with_fallback(
+    hass: HomeAssistant, filename: str
+) -> tuple[str | None, dict[str, Any] | None]:
+    """Return ``(path, payload)`` for the first existing variant of ``filename``.
+
+    Tries the canonical name first, then the ``.migrated`` suffix that
+    the one-shot v1→v2 migration leaves behind. Returns ``(None, None)``
+    when neither exists or both are unreadable.
+    """
+    candidates = [
+        hass.config.path(filename),
+        hass.config.path(filename + _MIGRATED_SUFFIX),
+    ]
+    for path in candidates:
+        if not await hass.async_add_executor_job(os.path.isfile, path):
+            continue
+        try:
+            async with aio_open(path, mode="r") as fh:
+                raw = await fh.read()
+            return path, json.loads(raw)
+        except (OSError, json.JSONDecodeError) as err:
+            _LOGGER.warning(
+                "Manual-config: %s is unreadable (%s); skipping.", path, err
+            )
+            return None, None
+    return None, None
+
+
+def _merge_manual_module(
+    store_entry: dict[str, Any] | None, yaml_entry: dict[str, Any]
+) -> dict[str, Any]:
+    """Deep-merge a YAML module entry onto an existing Store entry.
+
+    YAML wins for every field it sets at the module level. Per channel,
+    YAML fields override but options-flow-only fields
+    (``entity_type``, ``led_on/off``, ``operation_time_*``) are
+    preserved when the YAML doesn't carry them — so a user can refine a
+    YAML-declared module via the options flow without having those
+    edits reverted on the next startup.
+    """
+    if not isinstance(store_entry, dict):
+        store_entry = {}
+
+    merged = dict(store_entry)
+    for key, value in yaml_entry.items():
+        if key == "channels":
+            continue
+        merged[key] = value
+
+    yaml_channels = yaml_entry.get("channels") or []
+    store_channels = store_entry.get("channels") or []
+    if not isinstance(yaml_channels, list):
+        yaml_channels = []
+    if not isinstance(store_channels, list):
+        store_channels = []
+
+    out_channels: list[dict[str, Any]] = []
+    for idx, yaml_ch in enumerate(yaml_channels):
+        store_ch = (
+            store_channels[idx] if idx < len(store_channels) else {}
+        )
+        if not isinstance(store_ch, dict):
+            store_ch = {}
+        if not isinstance(yaml_ch, dict):
+            out_channels.append(store_ch)
+            continue
+        combined = dict(yaml_ch)
+        for field in _PRESERVED_CHANNEL_FIELDS:
+            if field not in combined and field in store_ch:
+                combined[field] = store_ch[field]
+        out_channels.append(combined)
+
+    # Channels beyond the YAML's length are preserved verbatim — the
+    # user may have run a successful auto-discovery sweep that added
+    # rows the YAML hasn't been updated for yet.
+    if len(store_channels) > len(yaml_channels):
+        out_channels.extend(
+            ch if isinstance(ch, dict) else {} for ch in store_channels[len(yaml_channels):]
+        )
+    merged["channels"] = out_channels
+
+    # Manual mode does not own a device_type byte; surface a marker on
+    # ``discovered_info`` so diagnostics can tell apart YAML-sourced
+    # rows from auto-discovered ones.
+    discovered_info = merged.get("discovered_info")
+    if not isinstance(discovered_info, dict):
+        discovered_info = {}
+    discovered_info["source"] = "manual_config"
+    merged["discovered_info"] = discovered_info
+    return merged
+
+
+async def _apply_module_config(
+    hass: HomeAssistant, store: NikobusModuleStorage
+) -> tuple[int, int, str | None]:
+    """Apply ``nikobus_module_config.json`` into the module store.
+
+    Returns ``(modules_applied, modules_added, source_path)``.
+    """
+    path, payload = await _read_json_with_fallback(
+        hass, MANUAL_MODULE_CONFIG_FILENAME
+    )
+    if path is None or not isinstance(payload, dict):
+        return 0, 0, None
+
+    flat = convert_legacy_to_flat(payload)
+    if not flat:
+        return 0, 0, path
+
+    modules = store.data.setdefault("nikobus_module", {})
+    if not isinstance(modules, dict):
+        modules = {}
+        store.data["nikobus_module"] = modules
+
+    added = 0
+    for address, yaml_entry in flat.items():
+        addr_upper = str(address).upper()
+        existing = modules.get(addr_upper)
+        if existing is None:
+            added += 1
+        modules[addr_upper] = _merge_manual_module(existing, yaml_entry)
+
+    return len(flat), added, path
+
+
+def _build_button_entry(
+    bus_address: str,
+    description: str,
+    existing: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Build a v2 button record from a single v1 entry.
+
+    Each v1 entry becomes a single-key physical button (channels=1) so
+    the v2 router's bus-address lookup finds it. ``bus_address`` is
+    used as both the dict key and the ``operation_points["1A"]``
+    address — the router only cares about the latter for routing, but
+    keying by it gives a stable, collision-free physical identity.
+    """
+    op_desc = description or f"#N{bus_address}"
+    phys_desc = description or f"#N{bus_address}"
+
+    entry: dict[str, Any] = dict(existing or {})
+    entry["type"] = entry.get("type") or "Manual button"
+    entry.setdefault("model", "")
+    entry["channels"] = 1
+    # Don't clobber a description the user may have set via HA's device
+    # registry rename machinery — but do replace the auto-generated
+    # ``#NXXXXXX`` placeholder when the YAML now carries a real label.
+    current_desc = entry.get("description")
+    if not current_desc or current_desc.endswith(f"#N{bus_address}"):
+        entry["description"] = phys_desc
+
+    op_points = entry.setdefault("operation_points", {})
+    if not isinstance(op_points, dict):
+        op_points = {}
+        entry["operation_points"] = op_points
+
+    op_point = op_points.setdefault("1A", {})
+    if not isinstance(op_point, dict):
+        op_point = {}
+        op_points["1A"] = op_point
+    op_point["bus_address"] = bus_address
+    current_op_desc = op_point.get("description")
+    if not current_op_desc or current_op_desc.endswith(f"#N{bus_address}"):
+        op_point["description"] = op_desc
+    op_point.setdefault("linked_modules", [])
+    # Drop any other op-points the auto-discovery sweep may have
+    # populated for this physical record — manual mode owns the shape
+    # of buttons it declares, and a stray op-point would cause the
+    # button platform to emit phantom entities.
+    for stale_key in [k for k in op_points if k != "1A"]:
+        op_points.pop(stale_key, None)
+    return entry
+
+
+async def _apply_button_config(
+    hass: HomeAssistant, button_data: dict[str, Any]
+) -> tuple[int, int, str | None]:
+    """Apply ``nikobus_button_config.json`` into the button store.
+
+    Returns ``(buttons_applied, buttons_added, source_path)``. Mutates
+    ``button_data`` in place — the coordinator passes the live
+    ``button_storage.data`` reference, so a subsequent ``async_save``
+    picks up these changes.
+    """
+    path, payload = await _read_json_with_fallback(
+        hass, MANUAL_BUTTON_CONFIG_FILENAME
+    )
+    if path is None or not isinstance(payload, dict):
+        return 0, 0, None
+
+    raw = payload.get("nikobus_button")
+    # v1 files store a list of entries; the v1 NikobusConfig loader
+    # converted them to a dict keyed by address at load time. Accept
+    # both shapes so users with either snapshot work without manual
+    # conversion.
+    legacy_iter: list[dict[str, Any]] = []
+    if isinstance(raw, list):
+        legacy_iter = [e for e in raw if isinstance(e, dict)]
+    elif isinstance(raw, dict):
+        for addr, entry in raw.items():
+            if isinstance(entry, dict):
+                merged = dict(entry)
+                merged.setdefault("address", addr)
+                legacy_iter.append(merged)
+    if not legacy_iter:
+        return 0, 0, path
+
+    buttons = button_data.setdefault("nikobus_button", {})
+    if not isinstance(buttons, dict):
+        buttons = {}
+        button_data["nikobus_button"] = buttons
+
+    added = 0
+    applied = 0
+    for entry in legacy_iter:
+        address = str(entry.get("address") or "").strip().upper()
+        if not address:
+            continue
+        description = str(entry.get("description") or "").strip()
+        existing = buttons.get(address)
+        if existing is None:
+            added += 1
+        buttons[address] = _build_button_entry(address, description, existing)
+        applied += 1
+
+    return applied, added, path
+
+
+async def async_apply_manual_config(
+    hass: HomeAssistant,
+    module_store: NikobusModuleStorage,
+    button_data: dict[str, Any],
+) -> bool:
+    """Apply the v1 module + button config files into the v2 stores.
+
+    Returns ``True`` if any change was made (and a save is therefore
+    warranted), ``False`` otherwise. Errors on either file are logged
+    and swallowed — the integration must still come up so the user can
+    review the logs and fix the file.
+    """
+    try:
+        modules_applied, modules_added, module_path = await _apply_module_config(
+            hass, module_store
+        )
+    except asyncio.CancelledError:
+        raise
+    except Exception:  # noqa: BLE001
+        _LOGGER.exception(
+            "Manual-config: error applying %s; continuing without module overlay",
+            MANUAL_MODULE_CONFIG_FILENAME,
+        )
+        modules_applied = modules_added = 0
+        module_path = None
+
+    try:
+        buttons_applied, buttons_added, button_path = await _apply_button_config(
+            hass, button_data
+        )
+    except asyncio.CancelledError:
+        raise
+    except Exception:  # noqa: BLE001
+        _LOGGER.exception(
+            "Manual-config: error applying %s; continuing without button overlay",
+            MANUAL_BUTTON_CONFIG_FILENAME,
+        )
+        buttons_applied = buttons_added = 0
+        button_path = None
+
+    if not (modules_applied or buttons_applied):
+        _LOGGER.info(
+            "Manual-config: neither %s nor %s yielded entries; "
+            "auto-discovery (if it works for this hardware) remains available "
+            "via the device button.",
+            MANUAL_MODULE_CONFIG_FILENAME,
+            MANUAL_BUTTON_CONFIG_FILENAME,
+        )
+        return False
+
+    _LOGGER.info(
+        "Manual-config applied: modules=%d (new=%d, source=%s) "
+        "buttons=%d (new=%d, source=%s)",
+        modules_applied,
+        modules_added,
+        module_path or "—",
+        buttons_applied,
+        buttons_added,
+        button_path or "—",
+    )
+    return True

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -11,11 +11,13 @@
             "hardware": {
                 "data": {
                     "has_feedbackmodule": "Feedback Module (05-207) installed and connected via PC-Link",
-                    "prior_gen3": "PC-Link is older than Gen 3"
+                    "prior_gen3": "PC-Link is older than Gen 3",
+                    "manual_config": "Use manual configuration (skip auto-discovery)"
                 },
                 "data_description": {
                     "has_feedbackmodule": "When enabled, the Feedback Module pushes state changes automatically — no polling needed.",
-                    "prior_gen3": "Enables compatibility tweaks for first and second-generation PC-Link hardware."
+                    "prior_gen3": "Enables compatibility tweaks for first and second-generation PC-Link hardware.",
+                    "manual_config": "For installs whose firmware auto-discovery cannot read (typically pre-Gen3 / Gen2 PC-Link). On every startup the integration re-applies nikobus_module_config.json and nikobus_button_config.json from the Home Assistant config directory. Falls back to the .migrated variants if the originals were renamed by an earlier v2 upgrade."
                 },
                 "description": "Tell us about your Nikobus hardware so the integration can use the optimal update strategy.",
                 "title": "Hardware Configuration"
@@ -35,12 +37,14 @@
                     "connection_string": "Connection (serial port or IP:port)",
                     "has_feedbackmodule": "Feedback Module (05-207) installed and connected via PC-Link",
                     "prior_gen3": "PC-Link is older than Gen 3",
+                    "manual_config": "Use manual configuration (skip auto-discovery)",
                     "refresh_interval": "Polling interval (seconds)"
                 },
                 "data_description": {
                     "connection_string": "Serial device path or TCP address of the PC-Link bridge",
                     "has_feedbackmodule": "When enabled, the Feedback Module pushes state changes automatically — no polling needed.",
                     "prior_gen3": "Enables compatibility tweaks for first and second-generation PC-Link hardware.",
+                    "manual_config": "For installs whose firmware auto-discovery cannot read (typically pre-Gen3 / Gen2 PC-Link). On every startup the integration re-applies nikobus_module_config.json and nikobus_button_config.json from the Home Assistant config directory.",
                     "refresh_interval": "How often to read module states from the bus (60–3600 s). Lower values mean faster updates but more bus traffic."
                 },
                 "description": "Update the connection string or hardware settings. The connection will be re-tested.",
@@ -155,11 +159,13 @@
             "hardware": {
                 "data": {
                     "has_feedbackmodule": "Feedback Module (05-207) installed and connected via PC-Link",
-                    "prior_gen3": "PC-Link is older than Gen 3"
+                    "prior_gen3": "PC-Link is older than Gen 3",
+                    "manual_config": "Use manual configuration (skip auto-discovery)"
                 },
                 "data_description": {
                     "has_feedbackmodule": "When enabled, the Feedback Module pushes state changes automatically — no polling needed.",
-                    "prior_gen3": "Enables compatibility tweaks for first and second-generation PC-Link hardware."
+                    "prior_gen3": "Enables compatibility tweaks for first and second-generation PC-Link hardware.",
+                    "manual_config": "For installs whose firmware auto-discovery cannot read (typically pre-Gen3 / Gen2 PC-Link). On every startup the integration re-applies nikobus_module_config.json and nikobus_button_config.json from the Home Assistant config directory. Falls back to the .migrated variants if the originals were renamed by an earlier v2 upgrade."
                 },
                 "description": "Update your hardware settings. The integration will reload automatically.",
                 "title": "Hardware Configuration"

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -17,7 +17,7 @@
                 "data_description": {
                     "has_feedbackmodule": "When enabled, the Feedback Module pushes state changes automatically — no polling needed.",
                     "prior_gen3": "Enables compatibility tweaks for first and second-generation PC-Link hardware.",
-                    "manual_config": "For installs whose firmware auto-discovery cannot read (typically pre-Gen3 / Gen2 PC-Link). On every startup the integration re-applies nikobus_module_config.json and nikobus_button_config.json from the Home Assistant config directory. Falls back to the .migrated variants if the originals were renamed by an earlier v2 upgrade."
+                    "manual_config": "For installs whose firmware auto-discovery cannot read (typically pre-Gen3 / Gen2 PC-Link). The files nikobus_module_config.json and nikobus_button_config.json in the Home Assistant config directory become the declarative source of truth: edits, additions, and removals are reflected after reloading the integration. Falls back to the .migrated variants if the originals were renamed by an earlier v2 upgrade."
                 },
                 "description": "Tell us about your Nikobus hardware so the integration can use the optimal update strategy.",
                 "title": "Hardware Configuration"
@@ -44,7 +44,7 @@
                     "connection_string": "Serial device path or TCP address of the PC-Link bridge",
                     "has_feedbackmodule": "When enabled, the Feedback Module pushes state changes automatically — no polling needed.",
                     "prior_gen3": "Enables compatibility tweaks for first and second-generation PC-Link hardware.",
-                    "manual_config": "For installs whose firmware auto-discovery cannot read (typically pre-Gen3 / Gen2 PC-Link). On every startup the integration re-applies nikobus_module_config.json and nikobus_button_config.json from the Home Assistant config directory.",
+                    "manual_config": "For installs whose firmware auto-discovery cannot read (typically pre-Gen3 / Gen2 PC-Link). The files nikobus_module_config.json and nikobus_button_config.json in the Home Assistant config directory become the declarative source of truth: edits, additions, and removals are reflected after reloading the integration.",
                     "refresh_interval": "How often to read module states from the bus (60–3600 s). Lower values mean faster updates but more bus traffic."
                 },
                 "description": "Update the connection string or hardware settings. The connection will be re-tested.",
@@ -165,7 +165,7 @@
                 "data_description": {
                     "has_feedbackmodule": "When enabled, the Feedback Module pushes state changes automatically — no polling needed.",
                     "prior_gen3": "Enables compatibility tweaks for first and second-generation PC-Link hardware.",
-                    "manual_config": "For installs whose firmware auto-discovery cannot read (typically pre-Gen3 / Gen2 PC-Link). On every startup the integration re-applies nikobus_module_config.json and nikobus_button_config.json from the Home Assistant config directory. Falls back to the .migrated variants if the originals were renamed by an earlier v2 upgrade."
+                    "manual_config": "For installs whose firmware auto-discovery cannot read (typically pre-Gen3 / Gen2 PC-Link). The files nikobus_module_config.json and nikobus_button_config.json in the Home Assistant config directory become the declarative source of truth: edits, additions, and removals are reflected after reloading the integration. Falls back to the .migrated variants if the originals were renamed by an earlier v2 upgrade."
                 },
                 "description": "Update your hardware settings. The integration will reload automatically.",
                 "title": "Hardware Configuration"

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -22,7 +22,7 @@
                 "data_description": {
                     "has_feedbackmodule": "Lorsqu'activé, le module Feedback envoie automatiquement les changements d'état — pas de scrutation nécessaire.",
                     "prior_gen3": "Active les adaptations de compatibilité pour les PC-Link de première et deuxième génération.",
-                    "manual_config": "Pour les installations dont le firmware ne peut être lu par la découverte automatique (généralement PC-Link pré-Gen3 / Gen2). À chaque démarrage, l'intégration réapplique nikobus_module_config.json et nikobus_button_config.json depuis le répertoire de configuration Home Assistant. Bascule sur les variantes .migrated si les originaux ont été renommés par une mise à niveau v2 antérieure."
+                    "manual_config": "Pour les installations dont le firmware ne peut être lu par la découverte automatique (généralement PC-Link pré-Gen3 / Gen2). Les fichiers nikobus_module_config.json et nikobus_button_config.json dans le répertoire de configuration Home Assistant deviennent la source de vérité déclarative : les modifications, ajouts et suppressions sont reflétés après rechargement de l'intégration. Bascule sur les variantes .migrated si les originaux ont été renommés par une mise à niveau v2 antérieure."
                 }
             },
             "polling": {
@@ -76,7 +76,7 @@
                 "data_description": {
                     "has_feedbackmodule": "Lorsqu'activé, le module Feedback envoie automatiquement les changements d'état.",
                     "prior_gen3": "Active les adaptations de compatibilité pour les PC-Link de première et deuxième génération.",
-                    "manual_config": "Pour les installations qui ne peuvent pas être lues par la découverte automatique (PC-Link pré-Gen3 / Gen2). À chaque démarrage, l'intégration réapplique nikobus_module_config.json et nikobus_button_config.json depuis le répertoire de configuration."
+                    "manual_config": "Pour les installations qui ne peuvent pas être lues par la découverte automatique (PC-Link pré-Gen3 / Gen2). nikobus_module_config.json et nikobus_button_config.json dans le répertoire de configuration sont la source de vérité déclarative ; les modifications sont appliquées au rechargement de l'intégration."
                 }
             },
             "polling": {

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -16,11 +16,13 @@
                 "description": "Indiquez votre matériel Nikobus afin que l'intégration utilise la stratégie de mise à jour optimale.",
                 "data": {
                     "has_feedbackmodule": "Module Feedback (05-207) installé et connecté via PC-Link",
-                    "prior_gen3": "PC-Link antérieur à la Gen 3"
+                    "prior_gen3": "PC-Link antérieur à la Gen 3",
+                    "manual_config": "Utiliser la configuration manuelle (ignorer la découverte automatique)"
                 },
                 "data_description": {
                     "has_feedbackmodule": "Lorsqu'activé, le module Feedback envoie automatiquement les changements d'état — pas de scrutation nécessaire.",
-                    "prior_gen3": "Active les adaptations de compatibilité pour les PC-Link de première et deuxième génération."
+                    "prior_gen3": "Active les adaptations de compatibilité pour les PC-Link de première et deuxième génération.",
+                    "manual_config": "Pour les installations dont le firmware ne peut être lu par la découverte automatique (généralement PC-Link pré-Gen3 / Gen2). À chaque démarrage, l'intégration réapplique nikobus_module_config.json et nikobus_button_config.json depuis le répertoire de configuration Home Assistant. Bascule sur les variantes .migrated si les originaux ont été renommés par une mise à niveau v2 antérieure."
                 }
             },
             "polling": {
@@ -40,6 +42,7 @@
                     "connection_string": "Connexion (port série ou IP:port)",
                     "has_feedbackmodule": "Module Feedback (05-207) installé et connecté via PC-Link",
                     "prior_gen3": "PC-Link antérieur à la Gen 3",
+                    "manual_config": "Utiliser la configuration manuelle (ignorer la découverte automatique)",
                     "refresh_interval": "Intervalle de scrutation (secondes)"
                 }
             }
@@ -67,11 +70,13 @@
                 "description": "Mettez à jour les paramètres matériels. L'intégration rechargera automatiquement.",
                 "data": {
                     "has_feedbackmodule": "Module Feedback (05-207) installé et connecté via PC-Link",
-                    "prior_gen3": "PC-Link antérieur à la Gen 3"
+                    "prior_gen3": "PC-Link antérieur à la Gen 3",
+                    "manual_config": "Utiliser la configuration manuelle (ignorer la découverte automatique)"
                 },
                 "data_description": {
                     "has_feedbackmodule": "Lorsqu'activé, le module Feedback envoie automatiquement les changements d'état.",
-                    "prior_gen3": "Active les adaptations de compatibilité pour les PC-Link de première et deuxième génération."
+                    "prior_gen3": "Active les adaptations de compatibilité pour les PC-Link de première et deuxième génération.",
+                    "manual_config": "Pour les installations qui ne peuvent pas être lues par la découverte automatique (PC-Link pré-Gen3 / Gen2). À chaque démarrage, l'intégration réapplique nikobus_module_config.json et nikobus_button_config.json depuis le répertoire de configuration."
                 }
             },
             "polling": {

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -16,11 +16,13 @@
                 "description": "Vertel ons over uw Nikobus-hardware zodat de integratie de optimale updatestrategie kan gebruiken.",
                 "data": {
                     "has_feedbackmodule": "Feedbackmodule (05-207) geïnstalleerd en verbonden via PC-Link",
-                    "prior_gen3": "PC-Link is ouder dan Gen 3"
+                    "prior_gen3": "PC-Link is ouder dan Gen 3",
+                    "manual_config": "Handmatige configuratie gebruiken (automatische ontdekking overslaan)"
                 },
                 "data_description": {
                     "has_feedbackmodule": "Indien ingeschakeld stuurt de Feedbackmodule automatisch statuswijzigingen — geen polling nodig.",
-                    "prior_gen3": "Schakelt compatibiliteitsaanpassingen in voor eerste en tweede generatie PC-Link hardware."
+                    "prior_gen3": "Schakelt compatibiliteitsaanpassingen in voor eerste en tweede generatie PC-Link hardware.",
+                    "manual_config": "Voor installaties waarvan de firmware niet kan worden uitgelezen door de automatische ontdekking (doorgaans pre-Gen3 / Gen2 PC-Link). Bij elke start past de integratie nikobus_module_config.json en nikobus_button_config.json opnieuw toe vanuit de Home Assistant-configuratiemap. Valt terug op .migrated-varianten als de originelen door een eerdere v2-upgrade zijn hernoemd."
                 }
             },
             "polling": {
@@ -40,6 +42,7 @@
                     "connection_string": "Verbinding (seriële poort of IP:poort)",
                     "has_feedbackmodule": "Feedbackmodule (05-207) geïnstalleerd en verbonden via PC-Link",
                     "prior_gen3": "PC-Link is ouder dan Gen 3",
+                    "manual_config": "Handmatige configuratie gebruiken (automatische ontdekking overslaan)",
                     "refresh_interval": "Polling-interval (seconden)"
                 }
             }
@@ -67,11 +70,13 @@
                 "description": "Werk uw hardware-instellingen bij. De integratie herlaadt automatisch.",
                 "data": {
                     "has_feedbackmodule": "Feedbackmodule (05-207) geïnstalleerd en verbonden via PC-Link",
-                    "prior_gen3": "PC-Link is ouder dan Gen 3"
+                    "prior_gen3": "PC-Link is ouder dan Gen 3",
+                    "manual_config": "Handmatige configuratie gebruiken (automatische ontdekking overslaan)"
                 },
                 "data_description": {
                     "has_feedbackmodule": "Indien ingeschakeld stuurt de Feedbackmodule automatisch statuswijzigingen.",
-                    "prior_gen3": "Schakelt compatibiliteitsaanpassingen in voor eerste en tweede generatie PC-Link hardware."
+                    "prior_gen3": "Schakelt compatibiliteitsaanpassingen in voor eerste en tweede generatie PC-Link hardware.",
+                    "manual_config": "Voor installaties die niet via automatische ontdekking kunnen worden uitgelezen (pre-Gen3 / Gen2 PC-Link). Bij elke start past de integratie nikobus_module_config.json en nikobus_button_config.json opnieuw toe vanuit de configuratiemap."
                 }
             },
             "polling": {

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -22,7 +22,7 @@
                 "data_description": {
                     "has_feedbackmodule": "Indien ingeschakeld stuurt de Feedbackmodule automatisch statuswijzigingen — geen polling nodig.",
                     "prior_gen3": "Schakelt compatibiliteitsaanpassingen in voor eerste en tweede generatie PC-Link hardware.",
-                    "manual_config": "Voor installaties waarvan de firmware niet kan worden uitgelezen door de automatische ontdekking (doorgaans pre-Gen3 / Gen2 PC-Link). Bij elke start past de integratie nikobus_module_config.json en nikobus_button_config.json opnieuw toe vanuit de Home Assistant-configuratiemap. Valt terug op .migrated-varianten als de originelen door een eerdere v2-upgrade zijn hernoemd."
+                    "manual_config": "Voor installaties waarvan de firmware niet kan worden uitgelezen door de automatische ontdekking (doorgaans pre-Gen3 / Gen2 PC-Link). De bestanden nikobus_module_config.json en nikobus_button_config.json in de Home Assistant-configuratiemap zijn de declaratieve bron van waarheid: wijzigingen, toevoegingen en verwijderingen worden toegepast na het herladen van de integratie. Valt terug op .migrated-varianten als de originelen door een eerdere v2-upgrade zijn hernoemd."
                 }
             },
             "polling": {
@@ -76,7 +76,7 @@
                 "data_description": {
                     "has_feedbackmodule": "Indien ingeschakeld stuurt de Feedbackmodule automatisch statuswijzigingen.",
                     "prior_gen3": "Schakelt compatibiliteitsaanpassingen in voor eerste en tweede generatie PC-Link hardware.",
-                    "manual_config": "Voor installaties die niet via automatische ontdekking kunnen worden uitgelezen (pre-Gen3 / Gen2 PC-Link). Bij elke start past de integratie nikobus_module_config.json en nikobus_button_config.json opnieuw toe vanuit de configuratiemap."
+                    "manual_config": "Voor installaties die niet via automatische ontdekking kunnen worden uitgelezen (pre-Gen3 / Gen2 PC-Link). nikobus_module_config.json en nikobus_button_config.json in de configuratiemap zijn de declaratieve bron van waarheid; wijzigingen worden toegepast na het herladen van de integratie."
                 }
             },
             "polling": {

--- a/tests/test_manual_config.py
+++ b/tests/test_manual_config.py
@@ -249,40 +249,156 @@ class TestApplyManualConfig(unittest.TestCase):
         self.assertIn("0E6C", store.data["nikobus_module"])
 
     # ------------------------------------------------------------------
-    # Buttons: list form (v1 canonical) — one entry → one routable record.
+    # Buttons: a 4-key physical wall button (4 v1 entries) is grouped
+    # into ONE v2 record with four operation_points — preserves the
+    # device-registry "one device per physical button" UX.
     # ------------------------------------------------------------------
 
-    def test_button_list_form_creates_single_key_records(self):
+    def test_button_entries_group_by_physical_address(self):
+        # Four v1 entries with the same linked_button.address — one
+        # physical 4-key keypad, four bus addresses.
         self._write("nikobus_button_config.json", {
             "nikobus_button": [
-                {"address": "112233", "description": "Hallway"},
-                {"address": "445566", "description": "Bedroom"},
+                {
+                    "address": "004E2C",
+                    "description": "Sofa wall light up",
+                    "linked_button": [{
+                        "type": "IR Button with 4 Operation Points",
+                        "model": "05-348",
+                        "address": "0D1C80",
+                        "channels": 4,
+                        "key": "1C",
+                    }],
+                },
+                {
+                    "address": "404E2C",
+                    "description": "Sofa wall light down",
+                    "linked_button": [{
+                        "type": "IR Button with 4 Operation Points",
+                        "model": "05-348",
+                        "address": "0D1C80",
+                        "channels": 4,
+                        "key": "1D",
+                    }],
+                },
+                {
+                    "address": "804E2C",
+                    "description": "Sofa shutter open",
+                    "linked_button": [{
+                        "type": "IR Button with 4 Operation Points",
+                        "model": "05-348",
+                        "address": "0D1C80",
+                        "channels": 4,
+                        "key": "1A",
+                    }],
+                },
+                {
+                    "address": "C04E2C",
+                    "description": "Sofa shutter close",
+                    "linked_button": [{
+                        "type": "IR Button with 4 Operation Points",
+                        "model": "05-348",
+                        "address": "0D1C80",
+                        "channels": 4,
+                        "key": "1B",
+                    }],
+                },
             ]
         })
         store = _InMemoryModuleStore()
         button_data = {"nikobus_button": {}}
 
-        changed = _run(
-            nkbmanual.async_apply_manual_config(self.hass, store, button_data)
-        )
+        _run(nkbmanual.async_apply_manual_config(self.hass, store, button_data))
 
-        self.assertTrue(changed)
         buttons = button_data["nikobus_button"]
-        self.assertIn("112233", buttons)
-        self.assertIn("445566", buttons)
-
-        hallway = buttons["112233"]
-        # Single-key shape — the v2 router routes by op-point bus_address,
-        # so one op-point per v1 entry is enough.
-        self.assertEqual(hallway["channels"], 1)
-        self.assertEqual(list(hallway["operation_points"].keys()), ["1A"])
-        self.assertEqual(
-            hallway["operation_points"]["1A"]["bus_address"], "112233"
-        )
-        self.assertEqual(hallway["description"], "Hallway")
+        # One physical record, NOT four.
+        self.assertEqual(list(buttons.keys()), ["0D1C80"])
+        phys = buttons["0D1C80"]
+        self.assertEqual(phys["channels"], 4)
+        self.assertEqual(phys["model"], "05-348")
+        self.assertEqual(phys["type"], "IR Button with 4 Operation Points")
+        # All four keys present, each with its own bus_address +
+        # description from the v1 entry it came from.
+        op_points = phys["operation_points"]
+        self.assertEqual(set(op_points.keys()), {"1A", "1B", "1C", "1D"})
+        self.assertEqual(op_points["1C"]["bus_address"], "004E2C")
+        self.assertEqual(op_points["1C"]["description"], "Sofa wall light up")
+        self.assertEqual(op_points["1A"]["bus_address"], "804E2C")
 
     # ------------------------------------------------------------------
-    # Buttons: dict form also accepted.
+    # Buttons: 8-channel keypads carry keys "2A" through "2D" alongside
+    # the "1A"-"1D" set; the loader doesn't constrain key labels.
+    # ------------------------------------------------------------------
+
+    def test_eight_channel_keypad(self):
+        self._write("nikobus_button_config.json", {
+            "nikobus_button": [
+                {
+                    "address": "01E3EE",
+                    "description": "Bedroom Right Light On",
+                    "linked_button": [{
+                        "type": "Button with 8 Operation Points",
+                        "model": "05-349",
+                        "address": "1DF1E0",
+                        "channels": 8,
+                        "key": "2C",
+                    }],
+                },
+                {
+                    "address": "41E3EE",
+                    "description": "Bedroom Right Light Off",
+                    "linked_button": [{
+                        "type": "Button with 8 Operation Points",
+                        "model": "05-349",
+                        "address": "1DF1E0",
+                        "channels": 8,
+                        "key": "2D",
+                    }],
+                },
+            ]
+        })
+        store = _InMemoryModuleStore()
+        button_data = {"nikobus_button": {}}
+
+        _run(nkbmanual.async_apply_manual_config(self.hass, store, button_data))
+
+        phys = button_data["nikobus_button"]["1DF1E0"]
+        self.assertEqual(phys["channels"], 8)
+        self.assertEqual(set(phys["operation_points"].keys()), {"2C", "2D"})
+
+    # ------------------------------------------------------------------
+    # Buttons: entries without a linked_button block (IR/virtual/scene
+    # triggers, auto-generated DISCOVERED placeholders) fall back to a
+    # synthetic single-key record so the bus address still routes.
+    # ------------------------------------------------------------------
+
+    def test_unlinked_entry_falls_back_to_single_key(self):
+        self._write("nikobus_button_config.json", {
+            "nikobus_button": [
+                # IR scene trigger — no linked_button at all
+                {"address": "9E4E2C", "description": "Living scene TV lights",
+                 "impacted_module": [{"address": "0E6C", "group": "1"}]},
+                # Auto-generated placeholder — no linked_button
+                {"address": "FFFFFF",
+                 "description": "DISCOVERED - Nikobus Button #NFFFFFF",
+                 "impacted_module": [{"address": "", "group": ""}]},
+            ]
+        })
+        store = _InMemoryModuleStore()
+        button_data = {"nikobus_button": {}}
+
+        _run(nkbmanual.async_apply_manual_config(self.hass, store, button_data))
+
+        buttons = button_data["nikobus_button"]
+        self.assertIn("9E4E2C", buttons)
+        self.assertIn("FFFFFF", buttons)
+        ir = buttons["9E4E2C"]
+        self.assertEqual(ir["channels"], 1)
+        self.assertEqual(ir["operation_points"]["1A"]["bus_address"], "9E4E2C")
+        self.assertEqual(ir["description"], "Living scene TV lights")
+
+    # ------------------------------------------------------------------
+    # Buttons: dict form (v1-post-transform shape) also accepted.
     # ------------------------------------------------------------------
 
     def test_button_dict_form_accepted(self):
@@ -304,27 +420,39 @@ class TestApplyManualConfig(unittest.TestCase):
         )
 
     # ------------------------------------------------------------------
-    # Declarative semantics: removing a button from the file removes it
-    # from the store on the next apply.
+    # Declarative: removing entries from the file removes them on reapply.
     # ------------------------------------------------------------------
 
     def test_button_removal_propagates_on_reapply(self):
         button_data = {"nikobus_button": {
-            "112233": {
-                "description": "Old hallway",
-                "channels": 1,
-                "operation_points": {"1A": {"bus_address": "112233"}},
+            "0D1C80": {
+                "description": "Old IR button",
+                "channels": 4,
+                "operation_points": {
+                    "1A": {"bus_address": "804E2C"},
+                    "1B": {"bus_address": "C04E2C"},
+                },
             },
-            "445566": {
-                "description": "Bedroom",
-                "channels": 1,
-                "operation_points": {"1A": {"bus_address": "445566"}},
+            "1DF1E0": {
+                "description": "Bedroom keypad",
+                "channels": 8,
+                "operation_points": {"2C": {"bus_address": "01E3EE"}},
             },
         }}
-        # File only mentions the bedroom now.
+        # File only declares the bedroom keypad now.
         self._write("nikobus_button_config.json", {
             "nikobus_button": [
-                {"address": "445566", "description": "Bedroom"},
+                {
+                    "address": "01E3EE",
+                    "description": "Bedroom Right Light On",
+                    "linked_button": [{
+                        "type": "Button with 8 Operation Points",
+                        "model": "05-349",
+                        "address": "1DF1E0",
+                        "channels": 8,
+                        "key": "2C",
+                    }],
+                },
             ]
         })
         store = _InMemoryModuleStore()
@@ -332,8 +460,43 @@ class TestApplyManualConfig(unittest.TestCase):
         _run(nkbmanual.async_apply_manual_config(self.hass, store, button_data))
 
         buttons = button_data["nikobus_button"]
-        self.assertNotIn("112233", buttons)
-        self.assertIn("445566", buttons)
+        self.assertNotIn("0D1C80", buttons)
+        self.assertIn("1DF1E0", buttons)
+
+    # ------------------------------------------------------------------
+    # Regression: an op-point whose bus address collides with another
+    # physical's address must not eclipse the proper grouping.
+    # ------------------------------------------------------------------
+
+    def test_unlinked_does_not_overwrite_grouped_physical(self):
+        self._write("nikobus_button_config.json", {
+            "nikobus_button": [
+                # Grouped first — physical 0D1C80
+                {
+                    "address": "004E2C",
+                    "description": "Real key",
+                    "linked_button": [{
+                        "type": "IR Button with 4 Operation Points",
+                        "model": "05-348",
+                        "address": "0D1C80",
+                        "channels": 4,
+                        "key": "1C",
+                    }],
+                },
+                # Standalone entry whose bus address happens to equal
+                # the grouped physical's address — must not overwrite.
+                {"address": "0D1C80", "description": "Stray placeholder"},
+            ]
+        })
+        store = _InMemoryModuleStore()
+        button_data = {"nikobus_button": {}}
+
+        _run(nkbmanual.async_apply_manual_config(self.hass, store, button_data))
+
+        buttons = button_data["nikobus_button"]
+        # The grouped physical record wins; the standalone is dropped.
+        self.assertEqual(buttons["0D1C80"]["channels"], 4)
+        self.assertIn("1C", buttons["0D1C80"]["operation_points"])
 
     # ------------------------------------------------------------------
     # Unreadable file is logged + swallowed; the loader still returns.
@@ -355,6 +518,193 @@ class TestApplyManualConfig(unittest.TestCase):
         )
         self.assertFalse(changed)
         self.assertIn("AABB", store.data["nikobus_module"])
+
+
+class TestRealWorldSample(unittest.TestCase):
+    """End-to-end pin against the live install sample (issue ##).
+
+    The sample contains every category that matters: switch / dimmer /
+    roller modules with mixed channel-level options (entity_type,
+    operation_time_up/down), pc_link / pc_logic / feedback_module
+    sentinel sections, an empty other_module list, a 4-key IR keypad
+    (4 entries), an 8-channel keypad (2C/2D entries), virtual IR
+    scene-trigger entries with no linked_button, and DISCOVERED
+    placeholders. If the loader handles this file the user does not
+    need to edit anything.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.config_dir = self._tmp.name
+        self.hass = _FakeHass(self.config_dir)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _write(self, filename: str, payload):
+        path = os.path.join(self.config_dir, filename)
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh)
+        return path
+
+    def test_real_world_modules_sample(self):
+        self._write("nikobus_module_config.json", {
+            "switch_module": [
+                {
+                    "description": "switch_module_s1",
+                    "model": "05-000-02",
+                    "address": "C9A5",
+                    "channels": [
+                        {"description": "Extérieur Porte Entrée",
+                         "entity_type": "light"},
+                        {"description": "Hall RDC Lumière",
+                         "entity_type": "light"},
+                    ],
+                    "discovered_info": {
+                        "name": "Switch Module", "device_type": "01",
+                        "channels_count": 12,
+                    },
+                },
+            ],
+            "roller_module": [{
+                "description": "rollershutter_module_r1",
+                "model": "05-001-02",
+                "address": "9105",
+                "channels": [
+                    {"description": "Salon Volet Sofa",
+                     "operation_time_up": "29",
+                     "operation_time_down": "27"},
+                    {"description": "not_in_use output_1",
+                     "operation_time_up": "30"},
+                ],
+                "discovered_info": {
+                    "name": "Roller Shutter Module", "device_type": "02",
+                    "channels_count": 6,
+                },
+            }],
+            "pc_link": [{
+                "description": "pc_link_pcl1",
+                "model": "05-200",
+                "address": "86F5",
+                "discovered_info": {
+                    "name": "PC Link", "device_type": "0A",
+                },
+            }],
+            "feedback_module": [{
+                "description": "feedback_module_fb1",
+                "model": "05-207",
+                "address": "966C",
+                "discovered_info": {
+                    "name": "Feedback Module", "device_type": "42",
+                },
+            }],
+            "other_module": [],
+        })
+
+        store = _InMemoryModuleStore()
+        _run(nkbmanual.async_apply_manual_config(
+            self.hass, store, {"nikobus_button": {}}))
+
+        modules = store.data["nikobus_module"]
+        self.assertIn("C9A5", modules)
+        self.assertIn("9105", modules)
+        self.assertIn("86F5", modules)
+        self.assertIn("966C", modules)
+
+        # Channel-level options carry through.
+        c9a5_ch0 = modules["C9A5"]["channels"][0]
+        self.assertEqual(c9a5_ch0["description"], "Extérieur Porte Entrée")
+        self.assertEqual(c9a5_ch0["entity_type"], "light")
+
+        roller_ch = modules["9105"]["channels"][0]
+        self.assertEqual(roller_ch["operation_time_up"], "29")
+        self.assertEqual(roller_ch["operation_time_down"], "27")
+
+        # discovered_info from v1 file survives, manual_config source
+        # marker added alongside the existing keys.
+        di = modules["C9A5"]["discovered_info"]
+        self.assertEqual(di["device_type"], "01")
+        self.assertEqual(di["channels_count"], 12)
+        self.assertEqual(di["source"], "manual_config")
+
+        # System modules (pc_link / feedback) keep their module_type
+        # bucket and channels=[] is fine for non-output modules.
+        self.assertEqual(modules["86F5"]["module_type"], "pc_link")
+        self.assertEqual(modules["966C"]["module_type"], "feedback_module")
+
+    def test_real_world_buttons_sample(self):
+        # Two 4-key wall buttons sharing physicals 0D1C80 and 1CA840,
+        # plus an 8-key keypad 1DF1E0 with two of its 2X keys, plus
+        # an IR scene trigger without linked_button, plus a discovered
+        # placeholder.
+        self._write("nikobus_button_config.json", {
+            "nikobus_button": [
+                # 0D1C80 — 4 entries
+                {"address": "004E2C", "description": "BT_Sofa_Wall_Up",
+                 "linked_button": [{"type": "IR Button with 4 Operation Points",
+                                    "model": "05-348", "address": "0D1C80",
+                                    "channels": 4, "key": "1C"}]},
+                {"address": "404E2C", "description": "BT_Sofa_Wall_Down",
+                 "linked_button": [{"type": "IR Button with 4 Operation Points",
+                                    "model": "05-348", "address": "0D1C80",
+                                    "channels": 4, "key": "1D"}]},
+                {"address": "804E2C", "description": "BT_Sofa_Shutter_Open",
+                 "linked_button": [{"type": "IR Button with 4 Operation Points",
+                                    "model": "05-348", "address": "0D1C80",
+                                    "channels": 4, "key": "1A"}]},
+                {"address": "C04E2C", "description": "BT_Sofa_Shutter_Close",
+                 "linked_button": [{"type": "IR Button with 4 Operation Points",
+                                    "model": "05-348", "address": "0D1C80",
+                                    "channels": 4, "key": "1B"}]},
+                # 1CA840 — 2 entries (only 1A + 1B used in install)
+                {"address": "00854E", "description": "BT_Parking_On",
+                 "linked_button": [{"type": "Button with 4 Operation Points",
+                                    "model": "05-346", "address": "1CA840",
+                                    "channels": 4, "key": "1C"}]},
+                {"address": "40854E", "description": "BT_Parking_Off",
+                 "linked_button": [{"type": "Button with 4 Operation Points",
+                                    "model": "05-346", "address": "1CA840",
+                                    "channels": 4, "key": "1D"}]},
+                # 1DF1E0 — 8-channel keypad
+                {"address": "01E3EE", "description": "BT_Right_On",
+                 "linked_button": [{"type": "Button with 8 Operation Points",
+                                    "model": "05-349", "address": "1DF1E0",
+                                    "channels": 8, "key": "2C"}]},
+                {"address": "41E3EE", "description": "BT_Right_Off",
+                 "linked_button": [{"type": "Button with 8 Operation Points",
+                                    "model": "05-349", "address": "1DF1E0",
+                                    "channels": 8, "key": "2D"}]},
+                # IR scene trigger — no linked_button
+                {"address": "9E4E2C", "description": "IR_TV_Lights",
+                 "impacted_module": [{"address": "0E6C", "group": "1"}]},
+                # Auto-generated placeholder — no linked_button
+                {"address": "FFFFFF",
+                 "description": "DISCOVERED - Nikobus Button #NFFFFFF",
+                 "impacted_module": [{"address": "", "group": ""}]},
+            ]
+        })
+
+        store = _InMemoryModuleStore()
+        button_data = {"nikobus_button": {}}
+        _run(nkbmanual.async_apply_manual_config(self.hass, store, button_data))
+
+        buttons = button_data["nikobus_button"]
+        # 3 physical buttons + 2 standalone = 5 v2 records out of 10
+        # v1 entries.
+        self.assertEqual(len(buttons), 5)
+        self.assertEqual(buttons["0D1C80"]["channels"], 4)
+        self.assertEqual(set(buttons["0D1C80"]["operation_points"].keys()),
+                         {"1A", "1B", "1C", "1D"})
+        # Bus-address routing for the keys.
+        self.assertEqual(
+            buttons["0D1C80"]["operation_points"]["1C"]["bus_address"], "004E2C")
+        self.assertEqual(buttons["1DF1E0"]["channels"], 8)
+        self.assertEqual(set(buttons["1DF1E0"]["operation_points"].keys()),
+                         {"2C", "2D"})
+        # Standalone fallback.
+        self.assertEqual(buttons["9E4E2C"]["channels"], 1)
+        self.assertEqual(buttons["9E4E2C"]["description"], "IR_TV_Lights")
+        self.assertIn("FFFFFF", buttons)
 
 
 if __name__ == "__main__":

--- a/tests/test_manual_config.py
+++ b/tests/test_manual_config.py
@@ -1,0 +1,343 @@
+"""Tests for the manual-configuration loader (``nkbmanual``).
+
+Manual-config mode is opt-in via the config flow's ``manual_config``
+toggle. When enabled, the integration re-applies the v1 JSON files on
+every startup (no rename) so installs whose firmware auto-discovery
+cannot crack — typically pre-Gen3 / Gen2 PC-Link, per nikobus-connect
+0.5.24 CHANGELOG — can keep their inventory declarative.
+
+These tests pin the load shape, the merge semantics (YAML wins for
+inventory fields, options-flow edits survive), the ``.migrated``
+fallback for users who already upgraded once, and the single-key
+button-entry shape that makes the v2 router route presses correctly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+# Reuse the same conftest hooks the migration tests use.
+ROOT = Path(__file__).parent.parent
+COMP = ROOT / "custom_components" / "nikobus"
+
+
+# Sanity: the real aiofiles is patched in by conftest / test_module_migration.
+# Importing test_module_migration first installs the real-file stub on the
+# module-level aiofiles object that nkbmanual / nkbmigration end up using.
+import tests.test_module_migration as _mig_tests  # noqa: F401,E402
+
+
+def _load(name, path):
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = ".".join(name.split(".")[:-1])
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# Reuse the shared NikobusModuleStorage stub by mirroring its API.
+class _InMemoryModuleStore:
+    def __init__(self, initial=None):
+        self._data = initial if initial is not None else {"nikobus_module": {}}
+        self.save_count = 0
+
+    async def async_load(self):
+        return self._data
+
+    async def async_save(self):
+        self.save_count += 1
+
+    @property
+    def data(self):
+        return self._data
+
+    @property
+    def is_empty(self):
+        return not bool(self._data.get("nikobus_module"))
+
+
+class _FakeConfig:
+    def __init__(self, config_dir: str):
+        self.config_dir = config_dir
+
+    def path(self, filename: str) -> str:
+        return os.path.join(self.config_dir, filename)
+
+
+class _FakeHass:
+    def __init__(self, config_dir: str):
+        self.config = _FakeConfig(config_dir)
+
+    async def async_add_executor_job(self, fn, *args):
+        return fn(*args)
+
+
+# Load nkbmanual fresh (its imports of nkbmigration / nkbstorage are
+# already registered by the module-migration test bootstrap).
+nkbmanual = _load(
+    "custom_components.nikobus.nkbmanual", COMP / "nkbmanual.py"
+)
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+class TestApplyManualConfig(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.config_dir = self._tmp.name
+        self.hass = _FakeHass(self.config_dir)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _write(self, filename: str, payload):
+        path = os.path.join(self.config_dir, filename)
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh)
+        return path
+
+    # ------------------------------------------------------------------
+    # Smoke: no files = no-op
+    # ------------------------------------------------------------------
+
+    def test_no_files_returns_false(self):
+        store = _InMemoryModuleStore()
+        button_data = {"nikobus_button": {}}
+
+        changed = _run(
+            nkbmanual.async_apply_manual_config(self.hass, store, button_data)
+        )
+
+        self.assertFalse(changed)
+        self.assertEqual(store.data, {"nikobus_module": {}})
+        self.assertEqual(button_data, {"nikobus_button": {}})
+
+    # ------------------------------------------------------------------
+    # Module file: applied into an empty store
+    # ------------------------------------------------------------------
+
+    def test_modules_applied_into_empty_store(self):
+        path = self._write("nikobus_module_config.json", {
+            "switch_module": [{
+                "description": "Living lights",
+                "model": "05-000-02",
+                "address": "C9A5",
+                "channels": [
+                    {"description": "Sofa"},
+                    {"description": "Pendant"},
+                ],
+            }],
+        })
+        store = _InMemoryModuleStore()
+        button_data = {"nikobus_button": {}}
+
+        changed = _run(
+            nkbmanual.async_apply_manual_config(self.hass, store, button_data)
+        )
+
+        self.assertTrue(changed)
+        entry = store.data["nikobus_module"]["C9A5"]
+        self.assertEqual(entry["module_type"], "switch_module")
+        self.assertEqual(entry["description"], "Living lights")
+        self.assertEqual(entry["model"], "05-000-02")
+        self.assertEqual(entry["channels"][0]["description"], "Sofa")
+        # Manual-config marker on discovered_info so diagnostics can
+        # tell apart YAML-sourced rows from auto-discovered ones.
+        self.assertEqual(entry["discovered_info"]["source"], "manual_config")
+        # Source file stays in place — no .migrated rename.
+        self.assertTrue(os.path.exists(path))
+
+    # ------------------------------------------------------------------
+    # Merge: YAML wins for inventory, options-flow edits survive
+    # ------------------------------------------------------------------
+
+    def test_options_flow_channel_edits_survive_reapply(self):
+        self._write("nikobus_module_config.json", {
+            "switch_module": [{
+                "description": "Kitchen",
+                "address": "AABB",
+                "channels": [
+                    {"description": "Counter"},
+                    {"description": "Pendant"},
+                ],
+            }],
+        })
+        # Simulate a populated store with an options-flow channel edit:
+        # the user has set entity_type=light + led_on on channel 1.
+        store = _InMemoryModuleStore({
+            "nikobus_module": {
+                "AABB": {
+                    "module_type": "switch_module",
+                    "description": "Stale auto-discovery name",
+                    "model": "05-000-02",
+                    "channels": [
+                        {
+                            "description": "Counter (will be overwritten)",
+                            "entity_type": "light",
+                            "led_on": "1A2B3C",
+                        },
+                        {"description": "Pendant"},
+                    ],
+                }
+            }
+        })
+        button_data = {"nikobus_button": {}}
+
+        _run(nkbmanual.async_apply_manual_config(self.hass, store, button_data))
+
+        entry = store.data["nikobus_module"]["AABB"]
+        # YAML wins for description (both module and channel level).
+        self.assertEqual(entry["description"], "Kitchen")
+        self.assertEqual(entry["channels"][0]["description"], "Counter")
+        # Options-flow-only fields survive.
+        self.assertEqual(entry["channels"][0]["entity_type"], "light")
+        self.assertEqual(entry["channels"][0]["led_on"], "1A2B3C")
+
+    # ------------------------------------------------------------------
+    # .migrated fallback for users who already upgraded once.
+    # ------------------------------------------------------------------
+
+    def test_migrated_fallback(self):
+        self._write("nikobus_module_config.json.migrated", {
+            "dimmer_module": [{
+                "description": "Salon dimmer",
+                "address": "0E6C",
+                "channels": [{"description": "Sconces"}],
+            }],
+        })
+        store = _InMemoryModuleStore()
+        button_data = {"nikobus_button": {}}
+
+        changed = _run(
+            nkbmanual.async_apply_manual_config(self.hass, store, button_data)
+        )
+
+        self.assertTrue(changed)
+        self.assertIn("0E6C", store.data["nikobus_module"])
+        self.assertEqual(
+            store.data["nikobus_module"]["0E6C"]["module_type"], "dimmer_module"
+        )
+
+    # ------------------------------------------------------------------
+    # Buttons: list form (v1 canonical) — one entry → one routable record
+    # ------------------------------------------------------------------
+
+    def test_button_list_form_creates_single_key_records(self):
+        self._write("nikobus_button_config.json", {
+            "nikobus_button": [
+                {"address": "112233", "description": "Hallway"},
+                {"address": "445566", "description": "Bedroom"},
+            ]
+        })
+        store = _InMemoryModuleStore()
+        button_data = {"nikobus_button": {}}
+
+        changed = _run(
+            nkbmanual.async_apply_manual_config(self.hass, store, button_data)
+        )
+
+        self.assertTrue(changed)
+        buttons = button_data["nikobus_button"]
+        self.assertIn("112233", buttons)
+        self.assertIn("445566", buttons)
+
+        hallway = buttons["112233"]
+        # Single-key shape — the v2 router routes by op-point bus_address,
+        # so one op-point per v1 entry is enough.
+        self.assertEqual(hallway["channels"], 1)
+        self.assertEqual(list(hallway["operation_points"].keys()), ["1A"])
+        self.assertEqual(
+            hallway["operation_points"]["1A"]["bus_address"], "112233"
+        )
+        self.assertEqual(hallway["description"], "Hallway")
+
+    # ------------------------------------------------------------------
+    # Buttons: dict form (v1 post-transform shape) also accepted.
+    # ------------------------------------------------------------------
+
+    def test_button_dict_form_accepted(self):
+        self._write("nikobus_button_config.json", {
+            "nikobus_button": {
+                "AABBCC": {"description": "Kitchen"},
+            }
+        })
+        store = _InMemoryModuleStore()
+        button_data = {"nikobus_button": {}}
+
+        _run(nkbmanual.async_apply_manual_config(self.hass, store, button_data))
+
+        self.assertIn("AABBCC", button_data["nikobus_button"])
+        self.assertEqual(
+            button_data["nikobus_button"]["AABBCC"]
+            ["operation_points"]["1A"]["bus_address"],
+            "AABBCC",
+        )
+
+    # ------------------------------------------------------------------
+    # Buttons: re-apply preserves an HA-side renamed description and
+    # any auto-discovered op-points are pruned back to "1A".
+    # ------------------------------------------------------------------
+
+    def test_button_reapply_preserves_user_rename_and_prunes_strays(self):
+        self._write("nikobus_button_config.json", {
+            "nikobus_button": [
+                {"address": "112233", "description": "#N112233"},  # placeholder
+            ]
+        })
+        store = _InMemoryModuleStore()
+        button_data = {"nikobus_button": {
+            "112233": {
+                "description": "Hallway (renamed by user)",
+                "channels": 4,
+                "operation_points": {
+                    "1A": {"bus_address": "112233"},
+                    # A stray op-point from a previous auto-discovery —
+                    # manual mode owns the shape, so this gets pruned.
+                    "1B": {"bus_address": "999999"},
+                },
+            }
+        }}
+
+        _run(nkbmanual.async_apply_manual_config(self.hass, store, button_data))
+
+        entry = button_data["nikobus_button"]["112233"]
+        # User-set description is preserved (placeholder didn't overwrite it).
+        self.assertEqual(entry["description"], "Hallway (renamed by user)")
+        # Stray "1B" was pruned — only "1A" remains.
+        self.assertEqual(list(entry["operation_points"].keys()), ["1A"])
+
+    # ------------------------------------------------------------------
+    # Unreadable file is logged + swallowed; the loader still returns.
+    # ------------------------------------------------------------------
+
+    def test_unreadable_file_logged_and_skipped(self):
+        # Invalid JSON
+        path = os.path.join(self.config_dir, "nikobus_module_config.json")
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write("{ this is not JSON")
+
+        store = _InMemoryModuleStore()
+        button_data = {"nikobus_button": {}}
+
+        # Must not raise.
+        changed = _run(
+            nkbmanual.async_apply_manual_config(self.hass, store, button_data)
+        )
+        self.assertFalse(changed)
+        self.assertEqual(store.data, {"nikobus_module": {}})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_manual_config.py
+++ b/tests/test_manual_config.py
@@ -1,15 +1,16 @@
 """Tests for the manual-configuration loader (``nkbmanual``).
 
 Manual-config mode is opt-in via the config flow's ``manual_config``
-toggle. When enabled, the integration re-applies the v1 JSON files on
-every startup (no rename) so installs whose firmware auto-discovery
-cannot crack — typically pre-Gen3 / Gen2 PC-Link, per nikobus-connect
-0.5.24 CHANGELOG — can keep their inventory declarative.
+toggle. When enabled, the integration treats the v1 JSON files as the
+declarative source of truth: ``nikobus_module_config.json`` and
+``nikobus_button_config.json`` are re-applied wholesale on every
+reload, so additions, edits, and removals show up after the next
+reload.
 
-These tests pin the load shape, the merge semantics (YAML wins for
-inventory fields, options-flow edits survive), the ``.migrated``
-fallback for users who already upgraded once, and the single-key
-button-entry shape that makes the v2 router route presses correctly.
+These tests pin: full replacement (no merge), the ``.migrated``
+fallback for users who already upgraded once, the single-key
+button-entry shape that makes the v2 router fire HA events on
+presses, and the no-files / unreadable-file paths.
 """
 
 from __future__ import annotations
@@ -21,16 +22,14 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import AsyncMock
 
 # Reuse the same conftest hooks the migration tests use.
 ROOT = Path(__file__).parent.parent
 COMP = ROOT / "custom_components" / "nikobus"
 
 
-# Sanity: the real aiofiles is patched in by conftest / test_module_migration.
-# Importing test_module_migration first installs the real-file stub on the
-# module-level aiofiles object that nkbmanual / nkbmigration end up using.
+# Importing test_module_migration first installs the real-file aiofiles
+# stub that nkbmanual / nkbmigration both end up using.
 import tests.test_module_migration as _mig_tests  # noqa: F401,E402
 
 
@@ -45,7 +44,6 @@ def _load(name, path):
     return module
 
 
-# Reuse the shared NikobusModuleStorage stub by mirroring its API.
 class _InMemoryModuleStore:
     def __init__(self, initial=None):
         self._data = initial if initial is not None else {"nikobus_module": {}}
@@ -82,8 +80,8 @@ class _FakeHass:
         return fn(*args)
 
 
-# Load nkbmanual fresh (its imports of nkbmigration / nkbstorage are
-# already registered by the module-migration test bootstrap).
+# Force a fresh load so the test picks up the latest module source.
+sys.modules.pop("custom_components.nikobus.nkbmanual", None)
 nkbmanual = _load(
     "custom_components.nikobus.nkbmanual", COMP / "nkbmanual.py"
 )
@@ -109,7 +107,7 @@ class TestApplyManualConfig(unittest.TestCase):
         return path
 
     # ------------------------------------------------------------------
-    # Smoke: no files = no-op
+    # Smoke: no files = no-op, store untouched.
     # ------------------------------------------------------------------
 
     def test_no_files_returns_false(self):
@@ -125,7 +123,7 @@ class TestApplyManualConfig(unittest.TestCase):
         self.assertEqual(button_data, {"nikobus_button": {}})
 
     # ------------------------------------------------------------------
-    # Module file: applied into an empty store
+    # Modules: applied into an empty store and tagged with source.
     # ------------------------------------------------------------------
 
     def test_modules_applied_into_empty_store(self):
@@ -153,57 +151,80 @@ class TestApplyManualConfig(unittest.TestCase):
         self.assertEqual(entry["description"], "Living lights")
         self.assertEqual(entry["model"], "05-000-02")
         self.assertEqual(entry["channels"][0]["description"], "Sofa")
-        # Manual-config marker on discovered_info so diagnostics can
-        # tell apart YAML-sourced rows from auto-discovered ones.
         self.assertEqual(entry["discovered_info"]["source"], "manual_config")
         # Source file stays in place — no .migrated rename.
         self.assertTrue(os.path.exists(path))
 
     # ------------------------------------------------------------------
-    # Merge: YAML wins for inventory, options-flow edits survive
+    # Declarative semantics: removals from the file remove from the store.
     # ------------------------------------------------------------------
 
-    def test_options_flow_channel_edits_survive_reapply(self):
+    def test_module_removal_propagates_on_reapply(self):
+        # Store starts populated with TWO modules.
+        store = _InMemoryModuleStore({
+            "nikobus_module": {
+                "AABB": {"module_type": "switch_module", "description": "stale",
+                         "channels": []},
+                "CCDD": {"module_type": "dimmer_module", "description": "still here",
+                         "channels": []},
+            }
+        })
+        # File now only declares one of them.
+        self._write("nikobus_module_config.json", {
+            "dimmer_module": [{
+                "description": "still here",
+                "address": "CCDD",
+                "channels": [],
+            }],
+        })
+        button_data = {"nikobus_button": {}}
+
+        _run(nkbmanual.async_apply_manual_config(self.hass, store, button_data))
+
+        modules = store.data["nikobus_module"]
+        self.assertNotIn("AABB", modules)
+        self.assertIn("CCDD", modules)
+
+    # ------------------------------------------------------------------
+    # Declarative semantics: YAML wins, options-flow edits do not survive.
+    # ------------------------------------------------------------------
+
+    def test_file_wins_over_options_flow_state(self):
+        # Pretend the user previously customized channel 1 via the
+        # options flow — in manual mode that state is NOT preserved
+        # across a reload; the file is authoritative.
+        store = _InMemoryModuleStore({
+            "nikobus_module": {
+                "AABB": {
+                    "module_type": "switch_module",
+                    "description": "stale name",
+                    "model": "05-000-02",
+                    "channels": [
+                        {"description": "Counter",
+                         "entity_type": "light",
+                         "led_on": "1A2B3C"},
+                    ],
+                }
+            }
+        })
         self._write("nikobus_module_config.json", {
             "switch_module": [{
                 "description": "Kitchen",
                 "address": "AABB",
                 "channels": [
-                    {"description": "Counter"},
-                    {"description": "Pendant"},
+                    {"description": "Counter"},  # no entity_type / led_on
                 ],
             }],
-        })
-        # Simulate a populated store with an options-flow channel edit:
-        # the user has set entity_type=light + led_on on channel 1.
-        store = _InMemoryModuleStore({
-            "nikobus_module": {
-                "AABB": {
-                    "module_type": "switch_module",
-                    "description": "Stale auto-discovery name",
-                    "model": "05-000-02",
-                    "channels": [
-                        {
-                            "description": "Counter (will be overwritten)",
-                            "entity_type": "light",
-                            "led_on": "1A2B3C",
-                        },
-                        {"description": "Pendant"},
-                    ],
-                }
-            }
         })
         button_data = {"nikobus_button": {}}
 
         _run(nkbmanual.async_apply_manual_config(self.hass, store, button_data))
 
         entry = store.data["nikobus_module"]["AABB"]
-        # YAML wins for description (both module and channel level).
         self.assertEqual(entry["description"], "Kitchen")
-        self.assertEqual(entry["channels"][0]["description"], "Counter")
-        # Options-flow-only fields survive.
-        self.assertEqual(entry["channels"][0]["entity_type"], "light")
-        self.assertEqual(entry["channels"][0]["led_on"], "1A2B3C")
+        # Options-flow-only fields are wiped — file is the truth.
+        self.assertNotIn("entity_type", entry["channels"][0])
+        self.assertNotIn("led_on", entry["channels"][0])
 
     # ------------------------------------------------------------------
     # .migrated fallback for users who already upgraded once.
@@ -226,12 +247,9 @@ class TestApplyManualConfig(unittest.TestCase):
 
         self.assertTrue(changed)
         self.assertIn("0E6C", store.data["nikobus_module"])
-        self.assertEqual(
-            store.data["nikobus_module"]["0E6C"]["module_type"], "dimmer_module"
-        )
 
     # ------------------------------------------------------------------
-    # Buttons: list form (v1 canonical) — one entry → one routable record
+    # Buttons: list form (v1 canonical) — one entry → one routable record.
     # ------------------------------------------------------------------
 
     def test_button_list_form_creates_single_key_records(self):
@@ -264,7 +282,7 @@ class TestApplyManualConfig(unittest.TestCase):
         self.assertEqual(hallway["description"], "Hallway")
 
     # ------------------------------------------------------------------
-    # Buttons: dict form (v1 post-transform shape) also accepted.
+    # Buttons: dict form also accepted.
     # ------------------------------------------------------------------
 
     def test_button_dict_form_accepted(self):
@@ -286,57 +304,57 @@ class TestApplyManualConfig(unittest.TestCase):
         )
 
     # ------------------------------------------------------------------
-    # Buttons: re-apply preserves an HA-side renamed description and
-    # any auto-discovered op-points are pruned back to "1A".
+    # Declarative semantics: removing a button from the file removes it
+    # from the store on the next apply.
     # ------------------------------------------------------------------
 
-    def test_button_reapply_preserves_user_rename_and_prunes_strays(self):
+    def test_button_removal_propagates_on_reapply(self):
+        button_data = {"nikobus_button": {
+            "112233": {
+                "description": "Old hallway",
+                "channels": 1,
+                "operation_points": {"1A": {"bus_address": "112233"}},
+            },
+            "445566": {
+                "description": "Bedroom",
+                "channels": 1,
+                "operation_points": {"1A": {"bus_address": "445566"}},
+            },
+        }}
+        # File only mentions the bedroom now.
         self._write("nikobus_button_config.json", {
             "nikobus_button": [
-                {"address": "112233", "description": "#N112233"},  # placeholder
+                {"address": "445566", "description": "Bedroom"},
             ]
         })
         store = _InMemoryModuleStore()
-        button_data = {"nikobus_button": {
-            "112233": {
-                "description": "Hallway (renamed by user)",
-                "channels": 4,
-                "operation_points": {
-                    "1A": {"bus_address": "112233"},
-                    # A stray op-point from a previous auto-discovery —
-                    # manual mode owns the shape, so this gets pruned.
-                    "1B": {"bus_address": "999999"},
-                },
-            }
-        }}
 
         _run(nkbmanual.async_apply_manual_config(self.hass, store, button_data))
 
-        entry = button_data["nikobus_button"]["112233"]
-        # User-set description is preserved (placeholder didn't overwrite it).
-        self.assertEqual(entry["description"], "Hallway (renamed by user)")
-        # Stray "1B" was pruned — only "1A" remains.
-        self.assertEqual(list(entry["operation_points"].keys()), ["1A"])
+        buttons = button_data["nikobus_button"]
+        self.assertNotIn("112233", buttons)
+        self.assertIn("445566", buttons)
 
     # ------------------------------------------------------------------
     # Unreadable file is logged + swallowed; the loader still returns.
     # ------------------------------------------------------------------
 
     def test_unreadable_file_logged_and_skipped(self):
-        # Invalid JSON
         path = os.path.join(self.config_dir, "nikobus_module_config.json")
         with open(path, "w", encoding="utf-8") as fh:
             fh.write("{ this is not JSON")
-
-        store = _InMemoryModuleStore()
+        store = _InMemoryModuleStore({"nikobus_module": {
+            "AABB": {"module_type": "switch_module", "channels": []},
+        }})
         button_data = {"nikobus_button": {}}
 
-        # Must not raise.
+        # Must not raise. The unreadable module file should leave the
+        # store intact (better than wiping it on a typo).
         changed = _run(
             nkbmanual.async_apply_manual_config(self.hass, store, button_data)
         )
         self.assertFalse(changed)
-        self.assertEqual(store.data, {"nikobus_module": {}})
+        self.assertIn("AABB", store.data["nikobus_module"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Re-add a v1-style declarative configuration path for installs whose firmware auto-discovery cannot read — typically pre-Gen3 / Gen2 PC-Link, per the `nikobus-connect` 0.5.24 CHANGELOG section *What this does NOT fix*. The v2 release made auto-discovery the only path; this PR re-introduces the YAML/JSON option without dismantling auto-discovery for users it works for.

- A new `manual_config` toggle in the hardware step of the config flow (initial + reconfigure + options).
- When enabled, `nikobus_module_config.json` and `nikobus_button_config.json` in the HA config directory become the **declarative source of truth**: additions, edits, and removals all take effect on the next reload.
- The one-shot v1→v2 rename migrations are skipped in manual mode so the source files survive across restarts. `.migrated` fallback for users who upgraded once before flipping the toggle.
- The options-flow *Customise a module* path is hidden in manual mode — any change through that UI would be wiped on the next reload, so the menu just doesn't offer it.

## How it works

**Modules** — reuses the existing `convert_legacy_to_flat` helper. Every category present in real installs (`switch_module`, `dimmer_module`, `roller_module`, `pc_link`, `pc_logic`, `feedback_module`, `other_module`) maps through cleanly. Channel-level `entity_type`, `operation_time_up`, `operation_time_down`, the legacy single `operation_time`, and `not_in_use output_N` placeholders all pass through verbatim. `discovered_info` (`device_type`, `channels_count`) survives, with a `source: "manual_config"` marker added alongside.

**Buttons** — each v1 list entry is one operation point. Entries sharing the same `linked_button[0].address` are grouped into one v2 physical button (`channels`, `type`, `model` from the keypad metadata, one `operation_point` per key — `1A`/`1B`/`1C`/`1D` for ≤4-channel, `2A`–`2D` added for 8-channel keypads). The v1 entry's top-level `address` becomes the `bus_address` on its operation point — that's what the v2 router matches presses against, so routing works identically to v1. Entries without `linked_button` (IR scene triggers, virtual buttons, auto-generated `DISCOVERED -` placeholders) fall back to a single-key synthetic record so their bus address still fires HA events.

`impacted_module` and `linked_modules` are intentionally ignored — v2 routes by bus address, and `_surface_legacy_undecoded_buttons` only runs post-discovery, so manual-mode users get no false Repairs warnings.

## Safety

- Unreadable module file leaves the existing store intact instead of clearing it — a JSON typo can't nuke a working inventory.
- The one-shot rename migrations stay enabled for non-manual users (no behaviour change for the auto-discovery path).

## Test plan

- [x] 14 new tests in `tests/test_manual_config.py`, including two end-to-end pins built from the real-world sample of a live install (every module category + 4-key + 8-key keypads + IR triggers + DISCOVERED placeholders).
- [x] No regressions in the rest of the suite (same 43 pre-existing failures, unchanged before/after).
- [ ] Manual smoke-test on a real pre-Gen3 install with the user's actual `nikobus_module_config.json` + `nikobus_button_config.json` in place.

https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5)_