### PR TITLE
2.8.0: pin nikobus-connect>=0.14.0 (05-312 remote) + README catch-up

### DIFF
--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.13.0"
+    "nikobus-connect>=0.14.0"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }


### PR DESCRIPTION
## Summary

Depends on [nikobus-connect#72](https://github.com/fdebrus/nikobus-connect/pull/72) (library 0.14.0). Two changes:

### Manifest bump

The Niko 05-312 Easywave 52-key hand-held remote materialises in the v2 button store correctly. The previous library version dropped it with `Unexpected number of channels: 52` and the remote never appeared in the integration. After 0.14.0, the next discovery run produces one button-store entry with all 52 op-points (naming follows the user's v1 `.migrated` convention).

- `manifest.json`: 2.7.0 → 2.8.0; dep `nikobus-connect>=0.13.0` → `>=0.14.0`.

### README catch-up

The README hadn't been updated since ~2.2-era; brings it in line with what we shipped across 2.3.0 → 2.8.0:

- **Supported modules**: add `05-008-02` Compact Dim Controller; replace the vague "Modules with Digital Interfaces" bullet with a precise "Input-class modules" entry naming 05-201 and 05-206; promote 05-205 to its own bullet with an honest "not yet decoded" note.
- **Nikobus Buttons**: enumerate supported RF transmitters (05-311/312/314/345), call out the 52-key 05-312 specifically, and document the multi-page transmitter auto-clustering (`Remote Transmitter (<suffix>)` virtual device with N children).
- **New "PC-Logic and Modular Interface inputs" section** covering the LM-INPUT N child-device layout, the Key A / Key B convention, with a small automation example.
- **Events section**: one line on the frame-count anchoring so users with a flaky TCP bridge understand the timer/bucket events still fire correctly even when frames arrive in a burst.

No structural rewrite of the README, no scope creep.

## Test plan

- [x] HA suite: 173 passed, no regressions.
- [ ] On the affected install: after upgrading, run discovery once; confirm one entry at the remote's physical with 52 op-points present in `.storage/nikobus.buttons`, and that pressing any of the 52 sub-codes triggers the corresponding op-point in HA.