### PR TITLE
2.1.1: bump nikobus-connect to >=0.6.0

### DIFF
--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.5.22"
+    "nikobus-connect>=0.6.0"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }


### PR DESCRIPTION
## Summary

Bump `nikobus-connect` requirement from `>=0.5.22` to `>=0.6.0`. Integration version goes to `2.1.1`.

`nikobus-connect 0.6.0` (just released) reverts the chunk decoder to the 0.8.0 single-alignment walk and drops the decoder-side `is_known_button_canonical` / `_is_garbage_chunk` gates that had been mopping up phantoms produced by the alt-alignment dual-pass.

## What changes for users on upgrade

- **Gen3 installs programmed via the Niko PC software** (PC-Link inventory complete) → unchanged behaviour. Discovery produces the same set of decoded records as before.
- **Gen3 installs programmed via DIN-button learn mode** (PC-Link inventory empty or sparse) → real wall buttons now surface from module link tables instead of being silently rejected as `unknown_button`. The 2026-05-15 user's install would have ~30 buttons appear here where previously zero made it through.
- **Installs that reported records at stream offsets +4 / +8** → need re-testing. If the records genuinely sit there on that firmware, this revert regresses them and we'd want a fresh capture to confirm.

The manual-config path stays useful for declaring HA-only automation buttons that have no physical wiring and therefore no presence in any module's link table.

## Test plan

- [x] HA-side test suite unchanged (42 pre-existing failures before and after the bump — zero regressions).
- [x] No HA-side code references the removed library APIs (`is_known_button_canonical`, `_is_garbage_chunk`, `_ALT_ALIGNMENT_SKIP_CHARS`, `_alt_payload_buffers`).
- [ ] Run discovery on a known-good Gen3 install — expect unchanged inventory.
- [ ] Run discovery on the 2026-05-15 DIN-programmed install — expect ~30 real buttons to surface from the modules' link tables.
- [ ] Re-test the 2026-05-04 install (B909 / 29FA) if available — confirm whether the alt-alignment finding was a misalignment artefact.

https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5)_