### PR TITLE
2.5.0: render 05-206 inputs as LM-INPUT N children

### DIFF
--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -196,28 +196,41 @@ def _ensure_pc_logic_parent_device(
     parent_addr: str,
     dict_module_data: dict[str, Any] | None,
 ) -> None:
-    """Register the PC-Logic module device that a logical-input child points
-    to via ``via_device``.
+    """Register the input-module device that a synthesised input-child
+    points to via ``via_device``.
 
-    Looks the module up in ``dict_module_data`` for accurate name/model.
-    Falls back to a placeholder when module data isn't available — a later
-    call to ``register_input_module_devices`` will update fields on the
-    same identifier.
+    Looks the parent module up in ``dict_module_data`` under both the
+    ``pc_logic`` and ``interface_module`` buckets — both module types
+    use the same synthesis path and provenance shape, so the parent
+    can live in either bucket. Falls back to a placeholder when module
+    data isn't available — a later call to ``register_input_module_devices``
+    will update fields on the same identifier.
     """
-    bucket = (dict_module_data or {}).get("pc_logic") or {}
     module_data: dict[str, Any] | None = None
-    if isinstance(bucket, dict):
+    found_module_type: str | None = None
+    for module_type in ("pc_logic", "interface_module"):
+        bucket = (dict_module_data or {}).get(module_type) or {}
+        if not isinstance(bucket, dict):
+            continue
         for addr, data in bucket.items():
             if str(addr).upper() == parent_addr and isinstance(data, dict):
                 module_data = data
+                found_module_type = module_type
                 break
+        if module_data is not None:
+            break
 
     if module_data is not None:
-        name = str(module_data.get("description") or f"PC-Logic ({parent_addr})")
-        model = str(module_data.get("model") or "pc_logic")
+        default_name = (
+            f"PC-Logic ({parent_addr})"
+            if found_module_type == "pc_logic"
+            else f"Modular Interface ({parent_addr})"
+        )
+        name = str(module_data.get("description") or default_name)
+        model = str(module_data.get("model") or found_module_type)
     else:
-        name = f"PC-Logic ({parent_addr})"
-        model = "pc_logic"
+        name = f"Input Module ({parent_addr})"
+        model = "input_module"
 
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
@@ -312,16 +325,16 @@ def register_opaque_module_devices(
 def _iter_input_module_entities(coordinator: NikobusDataCoordinator):
     """Yield one NikobusInputEntity per channel of every input-class module.
 
-    PC-Logic logical inputs are surfaced through synthesized button-store
-    entries (one ``LM-INPUT N`` device per input, parented under the
-    PC-Logic module), so the PC-Logic module itself has no per-channel
-    entities — skip it here. The 05-206 modular interface still uses the
-    channels-driven path.
+    Both PC-Logic (05-201) and Modular Interface (05-206) inputs are
+    surfaced through synthesized button-store entries (one ``LM-INPUT N``
+    device per input, parented under the owning module). Their per-channel
+    placeholder entities are redundant — skip the module-attached
+    ``NikobusInputEntity`` creation for both.
     """
     for module_type, address, module_data in _iter_module_records(
         coordinator.dict_module_data, INPUT_MODULE_TYPES
     ):
-        if module_type == "pc_logic":
+        if module_type in ("pc_logic", "interface_module"):
             continue
         module_desc = str(
             module_data.get("description") or f"{module_type} ({address})"

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -1125,11 +1125,12 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         # Input-class modules (PC-Logic, Modular Interface) skip ``build_routing``
         # because they don't drive output relays — emit their input-channel
         # button unique IDs directly so orphan-cleanup doesn't remove them.
-        # PC-Logic is excluded: its logical inputs surface through the
-        # synthesized button-store entries (one ``LM-INPUT N`` device per
-        # input), not per-channel input entities.
+        # PC-Logic (05-201) and Modular Interface (05-206) are excluded:
+        # their inputs surface through synthesised button-store entries
+        # (one ``LM-INPUT N`` device per input), not per-channel input
+        # entities. Both module types share the same synthesis path.
         for module_type in INPUT_MODULE_TYPES:
-            if module_type == "pc_logic":
+            if module_type in ("pc_logic", "interface_module"):
                 continue
             bucket = self.dict_module_data.get(module_type) or {}
             if not isinstance(bucket, dict):

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.11.0"
+    "nikobus-connect>=0.12.0"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }


### PR DESCRIPTION
## Summary

Depends on [nikobus-connect#68](https://github.com/fdebrus/nikobus-connect/pull/68) (library 0.12.0). Pairs with the library extending input-synthesis to 05-206 Modular Interface modules.

## Changes

- `_ensure_pc_logic_parent_device`: looks up parents in **both** `pc_logic` and `interface_module` buckets of `dict_module_data`, using type-appropriate fallback names (`"PC-Logic (xxxx)"` vs `"Modular Interface (xxxx)"`).
- `_iter_input_module_entities`: skips `interface_module` (along with `pc_logic`) — the inputs now surface through the synthesised button-store entries, so the per-channel placeholder duplication can go.
- `get_known_entity_unique_ids`: matching skip in the input-channel unique-ID loop.
- `manifest.json`: 2.4.2 → 2.5.0; dep `nikobus-connect>=0.11.0` → `>=0.12.0`.

## Test plan

- [x] HA suite: same 42 pre-existing failures, no new regressions.
- [ ] On the 6E40 install: after upgrading + running discovery, confirm the 6 `LM-INPUT N` devices appear under the Modular Interface, and pressing each input fires the corresponding binary sensor (idle → pressed → idle). If they don't, the address formula doesn't generalise to 05-206 and we revisit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5)_