### PR TITLE
2.9.2: route Interfaces before RF in device-category check

### DIFF
--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -593,10 +593,12 @@ class NikobusButtonEntity(NikobusEntity, ButtonEntity):
             attrs["wall_button_type"] = wall_info.get("type")
             # ``status`` comes from post-discovery reconciliation
             # (coordinator._reconcile_post_discovery): one of "active",
-            # "legacy_orphan", "legacy_undecoded". Surface only the
-            # non-default flags so healthy buttons aren't cluttered.
+            # "legacy_orphan", "legacy_undecoded", "synthesized_input".
+            # Surface only the legacy flags so healthy buttons (active
+            # wall buttons and synthesized PC-Logic / 05-206 inputs)
+            # aren't cluttered.
             status = wall_info.get("status")
-            if status and status != "active":
+            if status in ("legacy_orphan", "legacy_undecoded"):
                 attrs["wall_button_status"] = status
         return attrs
 

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -88,16 +88,20 @@ def _category_for_button_type(type_str: str) -> str:
 
     Classification rule based on the discovery-supplied ``type`` field:
 
-      * ``RF`` anywhere → Remotes (RF hand-held / RF wall transmitters)
       * ``Interface`` anywhere → Interfaces (push-button / switch /
         universal input interfaces — non-keypad input sources)
+      * ``RF`` anywhere → Remotes (RF hand-held / RF wall transmitters)
       * everything else → Wall buttons (physical bus push buttons)
+
+    Interface is matched before RF because ``"rf"`` is a substring of
+    ``"interface"`` — checking RF first would route every Universal /
+    Modular / push-button interface into Remotes.
     """
     lowered = type_str.lower()
-    if "rf" in lowered:
-        return CATEGORY_REMOTES
     if "interface" in lowered:
         return CATEGORY_INTERFACES
+    if "rf" in lowered:
+        return CATEGORY_REMOTES
     return CATEGORY_WALL_BUTTONS
 
 

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -1459,7 +1459,12 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
 
         # --- Button bucketing ----------------------------------------
         remaining = {str(a).upper() for a in modules.keys()}
-        bucket_counts = {"active": 0, "legacy_orphan": 0, "legacy_undecoded": 0}
+        bucket_counts = {
+            "active": 0,
+            "legacy_orphan": 0,
+            "legacy_undecoded": 0,
+            "synthesized_input": 0,
+        }
         buttons = self.dict_button_data.setdefault("nikobus_button", {})
         # Topology gate for the registry-only residue check. With no
         # PC-Logic in the install, a button whose every output record
@@ -1470,6 +1475,19 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         has_pc_logic = self._has_pc_logic_module()
         for phys in buttons.values():
             if not isinstance(phys, dict):
+                continue
+            # Library-synthesized PC-Logic (05-201) and Modular Interface
+            # (05-206) input children carry ``pc_logic_parent_address``
+            # set by the synthesizer in nikobus-connect
+            # ``_synthesize_pc_logic_inputs``. They model bus-event
+            # sources that the parent module listens to internally, not
+            # buttons that drive output modules — empty ``linked_modules``
+            # is the steady state, not a residue signal. Bucket them on
+            # their own status so the legacy-undecoded Repairs flow
+            # leaves them alone.
+            if phys.get("pc_logic_parent_address"):
+                phys["status"] = "synthesized_input"
+                bucket_counts["synthesized_input"] += 1
                 continue
             linked = self._collect_button_linked_modules(phys)
             outputs = self._collect_button_outputs(phys)
@@ -1520,7 +1538,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         _LOGGER.info(
             "Post-discovery reconciliation: probed=%d present=%d absent=%d "
             "swept=%d evicted=%d | buttons active=%d legacy_orphan=%d "
-            "legacy_undecoded=%d",
+            "legacy_undecoded=%d synthesized_input=%d",
             len(checked),
             len(present),
             len(absent),
@@ -1529,6 +1547,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             bucket_counts["active"],
             bucket_counts["legacy_orphan"],
             bucket_counts["legacy_undecoded"],
+            bucket_counts["synthesized_input"],
         )
         if evicted:
             _LOGGER.info(

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/tests/test_category_for_button_type.py
+++ b/tests/test_category_for_button_type.py
@@ -1,0 +1,132 @@
+"""Regression tests for the device-registry category router.
+
+The bug fixed here: ``"rf" in "interface".lower()`` is True (substring
+match inside "inte**rf**ace"), so the previous RF-first ordering shoved
+every Interface device into the Remotes category in the HA device list.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+COMP = Path(__file__).parent.parent / "custom_components" / "nikobus"
+
+
+def _ensure_stubs() -> None:
+    """Stubs for the few HA modules button.py touches at import time.
+
+    conftest.py loads coordinator/sensor but not button.py; we lazily add
+    the small extras the button module needs.
+    """
+    if "homeassistant.components.button" not in sys.modules:
+        m = types.ModuleType("homeassistant.components.button")
+        m.__spec__ = importlib.machinery.ModuleSpec(
+            "homeassistant.components.button", None
+        )
+        m.ButtonEntity = type("ButtonEntity", (), {})
+        sys.modules["homeassistant.components.button"] = m
+
+    # conftest's EntityCategory stub only exposes DIAGNOSTIC; button.py
+    # also references CONFIG on its inventory-trigger button.
+    for mod_name in ("homeassistant.const", "homeassistant.helpers.entity"):
+        mod = sys.modules.get(mod_name)
+        if mod is not None and hasattr(mod, "EntityCategory"):
+            if not hasattr(mod.EntityCategory, "CONFIG"):
+                mod.EntityCategory.CONFIG = "config"
+
+
+def _load_button_module():
+    _ensure_stubs()
+    if "custom_components.nikobus.entity" not in sys.modules:
+        spec = importlib.util.spec_from_file_location(
+            "custom_components.nikobus.entity", COMP / "entity.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        mod.__package__ = "custom_components.nikobus"
+        sys.modules["custom_components.nikobus.entity"] = mod
+        spec.loader.exec_module(mod)
+
+    if "custom_components.nikobus.button" not in sys.modules:
+        spec = importlib.util.spec_from_file_location(
+            "custom_components.nikobus.button", COMP / "button.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        mod.__package__ = "custom_components.nikobus"
+        sys.modules["custom_components.nikobus.button"] = mod
+        spec.loader.exec_module(mod)
+    return sys.modules["custom_components.nikobus.button"]
+
+
+def test_universal_interface_routes_to_interfaces() -> None:
+    """``"rf"`` is a substring of ``"interface"`` — must not steal it."""
+    button = _load_button_module()
+    assert (
+        button._category_for_button_type("Universal interface, 8 channels")
+        == button.CATEGORY_INTERFACES
+    )
+    assert (
+        button._category_for_button_type("Universal interface, 4 channels")
+        == button.CATEGORY_INTERFACES
+    )
+    assert (
+        button._category_for_button_type("Modular interface, 6 inputs")
+        == button.CATEGORY_INTERFACES
+    )
+    assert (
+        button._category_for_button_type("Interface for push buttons")
+        == button.CATEGORY_INTERFACES
+    )
+    assert (
+        button._category_for_button_type("Interface for switches")
+        == button.CATEGORY_INTERFACES
+    )
+
+
+def test_rf_devices_route_to_remotes() -> None:
+    button = _load_button_module()
+    assert (
+        button._category_for_button_type("Single RF-bus push button, 2 operation areas")
+        == button.CATEGORY_REMOTES
+    )
+    assert (
+        button._category_for_button_type("Double RF-bus push button, 4 operation areas")
+        == button.CATEGORY_REMOTES
+    )
+    assert (
+        button._category_for_button_type("Mini hand-held RF transmitter, 1 channel")
+        == button.CATEGORY_REMOTES
+    )
+    assert (
+        button._category_for_button_type(
+            "Easywave hand-held RF transmitter, 52 operation points"
+        )
+        == button.CATEGORY_REMOTES
+    )
+    assert (
+        button._category_for_button_type("RF868 mini transmitter, 4 channels")
+        == button.CATEGORY_REMOTES
+    )
+
+
+def test_wall_buttons_route_to_wall_buttons() -> None:
+    button = _load_button_module()
+    assert (
+        button._category_for_button_type("Bus push button, 4 control buttons")
+        == button.CATEGORY_WALL_BUTTONS
+    )
+    assert (
+        button._category_for_button_type(
+            "Bus push button, 4 control buttons with IR receiver"
+        )
+        == button.CATEGORY_WALL_BUTTONS
+    )
+    assert (
+        button._category_for_button_type(
+            "Bus push button, 8 control buttons with eight feedback LEDs"
+        )
+        == button.CATEGORY_WALL_BUTTONS
+    )

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -732,6 +732,62 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
             "legacy_undecoded",
         )
 
+    async def test_synthesized_pc_logic_input_is_not_flagged_as_legacy(self):
+        """PC-Logic (05-201) and Modular Interface (05-206) synthesized
+        inputs carry ``pc_logic_parent_address`` set by the library's
+        ``_synthesize_pc_logic_inputs``. They model bus-event sources
+        the parent module listens to internally, not buttons that drive
+        output modules — empty ``linked_modules`` is their steady state.
+
+        Pre-fix the classifier flagged all six as ``legacy_undecoded``
+        and the Repairs flow asked the user to purge them (gist
+        reproducer at install with parent 8DC8 + synthesised children
+        64A061..64A066). The fix routes them to ``synthesized_input``
+        so the legacy-undecoded Repairs issue ignores them.
+        """
+        synthesized = {
+            "1A": {"bus_address": "21814B", "linked_modules": []},
+            "1B": {"bus_address": "61814B", "linked_modules": []},
+        }
+        synthesized_input = {
+            "type": "PC-Logic Logical Input",
+            "model": "05-201",
+            "operation_points": synthesized,
+            "pc_logic_parent_address": "940C",
+            "pc_logic_parent_type": "pc_logic",
+        }
+        modular_input = {
+            "type": "Modular Interface Input",
+            "model": "05-206",
+            "operation_points": synthesized,
+            "pc_logic_parent_address": "1234",
+            "pc_logic_parent_type": "interface_module",
+        }
+        coord = self._make_coordinator_stub(
+            modules={"AABB": {"module_type": "switch_module"}},
+            buttons={
+                "64A061": synthesized_input,
+                "0E1234": modular_input,
+                # A wall button with no links — must still be flagged.
+                "112233": self._button(),
+            },
+            manifest={
+                "checked": ["AABB"],
+                "present_modules": ["AABB"],
+                "absent_modules": [],
+                "orphaned_buttons": [],
+            },
+        )
+
+        await coord._reconcile_post_discovery()
+
+        buttons = coord.dict_button_data["nikobus_button"]
+        self.assertEqual(buttons["64A061"]["status"], "synthesized_input")
+        self.assertEqual(buttons["0E1234"]["status"], "synthesized_input")
+        # Real wall button still flagged — the synthesized bypass must
+        # be scoped to pc_logic_parent-bearing entries only.
+        self.assertEqual(buttons["112233"]["status"], "legacy_undecoded")
+
     async def test_button_with_at_least_one_present_link_is_active(self):
         # Button linked to AABB (in sweep, kept) + CCDD (absent in both,
         # evicted). At least one link survives → active.
@@ -1413,6 +1469,31 @@ class TestSurfaceLegacyUndecodedButtons(unittest.IsolatedAsyncioTestCase):
         delete_args = mock_delete.call_args
         self.assertIn("legacy_undecoded_buttons", delete_args.args[2])
         self.assertIn("entry_test", delete_args.args[2])
+
+    @patch("custom_components.nikobus.coordinator.ir.async_create_issue")
+    @patch("custom_components.nikobus.coordinator.ir.async_delete_issue")
+    def test_synthesized_inputs_do_not_surface_repair(
+        self, mock_delete, mock_create
+    ):
+        # Repro for the false-positive on synthesized PC-Logic /
+        # Modular Interface inputs: every 05-201 child carries empty
+        # ``linked_modules`` by design, which pre-fix bucketed as
+        # ``legacy_undecoded`` and walked into this Repairs flow asking
+        # the user to purge their PC-Logic inputs. With the fix in
+        # ``_reconcile_post_discovery``, they land on
+        # ``synthesized_input`` and this surface filters them out.
+        coord = self._coord_stub()
+        buttons = {
+            "64A061": {"status": "synthesized_input"},
+            "64A062": {"status": "synthesized_input"},
+            "1843B4": {"status": "active"},
+        }
+
+        NikobusDataCoordinator._surface_legacy_undecoded_buttons(coord, buttons)
+
+        # No legacy entries at all — no repair issue should be created.
+        mock_create.assert_not_called()
+        mock_delete.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes a substring collision in `_category_for_button_type` that misrouted every interface device into the Remotes category in HA's device list.

### Root cause

`button.py:_category_for_button_type` checked `"rf" in lowered` **before** `"interface" in lowered`. `"rf"` is a substring of `"interface"` (inte**rf**ace), so every Niko interface device — Universal interface (4/8 ch), Modular interface (6 inputs), Interface for push buttons / switches — matched the RF check first and was registered under Remotes.

Visible on the affected install as a `Universal interface, 8 channels (1634D…)` device nested under the Remotes category device.

### Fix

Swap the two checks: `"interface"` first, then `"rf"`. Added a comment explaining why the order is load-bearing so it doesn't get reverted on a future cleanup pass.

After upgrade, interface devices move to the Interfaces category on the next entity refresh. Existing devices may need a config-entry reload to relink their `via_device`.

## Test plan

- [x] Manifest version → 2.9.2
- [x] New `tests/test_category_for_button_type.py` — 3 tests:
  - all 5 interface name variants from `mapping.py` route to Interfaces
  - all 5 RF transmitter / RF-bus name variants route to Remotes
  - bus push button variants stay in Wall buttons
- [x] Full HA suite: 178 passed (was 175 + 3 new)
- [ ] Smoke-test on the diagnostic install: confirm the 1634D universal interface re-parents from Remotes to Interfaces after reload

https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5)_