### PR TITLE
2.9.1: 05-312 link resolution + don't flag synthesized inputs as legacy

### DIFF
--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.14.0"
+    "nikobus-connect>=0.15.0"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }


### PR DESCRIPTION
## Summary

Two related changes that ship together — the second was surfaced while diagnosing the first on the same install.

### 2.9.0 — pin `nikobus-connect>=0.15.0`

Companion: fdebrus/nikobus-connect#73. Without 0.15.0 the user sees the 05-312 Easywave remote and its 52 op-points materialised (that landed in 2.8.0) but `linked_modules` stays empty — the rockers don't appear to control anything in the HA UI even though the underlying modules are wired correctly. 0.15.0 adds the BP-cell → op-point resolver (algorithmic, no per-install table).

### 2.9.1 — `synthesized_input` bucket in the post-Stage-2 classifier

Repro on the same install: after upgrading to 2.8.0, the Repairs flow surfaced **"6 Nikobus button(s) flagged as legacy"** listing `64A061`..`64A066`. Those are the 6 library-synthesized PC-Logic logical inputs (model `05-201`, parent `8DC8`) — they model bus-event sources the PC-Logic module listens to internally, not buttons that drive output modules, so empty `linked_modules` is their steady state, not a residue signal.

The classifier in `coordinator.py:_reconcile_post_discovery` walked every button and bucketed any with empty `linked_modules` as `legacy_undecoded`. Confirming the Repairs flow would have evicted the inputs from the button store; recovery would have needed a full re-scan to re-synthesize them.

Fix: detect `pc_logic_parent_address` (set on every 05-201 / 05-206 synthesized input by the library's `_synthesize_pc_logic_inputs`) and route those to a dedicated `synthesized_input` status. Both the legacy-undecoded Repairs surface and the button entity `wall_button_status` attribute filter on `("legacy_undecoded", "legacy_orphan")`, so neither shows the new status. Existing Repairs issue auto-clears on the next discovery once the affected entries reclassify.

## Test plan

- [x] Manifest version → 2.9.1, requirement → `nikobus-connect>=0.15.0`
- [x] New `test_synthesized_pc_logic_input_is_not_flagged_as_legacy` covering both 05-201 and 05-206 parents, with a wall-button negative control to make sure the bypass is scoped to `pc_logic_parent_address` bearers only
- [x] New `test_synthesized_inputs_do_not_surface_repair` against the issue-registry surface, asserts `mock_create.assert_not_called()` when all candidates are synthesized
- [x] Full `test_coordinator.py` suite: 90 passed
- [ ] Smoke-test on the diagnostic install: existing Repairs issue clears on next discovery; 05-312 op-points populate `linked_modules`
