### PR TITLE
Manual-config follow-ups: simpler help text, auto-rename .migrated, preserve linked_modules

### DIFF
--- a/custom_components/nikobus/nkbmanual.py
+++ b/custom_components/nikobus/nkbmanual.py
@@ -60,15 +60,49 @@ async def _read_json_with_fallback(
 ) -> tuple[str | None, dict[str, Any] | None]:
     """Return ``(path, payload)`` for the first existing variant of ``filename``.
 
-    Tries the canonical name first, then the ``.migrated`` suffix that
-    the one-shot v1→v2 migration leaves behind. Returns ``(None, None)``
-    when neither exists or both are unreadable.
+    Tries the canonical name first. If only the ``.migrated`` variant
+    (left behind by the one-shot v1→v2 migration) exists, rename it
+    back to the canonical name so the user edits a file with the
+    expected filename — and so future reads hit the fast path. If a
+    canonical file already exists, ``.migrated`` is left untouched
+    (the canonical one is whatever the user put there). Returns
+    ``(None, None)`` when neither exists or the chosen file is
+    unreadable.
     """
-    candidates = [
-        hass.config.path(filename),
-        hass.config.path(filename + _MIGRATED_SUFFIX),
-    ]
-    for path in candidates:
+    canonical_path = hass.config.path(filename)
+    migrated_path = canonical_path + _MIGRATED_SUFFIX
+
+    canonical_exists = await hass.async_add_executor_job(
+        os.path.isfile, canonical_path
+    )
+
+    if not canonical_exists:
+        migrated_exists = await hass.async_add_executor_job(
+            os.path.isfile, migrated_path
+        )
+        if migrated_exists:
+            try:
+                await hass.async_add_executor_job(
+                    os.rename, migrated_path, canonical_path
+                )
+                _LOGGER.info(
+                    "Manual-config: renamed %s back to %s so the file "
+                    "is editable under its canonical name.",
+                    migrated_path,
+                    canonical_path,
+                )
+                canonical_exists = True
+            except OSError as err:
+                _LOGGER.warning(
+                    "Manual-config: could not rename %s back to %s "
+                    "(%s); reading from .migrated and leaving it in "
+                    "place.",
+                    migrated_path,
+                    canonical_path,
+                    err,
+                )
+
+    for path in (canonical_path, migrated_path):
         if not await hass.async_add_executor_job(os.path.isfile, path):
             continue
         try:

--- a/custom_components/nikobus/nkbmanual.py
+++ b/custom_components/nikobus/nkbmanual.py
@@ -196,7 +196,28 @@ def _new_physical_record(
     }
 
 
-def _single_key_fallback(bus_address: str, description: str) -> dict[str, Any]:
+def _extract_linked_modules(entry: dict[str, Any]) -> list[dict[str, Any]]:
+    """Pull ``linked_modules`` off a v1 entry, dropping non-dict items.
+
+    The v2 schema attaches ``linked_modules`` per operation-point and
+    consumes only ``module_address`` and ``outputs[].channel`` from
+    each item — extra v1 fields (``mode``, ``t1``, ``t2``,
+    ``payload``, ``button_address``, ``ir_button_address``,
+    ``ir_code``) pass through harmlessly and surface in the
+    diagnostics export, so a manual-mode user's snapshot matches an
+    auto-discovered install.
+    """
+    raw = entry.get("linked_modules")
+    if not isinstance(raw, list):
+        return []
+    return [item for item in raw if isinstance(item, dict)]
+
+
+def _single_key_fallback(
+    bus_address: str,
+    description: str,
+    linked_modules: list[dict[str, Any]],
+) -> dict[str, Any]:
     """Build a 1-channel synthetic record for an unlinked v1 entry.
 
     Used for IR/virtual/scene entries that have no ``linked_button``
@@ -215,7 +236,7 @@ def _single_key_fallback(bus_address: str, description: str) -> dict[str, Any]:
             "1A": {
                 "bus_address": bus_address,
                 "description": label,
-                "linked_modules": [],
+                "linked_modules": linked_modules,
             }
         },
     }
@@ -262,6 +283,7 @@ async def _apply_button_config(
         if not bus_address:
             continue
         description = str(entry.get("description") or "").strip()
+        linked_modules = _extract_linked_modules(entry)
 
         physical = _extract_physical_info(entry)
         if physical is not None:
@@ -278,7 +300,7 @@ async def _apply_button_config(
                 "bus_address": bus_address,
                 "description": description
                 or f"Push button {key_label} #N{bus_address}",
-                "linked_modules": [],
+                "linked_modules": linked_modules,
             }
             op_points_total += 1
         else:
@@ -288,7 +310,7 @@ async def _apply_button_config(
             if bus_address in new_buttons:
                 continue
             new_buttons[bus_address] = _single_key_fallback(
-                bus_address, description
+                bus_address, description, linked_modules
             )
             op_points_total += 1
 

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -17,7 +17,7 @@
                 "data_description": {
                     "has_feedbackmodule": "When enabled, the Feedback Module pushes state changes automatically — no polling needed.",
                     "prior_gen3": "Enables compatibility tweaks for first and second-generation PC-Link hardware.",
-                    "manual_config": "For installs whose firmware auto-discovery cannot read (typically pre-Gen3 / Gen2 PC-Link). The files nikobus_module_config.json and nikobus_button_config.json in the Home Assistant config directory become the declarative source of truth: edits, additions, and removals are reflected after reloading the integration. Falls back to the .migrated variants if the originals were renamed by an earlier v2 upgrade."
+                    "manual_config": "Read modules and buttons from nikobus_module_config.json and nikobus_button_config.json in your Home Assistant config directory. Reload the integration after editing the files. Falls back to .migrated variants if present."
                 },
                 "description": "Tell us about your Nikobus hardware so the integration can use the optimal update strategy.",
                 "title": "Hardware Configuration"
@@ -44,7 +44,7 @@
                     "connection_string": "Serial device path or TCP address of the PC-Link bridge",
                     "has_feedbackmodule": "When enabled, the Feedback Module pushes state changes automatically — no polling needed.",
                     "prior_gen3": "Enables compatibility tweaks for first and second-generation PC-Link hardware.",
-                    "manual_config": "For installs whose firmware auto-discovery cannot read (typically pre-Gen3 / Gen2 PC-Link). The files nikobus_module_config.json and nikobus_button_config.json in the Home Assistant config directory become the declarative source of truth: edits, additions, and removals are reflected after reloading the integration.",
+                    "manual_config": "Read modules and buttons from nikobus_module_config.json and nikobus_button_config.json in your Home Assistant config directory. Reload the integration after editing the files.",
                     "refresh_interval": "How often to read module states from the bus (60–3600 s). Lower values mean faster updates but more bus traffic."
                 },
                 "description": "Update the connection string or hardware settings. The connection will be re-tested.",
@@ -165,7 +165,7 @@
                 "data_description": {
                     "has_feedbackmodule": "When enabled, the Feedback Module pushes state changes automatically — no polling needed.",
                     "prior_gen3": "Enables compatibility tweaks for first and second-generation PC-Link hardware.",
-                    "manual_config": "For installs whose firmware auto-discovery cannot read (typically pre-Gen3 / Gen2 PC-Link). The files nikobus_module_config.json and nikobus_button_config.json in the Home Assistant config directory become the declarative source of truth: edits, additions, and removals are reflected after reloading the integration. Falls back to the .migrated variants if the originals were renamed by an earlier v2 upgrade."
+                    "manual_config": "Read modules and buttons from nikobus_module_config.json and nikobus_button_config.json in your Home Assistant config directory. Reload the integration after editing the files. Falls back to .migrated variants if present."
                 },
                 "description": "Update your hardware settings. The integration will reload automatically.",
                 "title": "Hardware Configuration"

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -17,7 +17,7 @@
                 "data_description": {
                     "has_feedbackmodule": "When enabled, the Feedback Module pushes state changes automatically — no polling needed.",
                     "prior_gen3": "Enables compatibility tweaks for first and second-generation PC-Link hardware.",
-                    "manual_config": "Read modules and buttons from nikobus_module_config.json and nikobus_button_config.json in your Home Assistant config directory. Reload the integration after editing the files. Falls back to .migrated variants if present."
+                    "manual_config": "Read modules and buttons from nikobus_module_config.json and nikobus_button_config.json in your Home Assistant config directory."
                 },
                 "description": "Tell us about your Nikobus hardware so the integration can use the optimal update strategy.",
                 "title": "Hardware Configuration"
@@ -44,7 +44,7 @@
                     "connection_string": "Serial device path or TCP address of the PC-Link bridge",
                     "has_feedbackmodule": "When enabled, the Feedback Module pushes state changes automatically — no polling needed.",
                     "prior_gen3": "Enables compatibility tweaks for first and second-generation PC-Link hardware.",
-                    "manual_config": "Read modules and buttons from nikobus_module_config.json and nikobus_button_config.json in your Home Assistant config directory. Reload the integration after editing the files.",
+                    "manual_config": "Read modules and buttons from nikobus_module_config.json and nikobus_button_config.json in your Home Assistant config directory.",
                     "refresh_interval": "How often to read module states from the bus (60–3600 s). Lower values mean faster updates but more bus traffic."
                 },
                 "description": "Update the connection string or hardware settings. The connection will be re-tested.",
@@ -165,7 +165,7 @@
                 "data_description": {
                     "has_feedbackmodule": "When enabled, the Feedback Module pushes state changes automatically — no polling needed.",
                     "prior_gen3": "Enables compatibility tweaks for first and second-generation PC-Link hardware.",
-                    "manual_config": "Read modules and buttons from nikobus_module_config.json and nikobus_button_config.json in your Home Assistant config directory. Reload the integration after editing the files. Falls back to .migrated variants if present."
+                    "manual_config": "Read modules and buttons from nikobus_module_config.json and nikobus_button_config.json in your Home Assistant config directory."
                 },
                 "description": "Update your hardware settings. The integration will reload automatically.",
                 "title": "Hardware Configuration"

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -22,7 +22,7 @@
                 "data_description": {
                     "has_feedbackmodule": "Lorsqu'activé, le module Feedback envoie automatiquement les changements d'état — pas de scrutation nécessaire.",
                     "prior_gen3": "Active les adaptations de compatibilité pour les PC-Link de première et deuxième génération.",
-                    "manual_config": "Pour les installations dont le firmware ne peut être lu par la découverte automatique (généralement PC-Link pré-Gen3 / Gen2). Les fichiers nikobus_module_config.json et nikobus_button_config.json dans le répertoire de configuration Home Assistant deviennent la source de vérité déclarative : les modifications, ajouts et suppressions sont reflétés après rechargement de l'intégration. Bascule sur les variantes .migrated si les originaux ont été renommés par une mise à niveau v2 antérieure."
+                    "manual_config": "Lit les modules et boutons depuis nikobus_module_config.json et nikobus_button_config.json dans votre répertoire de configuration Home Assistant. Rechargez l'intégration après avoir modifié les fichiers. Bascule sur les variantes .migrated si présentes."
                 }
             },
             "polling": {
@@ -76,7 +76,7 @@
                 "data_description": {
                     "has_feedbackmodule": "Lorsqu'activé, le module Feedback envoie automatiquement les changements d'état.",
                     "prior_gen3": "Active les adaptations de compatibilité pour les PC-Link de première et deuxième génération.",
-                    "manual_config": "Pour les installations qui ne peuvent pas être lues par la découverte automatique (PC-Link pré-Gen3 / Gen2). nikobus_module_config.json et nikobus_button_config.json dans le répertoire de configuration sont la source de vérité déclarative ; les modifications sont appliquées au rechargement de l'intégration."
+                    "manual_config": "Lit les modules et boutons depuis nikobus_module_config.json et nikobus_button_config.json dans le répertoire de configuration. Rechargez l'intégration après avoir modifié les fichiers."
                 }
             },
             "polling": {

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -22,7 +22,7 @@
                 "data_description": {
                     "has_feedbackmodule": "Lorsqu'activé, le module Feedback envoie automatiquement les changements d'état — pas de scrutation nécessaire.",
                     "prior_gen3": "Active les adaptations de compatibilité pour les PC-Link de première et deuxième génération.",
-                    "manual_config": "Lit les modules et boutons depuis nikobus_module_config.json et nikobus_button_config.json dans votre répertoire de configuration Home Assistant. Rechargez l'intégration après avoir modifié les fichiers. Bascule sur les variantes .migrated si présentes."
+                    "manual_config": "Lit les modules et boutons depuis nikobus_module_config.json et nikobus_button_config.json dans votre répertoire de configuration Home Assistant."
                 }
             },
             "polling": {
@@ -76,7 +76,7 @@
                 "data_description": {
                     "has_feedbackmodule": "Lorsqu'activé, le module Feedback envoie automatiquement les changements d'état.",
                     "prior_gen3": "Active les adaptations de compatibilité pour les PC-Link de première et deuxième génération.",
-                    "manual_config": "Lit les modules et boutons depuis nikobus_module_config.json et nikobus_button_config.json dans le répertoire de configuration. Rechargez l'intégration après avoir modifié les fichiers."
+                    "manual_config": "Lit les modules et boutons depuis nikobus_module_config.json et nikobus_button_config.json dans le répertoire de configuration."
                 }
             },
             "polling": {

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -22,7 +22,7 @@
                 "data_description": {
                     "has_feedbackmodule": "Indien ingeschakeld stuurt de Feedbackmodule automatisch statuswijzigingen — geen polling nodig.",
                     "prior_gen3": "Schakelt compatibiliteitsaanpassingen in voor eerste en tweede generatie PC-Link hardware.",
-                    "manual_config": "Voor installaties waarvan de firmware niet kan worden uitgelezen door de automatische ontdekking (doorgaans pre-Gen3 / Gen2 PC-Link). De bestanden nikobus_module_config.json en nikobus_button_config.json in de Home Assistant-configuratiemap zijn de declaratieve bron van waarheid: wijzigingen, toevoegingen en verwijderingen worden toegepast na het herladen van de integratie. Valt terug op .migrated-varianten als de originelen door een eerdere v2-upgrade zijn hernoemd."
+                    "manual_config": "Lees modules en knoppen uit nikobus_module_config.json en nikobus_button_config.json in uw Home Assistant-configuratiemap. Herlaad de integratie na het bewerken van de bestanden. Valt terug op .migrated-varianten indien aanwezig."
                 }
             },
             "polling": {
@@ -76,7 +76,7 @@
                 "data_description": {
                     "has_feedbackmodule": "Indien ingeschakeld stuurt de Feedbackmodule automatisch statuswijzigingen.",
                     "prior_gen3": "Schakelt compatibiliteitsaanpassingen in voor eerste en tweede generatie PC-Link hardware.",
-                    "manual_config": "Voor installaties die niet via automatische ontdekking kunnen worden uitgelezen (pre-Gen3 / Gen2 PC-Link). nikobus_module_config.json en nikobus_button_config.json in de configuratiemap zijn de declaratieve bron van waarheid; wijzigingen worden toegepast na het herladen van de integratie."
+                    "manual_config": "Lees modules en knoppen uit nikobus_module_config.json en nikobus_button_config.json in de configuratiemap. Herlaad de integratie na het bewerken van de bestanden."
                 }
             },
             "polling": {

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -22,7 +22,7 @@
                 "data_description": {
                     "has_feedbackmodule": "Indien ingeschakeld stuurt de Feedbackmodule automatisch statuswijzigingen — geen polling nodig.",
                     "prior_gen3": "Schakelt compatibiliteitsaanpassingen in voor eerste en tweede generatie PC-Link hardware.",
-                    "manual_config": "Lees modules en knoppen uit nikobus_module_config.json en nikobus_button_config.json in uw Home Assistant-configuratiemap. Herlaad de integratie na het bewerken van de bestanden. Valt terug op .migrated-varianten indien aanwezig."
+                    "manual_config": "Lees modules en knoppen uit nikobus_module_config.json en nikobus_button_config.json in uw Home Assistant-configuratiemap."
                 }
             },
             "polling": {
@@ -76,7 +76,7 @@
                 "data_description": {
                     "has_feedbackmodule": "Indien ingeschakeld stuurt de Feedbackmodule automatisch statuswijzigingen.",
                     "prior_gen3": "Schakelt compatibiliteitsaanpassingen in voor eerste en tweede generatie PC-Link hardware.",
-                    "manual_config": "Lees modules en knoppen uit nikobus_module_config.json en nikobus_button_config.json in de configuratiemap. Herlaad de integratie na het bewerken van de bestanden."
+                    "manual_config": "Lees modules en knoppen uit nikobus_module_config.json en nikobus_button_config.json in de configuratiemap."
                 }
             },
             "polling": {

--- a/tests/test_manual_config.py
+++ b/tests/test_manual_config.py
@@ -502,6 +502,106 @@ class TestApplyManualConfig(unittest.TestCase):
         self.assertIn("1DF1E0", buttons)
 
     # ------------------------------------------------------------------
+    # linked_modules carry through verbatim onto the matching op-point,
+    # including v1-specific extras (mode, t1, t2, payload, ir_*). This
+    # matters because a diagnostics dump on a manual-mode install
+    # should look like an auto-discovered one — same "what does this
+    # button control" cross-reference.
+    # ------------------------------------------------------------------
+
+    def test_linked_modules_preserved_on_grouped_op_point(self):
+        self._write("nikobus_button_config.json", {
+            "nikobus_button": [
+                {
+                    "address": "004E2C",
+                    "description": "Sofa wall light up",
+                    "linked_button": [{
+                        "type": "IR Button with 4 Operation Points",
+                        "model": "05-348",
+                        "address": "0D1C80",
+                        "channels": 4,
+                        "key": "1C",
+                    }],
+                    "linked_modules": [{
+                        "module_address": "0E6C",
+                        "outputs": [{
+                            "channel": 1,
+                            "mode": "M01 (Dim on/off (2 buttons))",
+                            "t1": None,
+                            "t2": None,
+                            "payload": "FFB4000000007234",
+                            "button_address": "0D1C80",
+                            "ir_button_address": "0D1C82",
+                            "ir_code": "02A",
+                        }],
+                    }],
+                },
+            ]
+        })
+        store = _InMemoryModuleStore()
+        button_data = {"nikobus_button": {}}
+
+        _run(nkbmanual.async_apply_manual_config(self.hass, store, button_data))
+
+        op_point = button_data["nikobus_button"]["0D1C80"]["operation_points"]["1C"]
+        self.assertEqual(len(op_point["linked_modules"]), 1)
+        link = op_point["linked_modules"][0]
+        self.assertEqual(link["module_address"], "0E6C")
+        # v1-specific extras pass through unchanged for diagnostics.
+        out = link["outputs"][0]
+        self.assertEqual(out["channel"], 1)
+        self.assertEqual(out["mode"], "M01 (Dim on/off (2 buttons))")
+        self.assertEqual(out["ir_code"], "02A")
+
+    def test_linked_modules_preserved_on_unlinked_entry(self):
+        # No linked_button, but linked_modules present — preserve on
+        # the synthetic single-key fallback so diagnostics stays
+        # consistent.
+        self._write("nikobus_button_config.json", {
+            "nikobus_button": [
+                {
+                    "address": "9E4E2C",
+                    "description": "IR scene trigger",
+                    "linked_modules": [{
+                        "module_address": "0E6C",
+                        "outputs": [{"channel": 1, "mode": "M01 (On / off)"}],
+                    }],
+                },
+            ]
+        })
+        store = _InMemoryModuleStore()
+        button_data = {"nikobus_button": {}}
+
+        _run(nkbmanual.async_apply_manual_config(self.hass, store, button_data))
+
+        op_point = button_data["nikobus_button"]["9E4E2C"]["operation_points"]["1A"]
+        self.assertEqual(op_point["linked_modules"][0]["module_address"], "0E6C")
+
+    def test_missing_linked_modules_defaults_to_empty(self):
+        self._write("nikobus_button_config.json", {
+            "nikobus_button": [
+                {
+                    "address": "112233",
+                    "description": "No links",
+                    "linked_button": [{
+                        "type": "Button with 4 Operation Points",
+                        "model": "05-346",
+                        "address": "1CFE4A",
+                        "channels": 4,
+                        "key": "1A",
+                    }],
+                },
+            ]
+        })
+        store = _InMemoryModuleStore()
+        button_data = {"nikobus_button": {}}
+
+        _run(nkbmanual.async_apply_manual_config(self.hass, store, button_data))
+
+        op_point = button_data["nikobus_button"]["1CFE4A"]["operation_points"]["1A"]
+        self.assertEqual(op_point["linked_modules"], [])
+
+    # ------------------------------------------------------------------
     # Regression: an op-point whose bus address collides with another
     # physical's address must not eclipse the proper grouping.
     # ------------------------------------------------------------------

--- a/tests/test_manual_config.py
+++ b/tests/test_manual_config.py
@@ -227,17 +227,22 @@ class TestApplyManualConfig(unittest.TestCase):
         self.assertNotIn("led_on", entry["channels"][0])
 
     # ------------------------------------------------------------------
-    # .migrated fallback for users who already upgraded once.
+    # .migrated rename-back: users who tried v2 once had their files
+    # renamed by the one-shot migration. Flipping manual_config must
+    # restore the canonical name so the file is editable as-is.
     # ------------------------------------------------------------------
 
-    def test_migrated_fallback(self):
-        self._write("nikobus_module_config.json.migrated", {
+    def test_migrated_is_renamed_back_to_canonical(self):
+        migrated_path = self._write("nikobus_module_config.json.migrated", {
             "dimmer_module": [{
                 "description": "Salon dimmer",
                 "address": "0E6C",
                 "channels": [{"description": "Sconces"}],
             }],
         })
+        canonical_path = os.path.join(
+            self.config_dir, "nikobus_module_config.json"
+        )
         store = _InMemoryModuleStore()
         button_data = {"nikobus_button": {}}
 
@@ -247,6 +252,39 @@ class TestApplyManualConfig(unittest.TestCase):
 
         self.assertTrue(changed)
         self.assertIn("0E6C", store.data["nikobus_module"])
+        # Renamed back: canonical now exists, .migrated does not.
+        self.assertTrue(os.path.exists(canonical_path))
+        self.assertFalse(os.path.exists(migrated_path))
+
+    # ------------------------------------------------------------------
+    # If a canonical file already exists, the .migrated variant is
+    # left untouched. Trust whatever the user explicitly placed.
+    # ------------------------------------------------------------------
+
+    def test_both_files_present_canonical_wins_migrated_preserved(self):
+        canonical_path = self._write("nikobus_module_config.json", {
+            "switch_module": [{
+                "description": "User-edited", "address": "AABB",
+                "channels": [{"description": "Live"}],
+            }],
+        })
+        migrated_path = self._write("nikobus_module_config.json.migrated", {
+            "switch_module": [{
+                "description": "Stale", "address": "CCDD",
+                "channels": [{"description": "Old"}],
+            }],
+        })
+        store = _InMemoryModuleStore()
+        button_data = {"nikobus_button": {}}
+
+        _run(nkbmanual.async_apply_manual_config(self.hass, store, button_data))
+
+        modules = store.data["nikobus_module"]
+        self.assertIn("AABB", modules)  # from canonical
+        self.assertNotIn("CCDD", modules)  # .migrated NOT read
+        # Both files still on disk after the run.
+        self.assertTrue(os.path.exists(canonical_path))
+        self.assertTrue(os.path.exists(migrated_path))
 
     # ------------------------------------------------------------------
     # Buttons: a 4-key physical wall button (4 v1 entries) is grouped


### PR DESCRIPTION
## Summary

Four follow-ups on the manual-config path from #344, all touching the same feature so they ride in one PR:

1. **Simplify the `manual_config` help text** — the original wording bundled audience, semantics, and `.migrated` footnote into one long sentence. Cut to what the user needs at decide-time.
2. **Trim further to just the file paths** — drop the "reload after editing" and `.migrated` notes from the visible help. The reload instruction is HA-standard for any options change; the `.migrated` behaviour is now automatic (see #3).
3. **Rename `.migrated` files back to canonical on first manual-config read** — users who tried v2, hit the auto-discovery gap, and are now flipping the toggle had their `nikobus_module_config.json` / `nikobus_button_config.json` renamed by the one-shot migration. Promote them back to the canonical name on first read so the user sees the editable filename. If a canonical file already exists, leave `.migrated` alone (trust the user's explicit placement). Rename failures are logged and fall back to reading `.migrated` in place.
4. **Preserve `linked_modules` from the v1 button file onto v2 op-points** — the v1 file carries the rich "this key controls module X channel Y in mode M" cross-reference per entry. The previous loader dropped it. Carry it through verbatim onto the matching op-point so a diagnostics export from a manual-mode install matches an auto-discovered one. v1-specific extras (`mode`, `t1`, `t2`, `payload`, `ir_button_address`, `ir_code`) ride along harmlessly.

## Behaviour matrix for `.migrated` rename

| Files on disk | Action |
|---|---|
| Only `.json` | Read it, leave it alone |
| Only `.migrated` | Rename `.migrated` → `.json`, then read |
| Both | Read `.json`, leave `.migrated` untouched (user's explicit placement wins) |
| Neither | No-op, log a warning |
| Rename fails (permissions) | Log, read `.migrated` in place |

## Test plan

- [x] 18 tests in `tests/test_manual_config.py` (was 14), including new pins for `.migrated` rename in all three states above and `linked_modules` preservation on both grouped and unlinked entries.
- [x] No regressions in the rest of the suite (same 43 pre-existing failures, unchanged).
- [ ] Manual smoke-test: flip the toggle on an install whose v1 files were renamed to `.migrated` by the v2 upgrade — confirm both files come back as `.json`, modules/buttons appear, diagnostics show populated `linked_modules`.

https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5)_