### PR TITLE
2.4.1: pin nikobus-connect>=0.10.0 (PC-Logic bus-address fix)

### DIFF
--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.9.0"
+    "nikobus-connect>=0.10.0"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }


### PR DESCRIPTION
## Summary

Depends on [nikobus-connect#66](https://github.com/fdebrus/nikobus-connect/pull/66) (library 0.10.0).

Bumps the dep pin so PC-Logic input presses route correctly after the library fix. Existing PC-Logic input entries in the button store will have their `bus_address` values rewritten on the next discovery run.

## Changes

- `manifest.json`: 2.4.0 → 2.4.1; dep `nikobus-connect>=0.9.0` → `>=0.10.0`.

## Test plan

- [ ] On the 940C install: after upgrading, run discovery once; then press each PC-Logic input and confirm the `LM-INPUT N` binary sensor fires idle → pressed → idle (no more "unknown button" log lines).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5)_