### PR TITLE
Mirror library: PC-Logic / interface channel placeholder reads input_N

### DIFF
--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -116,6 +116,14 @@ _DEFAULT_CHANNELS_BY_TYPE: dict[str, int] = {
 }
 
 
+# Module types whose "channels" are bus-event sources, not output loads —
+# PC-Logic exposes 6 logical inputs, the 05-206 modular interface exposes
+# 6 wired inputs. The placeholder description reads "input_N" instead of
+# the generic "output_N" used for switch / dimmer / roller. Mirrors the
+# library's ``_INPUT_MODULE_TYPES`` in ``fileio.py``.
+_INPUT_MODULE_TYPES: frozenset[str] = frozenset({"pc_logic", "interface_module"})
+
+
 def _make_default_channel(module_type: str, index: int) -> dict[str, Any]:
     """Build a placeholder channel entry for a freshly-padded slot.
 
@@ -123,7 +131,8 @@ def _make_default_channel(module_type: str, index: int) -> dict[str, Any]:
     re-discovery merge doesn't see drift between user-padded entries
     and library-padded ones.
     """
-    channel: dict[str, Any] = {"description": f"not_in_use output_{index}"}
+    label = "input" if module_type in _INPUT_MODULE_TYPES else "output"
+    channel: dict[str, Any] = {"description": f"not_in_use {label}_{index}"}
     if module_type == "roller_module":
         channel["operation_time_up"] = "30"
     return channel


### PR DESCRIPTION
## Summary

Mirror the `nikobus-connect` channel-label fix (PR fdebrus/nikobus-connect#61) on the HA side. The `_make_default_channel` helper in `config_flow.py` pads channels when the user changes a module's type via the options flow; both helpers must produce identical defaults or a re-discovery merge sees drift between user-padded and library-padded entries.

## What changes

`_make_default_channel(module_type, index)` now returns `not_in_use input_N` for `pc_logic` and `interface_module`, matching the library's behaviour. Output modules (switch / dimmer / roller / other) are unchanged.

## Dependency

This PR is **cosmetic-only on its own** — the actual user-visible fix lands when the library version with the matching `_default_channel` and `_pad_channels` changes is released and the `nikobus-connect>=X` pin in `manifest.json` is bumped.

So the suggested order is:

1. Merge & release `nikobus-connect` PR #61.
2. Merge this PR.
3. Bump the `nikobus-connect` pin in `manifest.json` to the new release (separate small PR, or amend into this one once the release tag is known).

## Test plan

- [x] No regressions in the HA-side test suite (42 pre-existing failures unchanged before and after).
- [ ] After the library release + pin bump, run *Discover modules & buttons* on an install with PC-Logic / interface modules; confirm storage placeholders rewrite to `not_in_use input_N`.

https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5)_