### PR TITLE
2.4.0: stop creating per-channel PC-Logic input stubs

### DIFF
--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -310,10 +310,19 @@ def register_opaque_module_devices(
 
 
 def _iter_input_module_entities(coordinator: NikobusDataCoordinator):
-    """Yield one NikobusInputEntity per channel of every input-class module."""
+    """Yield one NikobusInputEntity per channel of every input-class module.
+
+    PC-Logic logical inputs are surfaced through synthesized button-store
+    entries (one ``LM-INPUT N`` device per input, parented under the
+    PC-Logic module), so the PC-Logic module itself has no per-channel
+    entities — skip it here. The 05-206 modular interface still uses the
+    channels-driven path.
+    """
     for module_type, address, module_data in _iter_module_records(
         coordinator.dict_module_data, INPUT_MODULE_TYPES
     ):
+        if module_type == "pc_logic":
+            continue
         module_desc = str(
             module_data.get("description") or f"{module_type} ({address})"
         )

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -368,17 +368,22 @@ def op_point_display_name(
     library description verbatim; it already carries the channel label.
 
     PC-Logic logical-input keys (the parent button carries
-    ``pc_logic_parent_address``) render as the compact ``Key A`` /
-    ``Key B`` form, matching how the parent ``LM-INPUT N`` device is
-    named.
+    ``pc_logic_parent_address``) render as ``Key A on LM-INPUT N`` /
+    ``Key B on LM-INPUT N``, mirroring the IR ``<key> on <parent>``
+    pattern so the device list disambiguates each slot's keys.
     """
     if key_label.startswith("IR:"):
         ir_code = key_label[len("IR:"):]
         return f"IR {ir_code} on {physical_address}"
     if isinstance(parent_phys, dict) and parent_phys.get("pc_logic_parent_address"):
-        # ``1A`` → "Key A", ``1B`` → "Key B".
-        if len(key_label) == 2 and key_label[1].isalpha():
-            return f"Key {key_label[1].upper()}"
+        # ``1A`` → "Key A on LM-INPUT N", ``1B`` → "Key B on LM-INPUT N".
+        slot = parent_phys.get("pc_logic_slot_index")
+        if (
+            len(key_label) == 2
+            and key_label[1].isalpha()
+            and isinstance(slot, int)
+        ):
+            return f"Key {key_label[1].upper()} on LM-INPUT {slot}"
     return op_point.get("description") or f"Push button {key_label}"
 
 

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -1125,7 +1125,12 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         # Input-class modules (PC-Logic, Modular Interface) skip ``build_routing``
         # because they don't drive output relays — emit their input-channel
         # button unique IDs directly so orphan-cleanup doesn't remove them.
+        # PC-Logic is excluded: its logical inputs surface through the
+        # synthesized button-store entries (one ``LM-INPUT N`` device per
+        # input), not per-channel input entities.
         for module_type in INPUT_MODULE_TYPES:
+            if module_type == "pc_logic":
+                continue
             bucket = self.dict_module_data.get(module_type) or {}
             if not isinstance(bucket, dict):
                 continue

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.8.0"
+    "nikobus-connect>=0.9.0"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }


### PR DESCRIPTION
## Summary

Depends on [nikobus-connect#65](https://github.com/fdebrus/nikobus-connect/pull/65) (library 0.9.0).

Stops creating per-channel `NikobusInputEntity` placeholders for PC-Logic modules. The 6 logical inputs are now surfaced exclusively through the synthesized button-store entries (one `LM-INPUT N` device with a button entity + idle/pressed binary sensor per key, introduced in 2.3.0). The legacy stubs were stateless, duplicated the synthesized buttons, and the TODO'd input-routing was never wired up.

## Changes

- `_iter_input_module_entities` skips `pc_logic`.
- `get_known_entity_unique_ids` skips `pc_logic` in the input-module loop.
- `manifest.json`: 2.3.0 → 2.4.0; dep pin `>=0.8.0` → `>=0.9.0`.
- 05-206 modular interface unaffected.

## Test plan

- [x] HA suite: same 42 pre-existing failures, no new regressions.
- [ ] On the 940C install: confirm the PC-Logic module shows only the 6 LM-INPUT N children (no LM01..LM06 duplicate stubs).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5)_