### PR TITLE
2.2.0: expose forensic register-range scan via query_module_inventory action

### DIFF
--- a/custom_components/nikobus/__init__.py
+++ b/custom_components/nikobus/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import Final
+from typing import Any, Final
 
 import voluptuous as vol
 from aiofiles import open as aio_open
@@ -54,7 +54,49 @@ SERVICE_PURGE_STALE_INVENTORY: Final = "purge_stale_inventory"
 DEFAULT_DETECT_OUTER_ATTEMPTS: Final[int] = 1
 DEFAULT_DETECT_OUTER_DELAY: Final[float] = 0.0
 
-SCAN_MODULE_SCHEMA = vol.Schema({vol.Optional("module_address", default=""): cv.string})
+def _parse_register_byte(value: Any) -> int:
+    """Accept an int 0..255 or a hex string (``"FF"``, ``"0xFF"``)."""
+    if isinstance(value, bool):
+        raise vol.Invalid("Register must be an integer or hex string, not a bool")
+    if isinstance(value, int):
+        n = value
+    else:
+        text = str(value).strip()
+        if not text:
+            raise vol.Invalid("Register cannot be empty")
+        if text.lower().startswith("0x"):
+            text = text[2:]
+        try:
+            n = int(text, 16)
+        except ValueError:
+            raise vol.Invalid(f"Cannot parse '{value}' as a hex register byte")
+    if not (0 <= n <= 0xFF):
+        raise vol.Invalid(f"Register {n:#x} out of range 0x00..0xFF")
+    return n
+
+
+def _parse_sub_byte(value: Any) -> str:
+    """Accept a 2-char hex string and return the canonical uppercase form."""
+    text = str(value or "").strip()
+    if text.lower().startswith("0x"):
+        text = text[2:]
+    if len(text) not in (1, 2) or not all(c in "0123456789abcdefABCDEF" for c in text):
+        raise vol.Invalid(f"sub_byte must be a hex byte (e.g. '04'), got: {value!r}")
+    return text.upper().zfill(2)
+
+
+SCAN_MODULE_SCHEMA = vol.Schema({
+    vol.Optional("module_address", default=""): cv.string,
+    # Forensic-mode trio: when register_start AND register_end are both
+    # provided, the scan walks only that range with the given sub_byte
+    # (default "04") and skips the library's extra-pass / non-output-
+    # module guard logic. Used for reverse-engineering storage layouts
+    # of modules the production scan declines or doesn't fully cover.
+    # Requires a specific module_address — not compatible with ALL mode.
+    vol.Optional("register_start"): _parse_register_byte,
+    vol.Optional("register_end"): _parse_register_byte,
+    vol.Optional("sub_byte"): _parse_sub_byte,
+})
 SEND_BUTTON_PRESS_SCHEMA = vol.Schema({
     vol.Required("address"): cv.string,
 })
@@ -85,6 +127,25 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     async def handle_module_discovery(call: ServiceCall) -> None:
         """Trigger a Nikobus inventory scan via the coordinator's discovery engine."""
         module_address = (call.data.get("module_address", "") or "").strip().upper()
+        register_start = call.data.get("register_start")
+        register_end = call.data.get("register_end")
+        sub_byte = call.data.get("sub_byte")
+
+        # Forensic mode validation surfaces here so the user gets a
+        # ServiceValidationError instead of the library's bare
+        # ValueError, with a more actionable translation message.
+        custom_range = register_start is not None or register_end is not None
+        if custom_range:
+            if not module_address:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="forensic_requires_module_address",
+                )
+            if register_start is None or register_end is None:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="forensic_range_incomplete",
+                )
 
         coordinator = _loaded_coordinator(hass)
         if coordinator is None:
@@ -106,6 +167,20 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         if not module_address:
             _LOGGER.info("Starting manual Nikobus PC-Link inventory discovery")
             await coordinator.nikobus_discovery.start_inventory_discovery()
+        elif custom_range:
+            _LOGGER.info(
+                "Forensic Nikobus scan | module=%s registers=0x%02X..0x%02X sub=%s",
+                module_address,
+                register_start,
+                register_end,
+                sub_byte or "04",
+            )
+            await coordinator.nikobus_discovery.query_module_inventory(
+                module_address,
+                register_start=register_start,
+                register_end=register_end,
+                sub_byte=sub_byte,
+            )
         else:
             _LOGGER.info("Starting manual Nikobus discovery for module: %s", module_address)
             await coordinator.nikobus_discovery.query_module_inventory(module_address)

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.6.0"
+    "nikobus-connect>=0.7.0"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }

--- a/custom_components/nikobus/services.yaml
+++ b/custom_components/nikobus/services.yaml
@@ -5,6 +5,29 @@ query_module_inventory:
       required: false
       selector:
         text:
+    register_start:
+      example: "0x70"
+      required: false
+      selector:
+        text:
+    register_end:
+      example: "0x83"
+      required: false
+      selector:
+        text:
+    sub_byte:
+      example: "04"
+      required: false
+      selector:
+        select:
+          options:
+            - label: "04 — output link table (default)"
+              value: "04"
+            - label: "00 — module header / identity"
+              value: "00"
+            - label: "01 — BP-cell records / vendor map"
+              value: "01"
+          custom_value: true
 
 send_button_press:
   fields:

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -130,6 +130,12 @@
         "communication_error": {
             "message": "Communication with Nikobus failed: {error}"
         },
+        "forensic_requires_module_address": {
+            "message": "Forensic register scan requires a module_address. Specify one (e.g. 940C) — the register range cannot be applied across all modules."
+        },
+        "forensic_range_incomplete": {
+            "message": "Forensic mode requires both register_start and register_end. Provide both or omit both."
+        },
         "discovery_already_running": {
             "message": "A Nikobus discovery is already running."
         },
@@ -220,11 +226,23 @@
     },
     "services": {
         "query_module_inventory": {
-            "description": "Triggers a Nikobus module inventory scan for all modules or a single module.",
+            "description": "Triggers a Nikobus module inventory scan. Without parameters, scans every output module. With a module_address, scans just that module using the per-module-type tuned ranges. With register_start + register_end (and optionally sub_byte), runs a forensic-mode scan of exactly the requested range — useful for reverse-engineering storage layouts on PC-Logic, interface modules, or unfamiliar regions of any module.",
             "fields": {
                 "module_address": {
-                    "description": "Optional Nikobus module address to limit the inventory scan.",
+                    "description": "Optional Nikobus module address (e.g. 940C, F586). Without it, scans every known output module.",
                     "name": "Module address"
+                },
+                "register_start": {
+                    "description": "Forensic mode — lower bound of the register range to scan, as a hex byte (e.g. 0x70 or 70). Requires register_end and a specific module_address. When provided, the scan walks only this range and skips the production extra-pass logic.",
+                    "name": "Register start"
+                },
+                "register_end": {
+                    "description": "Forensic mode — upper bound of the register range to scan, as a hex byte (e.g. 0x83 or 83). Must be ≥ register_start.",
+                    "name": "Register end"
+                },
+                "sub_byte": {
+                    "description": "Memory bank selector for forensic mode (default 04 — output link table). Other observed banks: 00 (module header / identity), 01 (BP-cell records).",
+                    "name": "Sub-byte"
                 }
             },
             "name": "Query module inventory"


### PR DESCRIPTION
## Summary

Expose the library's new forensic register-range scan (fdebrus/nikobus-connect#62) as parameters on the existing `nikobus.query_module_inventory` service action. Bumps integration version to **2.2.0** and the `nikobus-connect` requirement to **`>=0.7.0`**.

## What changes

The `nikobus.query_module_inventory` action gains three optional fields (visible in Developer Tools → Actions and any scripts/automations that call the service):

| Field | Type | Default | Purpose |
|---|---|---|---|
| `module_address` | string | "" (= ALL) | Existing — unchanged |
| `register_start` | hex byte | — | NEW. Lower bound of register range to scan |
| `register_end`   | hex byte | — | NEW. Upper bound of register range to scan |
| `sub_byte`       | hex byte | `"04"` | NEW. Memory bank selector |

`register_start` / `register_end` accept any common hex form: `70`, `0x70`, `FF`, `0xFF`. The `sub_byte` selector exposes the three productive banks observed in vendor traces (`04` output link table, `00` module header, `01` BP-cell records), with a custom-value entry for further exploration.

**Forensic mode** activates when both range bounds are provided alongside a specific `module_address`. The integration calls the library's new `query_module_inventory(addr, register_start=…, register_end=…, sub_byte=…)` path, which scans exactly that range and skips the per-module-type extra passes + the non-output-module guard. So you can scan PC-Logic, interface modules, audio modules, or any normally-scanned module's unfamiliar regions, and the raw `Register scan response` frames land in the HA log for analysis.

**Production mode** is fully unchanged when the new fields are left blank — the service behaves exactly as today.

## Validation

| Input | Result |
|---|---|
| Only one of the range bounds set | `ServiceValidationError` with translated message |
| Forensic params without `module_address` | `ServiceValidationError` |
| Range bound out of `0x00..0xFF` | Voluptuous schema rejection |
| Inverted range (`end < start`) | Library raises (surfaces as `ValueError`) |

Two new translation keys (`forensic_requires_module_address`, `forensic_range_incomplete`) give users actionable messages instead of bare exceptions.

## How to use it

From the HA UI: **Developer Tools → Actions → Nikobus: Query module inventory**, fill in `module_address`, `register_start`, `register_end`, optionally `sub_byte`. Submit. Watch `home-assistant.log` (or grep for `Forensic register scan` then `Register scan response`).

Example for PC-Logic exploration:

```yaml
action: nikobus.query_module_inventory
data:
  module_address: "940C"
  register_start: "0x00"
  register_end:   "0xFF"
  sub_byte:       "01"
```

## Test plan

- [x] No regressions in the HA test suite (42 pre-existing failures unchanged before and after).
- [x] Service schema parses (voluptuous + the new hex coercer).
- [x] `services.yaml` validates as YAML.
- [x] All four translation JSONs parse.
- [ ] After library 0.7.0 release: smoke-test the forensic scan against PC-Logic at `940C` on the real hardware, register `0x00..0xFF`, sub-byte `04` and `01` — confirm responses land in the log.

## Dependency

This PR pins `nikobus-connect>=0.7.0` in `manifest.json`. Suggested merge order:

1. Merge fdebrus/nikobus-connect#62.
2. Tag & release nikobus-connect 0.7.0.
3. Merge this PR.

https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5)_