### PR TITLE
2.4.2: pin nikobus-connect>=0.11.0 (PC-Logic formula generalisation)

### DIFF
--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.10.0"
+    "nikobus-connect>=0.11.0"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }


### PR DESCRIPTION
## Summary

Depends on [nikobus-connect#67](https://github.com/fdebrus/nikobus-connect/pull/67) (library 0.11.0).

Generalises the PC-Logic input synthesis formula so it works for installs the 0.8.0 `byteswap × 8` formula refused. Installs with PC-Logic at e.g. `8DC8` will now gain synthesised `LM-INPUT N` children on next discovery.

## Changes

- `manifest.json`: 2.4.1 → 2.4.2; dep `nikobus-connect>=0.10.0` → `>=0.11.0`.

## Test plan

- [ ] On the 8DC8 install: after upgrading + running discovery, confirm the 6 `LM-INPUT N` devices appear under PC-Logic and the binary sensors fire idle → pressed → idle on each input press.
- [ ] On the 940C install: confirm no regression — same physicals, same op-points, same `LM-INPUT N` rendering.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5)_