### PR TITLE
2.10.0: discovery quality metrics in diagnostics export

### DIFF
--- a/custom_components/nikobus/diagnostics.py
+++ b/custom_components/nikobus/diagnostics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
@@ -19,6 +20,176 @@ from .coordinator import NikobusConfigEntry
 from .entity import device_entry_diagnostics
 
 TO_REDACT = {CONF_CONNECTION_STRING}
+
+
+def _per_module_decode_metrics(coordinator) -> dict[str, dict[str, Any]]:
+    """Build per-output-module decode-quality metrics.
+
+    For each module address surface:
+      * ``channel_count`` — channels the catalogue ascribes to this module
+      * ``link_record_count`` — total decoded link records routed to it
+      * ``triggering_buttons`` — number of distinct physical buttons that
+        drive at least one of its channels
+      * ``unique_modes`` — set of M-codes seen across its records
+      * ``channels_with_links`` / ``channels_without_links`` — how many
+        of the catalogued channels have at least one decoded link record
+        vs none (channels with zero links are either unprogrammed or
+        residue from a previous install)
+      * ``unique_t1_values`` / ``unique_t2_values`` — distinct resolved
+        timer strings (post-decode, after the per-mode T1/T2 tables)
+
+    No bus-specific assumptions — pure aggregation of what the discovery
+    decoder has already produced. Surfaces the same info on any install.
+    """
+
+    out: dict[str, dict[str, Any]] = {}
+
+    # Build (module, channel) → list[button-record] index by reusing
+    # the coordinator's own helper. Returns [] for unknown channels.
+    buttons = (coordinator.dict_button_data or {}).get("nikobus_button", {})
+    if not isinstance(buttons, dict):
+        buttons = {}
+
+    # Collect every (module_address, channel, mode, t1, t2, button_phys)
+    records: list[dict[str, Any]] = []
+    for physical_addr, phys in buttons.items():
+        if not isinstance(phys, dict):
+            continue
+        op_points = phys.get("operation_points") or {}
+        if not isinstance(op_points, dict):
+            continue
+        for key_label, op in op_points.items():
+            if not isinstance(op, dict):
+                continue
+            for link in op.get("linked_modules") or []:
+                if not isinstance(link, dict):
+                    continue
+                module_address = link.get("module_address")
+                if not isinstance(module_address, str):
+                    continue
+                module_key = module_address.upper()
+                for output in link.get("outputs") or []:
+                    if not isinstance(output, dict):
+                        continue
+                    channel = output.get("channel")
+                    if not isinstance(channel, int):
+                        continue
+                    records.append({
+                        "module": module_key,
+                        "channel": channel,
+                        "mode": output.get("mode"),
+                        "t1": output.get("t1"),
+                        "t2": output.get("t2"),
+                        "button_phys": physical_addr,
+                    })
+
+    # Group by module
+    by_module: dict[str, list[dict[str, Any]]] = {}
+    for r in records:
+        by_module.setdefault(r["module"], []).append(r)
+
+    # Resolve channel counts from dict_module_data
+    channel_counts: dict[str, int] = {}
+    for _bucket, modules in (coordinator.dict_module_data or {}).items():
+        if not isinstance(modules, dict):
+            continue
+        for addr, meta in modules.items():
+            if not isinstance(meta, dict):
+                continue
+            cnt = meta.get("channel_count") or meta.get("channels")
+            try:
+                channel_counts[addr.upper()] = int(cnt) if cnt is not None else 0
+            except (TypeError, ValueError):
+                channel_counts[addr.upper()] = 0
+
+    for module_addr, recs in by_module.items():
+        ch_total = channel_counts.get(module_addr, 0)
+        channels_seen: set[int] = {r["channel"] for r in recs}
+        buttons_seen: set[str] = {r["button_phys"] for r in recs}
+        modes_seen: Counter = Counter(
+            r["mode"] for r in recs if r["mode"] is not None
+        )
+        t1_values = sorted({r["t1"] for r in recs if r["t1"]})
+        t2_values = sorted({r["t2"] for r in recs if r["t2"]})
+        out[module_addr] = {
+            "channel_count": ch_total,
+            "link_record_count": len(recs),
+            "triggering_buttons": len(buttons_seen),
+            "channels_with_links": len(channels_seen),
+            "channels_without_links": max(0, ch_total - len(channels_seen)),
+            "unique_modes": sorted(modes_seen.keys()),
+            "mode_distribution": dict(modes_seen),
+            "unique_t1_values": t1_values,
+            "unique_t2_values": t2_values,
+        }
+
+    # Also surface modules that are in the inventory but have zero
+    # decoded link records — useful for spotting modules that were
+    # discovered but produced no programming.
+    for module_addr, ch_total in channel_counts.items():
+        if module_addr in out:
+            continue
+        out[module_addr] = {
+            "channel_count": ch_total,
+            "link_record_count": 0,
+            "triggering_buttons": 0,
+            "channels_with_links": 0,
+            "channels_without_links": ch_total,
+            "unique_modes": [],
+            "mode_distribution": {},
+            "unique_t1_values": [],
+            "unique_t2_values": [],
+        }
+
+    return out
+
+
+def _button_decode_metrics(coordinator) -> dict[str, Any]:
+    """Top-level button-store decode metrics.
+
+    Surfaces aggregate counts useful for sanity-checking what came out
+    of discovery: total operation points, how many have at least one
+    linked module vs none, how many are PC-Logic-synthesized inputs
+    vs real wall buttons, etc.
+    """
+
+    buttons = (coordinator.dict_button_data or {}).get("nikobus_button", {})
+    if not isinstance(buttons, dict):
+        return {
+            "physical_button_count": 0,
+            "operation_point_count": 0,
+            "op_points_with_links": 0,
+            "op_points_without_links": 0,
+            "synthesized_input_count": 0,
+        }
+
+    op_total = 0
+    op_with_links = 0
+    op_without_links = 0
+    synthesized = 0
+    for phys in buttons.values():
+        if not isinstance(phys, dict):
+            continue
+        if phys.get("pc_logic_parent_address"):
+            synthesized += 1
+        op_points = phys.get("operation_points") or {}
+        if not isinstance(op_points, dict):
+            continue
+        for op in op_points.values():
+            if not isinstance(op, dict):
+                continue
+            op_total += 1
+            if op.get("linked_modules"):
+                op_with_links += 1
+            else:
+                op_without_links += 1
+    return {
+        "physical_button_count": len(buttons),
+        "operation_point_count": op_total,
+        "op_points_with_links": op_with_links,
+        "op_points_without_links": op_without_links,
+        "synthesized_input_count": synthesized,
+    }
 
 
 async def async_get_config_entry_diagnostics(
@@ -70,6 +241,10 @@ async def async_get_config_entry_diagnostics(
             "scene_count": len(coordinator.dict_scene_data.get("scene", [])),
             "discovery_phase": coordinator.discovery_phase,
             "raw_hex_states": raw_module_states,
+        },
+        "discovery_quality": {
+            "per_module": _per_module_decode_metrics(coordinator),
+            "buttons": _button_decode_metrics(coordinator),
         },
         "devices": [device_entry_diagnostics(dev) for dev in nikobus_devices],
     }

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.9.2",
+  "version": "2.10.0",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/tests/test_diagnostics_quality.py
+++ b/tests/test_diagnostics_quality.py
@@ -1,0 +1,260 @@
+"""Tests for the discovery-quality metrics in diagnostics.
+
+These metrics aggregate post-discovery state into install-agnostic
+numbers (link-record counts, triggering buttons, channels with/without
+programming, mode distributions). They run on every install — no
+specific catalogue or NKB-overlay assumption.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+COMP = Path(__file__).parent.parent / "custom_components" / "nikobus"
+
+
+def _ensure_stubs() -> None:
+    if "homeassistant.components.diagnostics" not in sys.modules:
+        m = types.ModuleType("homeassistant.components.diagnostics")
+        m.__spec__ = importlib.machinery.ModuleSpec(
+            "homeassistant.components.diagnostics", None
+        )
+        m.async_redact_data = lambda data, redact_keys: {
+            k: ("REDACTED" if k in redact_keys else v) for k, v in data.items()
+        }
+        sys.modules["homeassistant.components.diagnostics"] = m
+
+
+def _load_diagnostics():
+    _ensure_stubs()
+    if "custom_components.nikobus.diagnostics" not in sys.modules:
+        spec = importlib.util.spec_from_file_location(
+            "custom_components.nikobus.diagnostics", COMP / "diagnostics.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        mod.__package__ = "custom_components.nikobus"
+        sys.modules["custom_components.nikobus.diagnostics"] = mod
+        spec.loader.exec_module(mod)
+    return sys.modules["custom_components.nikobus.diagnostics"]
+
+
+class _FakeCoordinator:
+    """Minimal stub exposing the attributes the metric helpers read."""
+
+    def __init__(self, dict_module_data, dict_button_data):
+        self.dict_module_data = dict_module_data
+        self.dict_button_data = dict_button_data
+
+
+def test_per_module_metrics_empty_install() -> None:
+    """Zero modules → empty per-module dict."""
+    diag = _load_diagnostics()
+    coord = _FakeCoordinator(dict_module_data={}, dict_button_data={})
+    result = diag._per_module_decode_metrics(coord)
+    assert result == {}
+
+
+def test_per_module_metrics_one_module_one_link() -> None:
+    """Single button → single output channel → metrics reflect it."""
+    diag = _load_diagnostics()
+    coord = _FakeCoordinator(
+        dict_module_data={
+            "switch_module": {
+                "C7C1": {"channel_count": 12},
+            },
+        },
+        dict_button_data={
+            "nikobus_button": {
+                "020080": {
+                    "operation_points": {
+                        "1A": {
+                            "linked_modules": [
+                                {
+                                    "module_address": "C7C1",
+                                    "outputs": [
+                                        {
+                                            "channel": 5,
+                                            "mode": "M01 (On / off)",
+                                            "t1": None,
+                                            "t2": None,
+                                        }
+                                    ],
+                                }
+                            ],
+                        },
+                    },
+                },
+            },
+        },
+    )
+    result = diag._per_module_decode_metrics(coord)
+    assert "C7C1" in result
+    m = result["C7C1"]
+    assert m["channel_count"] == 12
+    assert m["link_record_count"] == 1
+    assert m["triggering_buttons"] == 1
+    assert m["channels_with_links"] == 1
+    assert m["channels_without_links"] == 11
+    assert m["unique_modes"] == ["M01 (On / off)"]
+
+
+def test_per_module_metrics_aggregates_distinct_buttons_modes_timers() -> None:
+    """Multiple buttons hitting same module → counts aggregate correctly."""
+    diag = _load_diagnostics()
+    coord = _FakeCoordinator(
+        dict_module_data={
+            "switch_module": {
+                "C7C1": {"channel_count": 12},
+            },
+        },
+        dict_button_data={
+            "nikobus_button": {
+                "020080": {
+                    "operation_points": {
+                        "1A": {
+                            "linked_modules": [{
+                                "module_address": "C7C1",
+                                "outputs": [
+                                    {"channel": 1, "mode": "M01", "t1": None, "t2": None},
+                                    {"channel": 2, "mode": "M06", "t1": "30 m", "t2": None},
+                                ],
+                            }],
+                        },
+                    },
+                },
+                "020081": {
+                    "operation_points": {
+                        "1B": {
+                            "linked_modules": [{
+                                "module_address": "C7C1",
+                                "outputs": [
+                                    {"channel": 1, "mode": "M03", "t1": "1 s", "t2": None},
+                                ],
+                            }],
+                        },
+                    },
+                },
+            },
+        },
+    )
+    m = diag._per_module_decode_metrics(coord)["C7C1"]
+    assert m["link_record_count"] == 3
+    assert m["triggering_buttons"] == 2
+    assert m["channels_with_links"] == 2  # channels 1 and 2
+    assert m["channels_without_links"] == 10
+    assert set(m["unique_modes"]) == {"M01", "M03", "M06"}
+    assert set(m["unique_t1_values"]) == {"30 m", "1 s"}
+
+
+def test_per_module_metrics_module_with_zero_records_still_surfaces() -> None:
+    """Modules present in inventory but with no links surface as zero-record."""
+    diag = _load_diagnostics()
+    coord = _FakeCoordinator(
+        dict_module_data={
+            "switch_module": {
+                "C7C1": {"channel_count": 12},
+            },
+        },
+        dict_button_data={"nikobus_button": {}},
+    )
+    result = diag._per_module_decode_metrics(coord)
+    assert "C7C1" in result
+    assert result["C7C1"]["link_record_count"] == 0
+    assert result["C7C1"]["channels_without_links"] == 12
+
+
+def test_per_module_metrics_handles_missing_channel_count() -> None:
+    """Modules without a channel_count get 0 (not a crash)."""
+    diag = _load_diagnostics()
+    coord = _FakeCoordinator(
+        dict_module_data={
+            "switch_module": {
+                "C7C1": {},  # no channel_count / channels key
+            },
+        },
+        dict_button_data={"nikobus_button": {}},
+    )
+    result = diag._per_module_decode_metrics(coord)
+    assert result["C7C1"]["channel_count"] == 0
+
+
+def test_button_metrics_counts_synthesized_inputs() -> None:
+    """PC-Logic / 05-206 synthesized inputs are counted separately."""
+    diag = _load_diagnostics()
+    coord = _FakeCoordinator(
+        dict_module_data={},
+        dict_button_data={
+            "nikobus_button": {
+                # Real wall button with linked outputs
+                "020080": {
+                    "operation_points": {
+                        "1A": {"linked_modules": [{"outputs": [{"channel": 1}]}]},
+                        "1B": {"linked_modules": []},
+                    },
+                },
+                # PC-Logic synthesized input
+                "640061": {
+                    "pc_logic_parent_address": "8DC8",
+                    "pc_logic_slot_index": 1,
+                    "operation_points": {
+                        "1A": {"linked_modules": []},
+                        "1B": {"linked_modules": []},
+                    },
+                },
+            },
+        },
+    )
+    m = diag._button_decode_metrics(coord)
+    assert m["physical_button_count"] == 2
+    assert m["operation_point_count"] == 4
+    assert m["op_points_with_links"] == 1
+    assert m["op_points_without_links"] == 3
+    assert m["synthesized_input_count"] == 1
+
+
+def test_button_metrics_empty_install() -> None:
+    """Empty install → all zeros."""
+    diag = _load_diagnostics()
+    coord = _FakeCoordinator(
+        dict_module_data={}, dict_button_data={"nikobus_button": {}}
+    )
+    m = diag._button_decode_metrics(coord)
+    assert m == {
+        "physical_button_count": 0,
+        "operation_point_count": 0,
+        "op_points_with_links": 0,
+        "op_points_without_links": 0,
+        "synthesized_input_count": 0,
+    }
+
+
+def test_per_module_metrics_module_address_normalised_uppercase() -> None:
+    """Lookup by upper-case module address regardless of source casing."""
+    diag = _load_diagnostics()
+    coord = _FakeCoordinator(
+        dict_module_data={
+            "switch_module": {"c7c1": {"channel_count": 12}},
+        },
+        dict_button_data={
+            "nikobus_button": {
+                "020080": {
+                    "operation_points": {
+                        "1A": {
+                            "linked_modules": [{
+                                "module_address": "C7C1",
+                                "outputs": [{"channel": 1, "mode": "M01"}],
+                            }],
+                        },
+                    },
+                },
+            },
+        },
+    )
+    result = diag._per_module_decode_metrics(coord)
+    # Same module, regardless of source casing — one entry, not two
+    assert "C7C1" in result
+    assert result["C7C1"]["link_record_count"] == 1


### PR DESCRIPTION
## Summary

Add a ``discovery_quality`` section to the existing diagnostics download with install-agnostic decode-quality metrics. Pure additive aggregation of post-discovery state — no behaviour change, no new bus probes.

## What gets surfaced

```json
"discovery_quality": {
  "per_module": {
    "C7C1": {
      "channel_count": 12,
      "link_record_count": 27,
      "triggering_buttons": 14,
      "channels_with_links": 10,
      "channels_without_links": 2,
      "unique_modes": ["M01", "M03", "M05", "M06"],
      "mode_distribution": {"M01": 5, "M03": 10, "M05": 8, "M06": 4},
      "unique_t1_values": ["30 m", "60 m"],
      "unique_t2_values": []
    },
    ...
  },
  "buttons": {
    "physical_button_count": 28,
    "operation_point_count": 86,
    "op_points_with_links": 74,
    "op_points_without_links": 12,
    "synthesized_input_count": 6
  }
}
```

## Why it's useful

Without changing what we scan or how we decode, this surfaces enough state to spot:

- **Output channels with zero links** → unprogrammed channel or residue from a previous install
- **Buttons with all op-points unlinked** → orphan / disconnected
- **High ``op_points_without_links`` count** → possible decode gap

Particularly helpful when triaging "my X doesn't work in HA" reports — the diagnostics download now answers "is the link record actually present in the button store?" without needing to walk dict_button_data manually.

## Test plan

- [x] New ``tests/test_diagnostics_quality.py`` (8 tests):
  - Empty install → zero everything
  - Single button → single output → metrics reflect it
  - Multi-button multi-channel aggregation
  - Missing ``channel_count`` handled (defaults to 0)
  - Modules in inventory but with no links still surface (channels_without_links == channel_count)
  - Synthesized PC-Logic / 05-206 inputs counted separately
  - Module-address case normalization (lowercase ↔ uppercase merge to one entry)
- [x] Full HA test suite: 186 passed
- [ ] Smoke-test on a real install (download diagnostics, confirm new section populates)

https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5)_