### PR TITLE
2.10.0: vendor-aligned discovery progress display

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -457,15 +457,30 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
     }
 
     async def _handle_discovery_progress(self, progress: Any) -> None:
-        """Consume a ``DiscoveryProgress`` event emitted by nikobus-connect 0.3.5+.
+        """Consume a ``DiscoveryProgress`` event emitted by nikobus-connect.
 
         ``progress`` is a ``nikobus_connect.discovery.DiscoveryProgress``
-        dataclass with: ``phase``, ``module_address``, ``module_index``,
-        ``module_total``, ``register``, ``register_total``,
-        ``decoded_records``. The library emits one of the four real phases
-        (``inventory`` / ``identity`` / ``register_scan`` / ``finalizing``);
-        idle / finished / error states are handled by the caller's own
-        ``_handle_discovery_finished`` and error-path code.
+        dataclass. Fields used here:
+
+        - ``phase``: one of ``"inventory"``, ``"identity"``,
+          ``"register_scan"``, ``"finalizing"``.
+        - ``module_address`` / ``module_index`` / ``module_total``:
+          current module + queue position.
+        - ``register_total``: cumulative target for the current module
+          across all scan passes (0.16.1+). 48 for the vendor plan
+          on output modules + PC-Logic; 93 for PC-Link.
+        - ``registers_sent``: cumulative count already sent for the
+          current module. The right value for the per-module
+          progress numerator under the vendor scan plan, since the
+          plan reads non-contiguous bytes across multiple passes and
+          ``register`` jumps around (e.g. 0x09 → 0x3E → 0x70).
+        - ``pass_index`` / ``pass_total``: 1-based pass position
+          within the module's plan (e.g. 2/3 for the vendor plan
+          link-table pass). 0 outside scans.
+        - ``sub_byte``: wire sub-byte of the current pass.
+        - ``register``: current byte being read; surfaced for
+          diagnostic display but NOT used as the progress numerator.
+        - ``decoded_records``: running cumulative across the run.
 
         Exceptions raised here are swallowed — the library treats this
         callback as fire-and-forget and must not be stalled by UI plumbing.
@@ -481,16 +496,28 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             module_total = int(getattr(progress, "module_total", 0) or 0)
             register = getattr(progress, "register", None)
             register_total = int(getattr(progress, "register_total", 0) or 0)
+            # New 0.16.1 fields — fall back to the legacy (register -
+            # 0x10 + 1) calculation when the library doesn't supply
+            # them (older lib versions, forensic-mode scans).
+            registers_sent = int(getattr(progress, "registers_sent", 0) or 0)
+            pass_index = int(getattr(progress, "pass_index", 0) or 0)
+            pass_total = int(getattr(progress, "pass_total", 0) or 0)
+            sub_byte = getattr(progress, "sub_byte", None)
             decoded_records = int(getattr(progress, "decoded_records", 0) or 0)
 
-            registers_done = 0
-            if register is not None and register_total:
-                # Registers start at 0x10, so done-count is (current - 0x10 + 1).
+            if registers_sent:
+                registers_done = registers_sent
+            elif register is not None and register_total:
+                # Pre-0.16.1 fallback: assume contiguous registers
+                # from 0x10. Wrong under the vendor plan but harmless
+                # for legacy callers that bypass the plan.
                 try:
                     cur = int(register)
                     registers_done = max(0, cur - 0x10 + 1)
                 except (TypeError, ValueError):
                     registers_done = 0
+            else:
+                registers_done = 0
 
             if sub_phase == DISCOVERY_SUB_PHASE_INVENTORY:
                 message = "PC Link inventory: enumerating bus addresses…"
@@ -502,23 +529,25 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 )
             elif sub_phase == DISCOVERY_SUB_PHASE_REGISTER_SCAN:
                 if module_address:
-                    # Library supplies ``register_total`` (a count starting
-                    # at register 0x10). Show the actual upper bound rather
-                    # than the legacy hard-coded 0xFF — some modules scan
-                    # much narrower ranges, and the early-stop heuristic
-                    # revises ``register_total`` downward once it fires.
-                    # Fall back to 0xFF only when the library did not send
-                    # a register_total (older lib versions / pre-scan tick).
-                    if register_total:
-                        top_register = 0x10 + register_total - 1
-                    else:
-                        top_register = 0xFF
-                    message = (
+                    base = (
                         f"Scanning module {module_address} "
-                        f"({module_index}/{module_total}) — "
-                        f"register 0x{int(register or 0):02X} of "
-                        f"0x{top_register:02X} ({decoded_records} records)"
+                        f"({module_index}/{module_total})"
                     )
+                    # 0.16.1+ surfaces the vendor scan plan's
+                    # multi-pass structure — include the pass position
+                    # so users see "we're in pass 2/3, not stuck on
+                    # one band" during the ~1 s pause between passes.
+                    if pass_total > 1 and pass_index:
+                        sub_label = f" sub={sub_byte}" if sub_byte else ""
+                        base += f" — pass {pass_index}/{pass_total}{sub_label}"
+                    if register_total:
+                        base += (
+                            f" — {registers_done}/{register_total} regs "
+                            f"({decoded_records} records)"
+                        )
+                    else:
+                        base += f" ({decoded_records} records)"
+                    message = base
                 else:
                     message = f"Scanning modules ({module_index}/{module_total})"
             elif sub_phase == DISCOVERY_SUB_PHASE_FINALIZING:
@@ -531,18 +560,13 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             self.discovery_register_current = (
                 int(register) if register is not None else None
             )
-            # PC-Link inventory walks 0xA4..0xFF = 92 frames (with the
-            # 0.5.13+ all-FF early-stop kicking in well before the end).
-            # The library reports ``register_total`` as the full 0x10..
-            # 0xFF (240) register space, which inflates the bar to ~1/3
-            # of true progress. Cap to 92 for the inventory phase so the
-            # percentage matches what the library actually scans.
-            if sub_phase == DISCOVERY_SUB_PHASE_INVENTORY:
-                effective_register_total = 92
-            elif register_total:
-                effective_register_total = register_total
-            else:
-                effective_register_total = 240
+            # The library's ``register_total`` is now the cumulative
+            # per-module target under the vendor plan (48 for output
+            # modules + PC-Logic, 93 for PC-Link, 112 with broad_scan).
+            # No HA-side capping needed — the library reports the
+            # real targets accurately. Keep the 240 fallback for
+            # forensic / legacy paths where register_total is 0.
+            effective_register_total = register_total or 240
             self._update_discovery_state(
                 phase=legacy_phase,
                 message=message,

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.9.2",
+  "version": "2.10.0",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.15.0"
+    "nikobus-connect>=0.16.1"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }

--- a/tests/test_discovery_progress_vendor_aligned.py
+++ b/tests/test_discovery_progress_vendor_aligned.py
@@ -1,0 +1,164 @@
+"""Tests for the 0.16.1-aware discovery progress handler.
+
+The library's vendor-aligned scan plan reads non-contiguous registers
+across multiple passes per module, so the pre-0.16.1 HA-side math
+(``done = register - 0x10 + 1``) produces wildly wrong percentages.
+0.16.1+ surfaces ``registers_sent`` directly — these tests pin that
+the HA handler uses it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+
+import sys
+from pathlib import Path
+
+# Conftest sets up the coordinator stubs; we just need to import the
+# coordinator module after conftest has run.
+
+
+@dataclass
+class _FakeProgress:
+    """Lightweight stand-in for ``nikobus_connect.discovery.DiscoveryProgress``."""
+
+    phase: str = "register_scan"
+    module_address: str | None = None
+    module_index: int = 0
+    module_total: int = 0
+    register: int | None = None
+    register_total: int = 0
+    registers_sent: int = 0
+    pass_index: int = 0
+    pass_total: int = 0
+    sub_byte: str | None = None
+    decoded_records: int = 0
+
+
+def _make_coordinator():
+    """Build a minimal coordinator with the progress handler attached."""
+    from custom_components.nikobus.coordinator import NikobusDataCoordinator
+
+    coord = MagicMock(spec=NikobusDataCoordinator)
+    coord.discovery_phase = "scan"
+    coord.discovery_status_message = ""
+    coord.discovery_sub_phase = "idle"
+    coord.discovery_decoded_records = 0
+    coord.discovery_register_current = None
+    coord._SUB_TO_LEGACY_PHASE = {"register_scan": "scan"}
+    update = MagicMock()
+    coord._update_discovery_state = update
+
+    # Bind the real method to the mock so it actually runs.
+    coord._handle_discovery_progress = (
+        NikobusDataCoordinator._handle_discovery_progress.__get__(coord)
+    )
+    return coord, update
+
+
+def test_handler_uses_registers_sent_directly() -> None:
+    """When ``registers_sent`` is provided, ratio is registers_sent/total."""
+    coord, update = _make_coordinator()
+    progress = _FakeProgress(
+        phase="register_scan",
+        module_address="C7C1",
+        module_index=1,
+        module_total=3,
+        register=0x70,
+        register_total=48,
+        registers_sent=10,
+        pass_index=2,
+        pass_total=3,
+        sub_byte="01",
+    )
+    asyncio.run(coord._handle_discovery_progress(progress))
+    update.assert_called_once()
+    kwargs = update.call_args.kwargs
+    assert kwargs["registers_done"] == 10
+    assert kwargs["registers_total"] == 48
+
+
+def test_handler_falls_back_to_register_minus_10_when_no_registers_sent() -> None:
+    """Pre-0.16.1 progress events (no registers_sent) fall back to the
+    legacy contiguous-from-0x10 calculation."""
+    coord, update = _make_coordinator()
+    progress = _FakeProgress(
+        phase="register_scan",
+        module_address="C7C1",
+        module_index=1,
+        module_total=3,
+        register=0x15,
+        register_total=64,
+        registers_sent=0,  # not supplied → fallback
+    )
+    asyncio.run(coord._handle_discovery_progress(progress))
+    kwargs = update.call_args.kwargs
+    # 0x15 - 0x10 + 1 = 6
+    assert kwargs["registers_done"] == 6
+    assert kwargs["registers_total"] == 64
+
+
+def test_handler_status_message_includes_pass_info_for_vendor_plan() -> None:
+    """Multi-pass scans surface ``pass N/M sub=XX`` in the user-facing
+    status message so the UI doesn't look frozen between passes."""
+    coord, update = _make_coordinator()
+    progress = _FakeProgress(
+        phase="register_scan",
+        module_address="C7C1",
+        module_index=2,
+        module_total=5,
+        register=0x70,
+        register_total=48,
+        registers_sent=15,
+        pass_index=2,
+        pass_total=3,
+        sub_byte="01",
+    )
+    asyncio.run(coord._handle_discovery_progress(progress))
+    message = update.call_args.kwargs["message"]
+    assert "C7C1" in message
+    assert "(2/5)" in message
+    assert "pass 2/3" in message
+    assert "sub=01" in message
+    assert "15/48" in message
+
+
+def test_handler_status_message_omits_pass_info_for_single_pass() -> None:
+    """PC-Link's 1-pass scan doesn't clutter the message with pass info."""
+    coord, update = _make_coordinator()
+    progress = _FakeProgress(
+        phase="register_scan",
+        module_address="8C49",
+        module_index=1,
+        module_total=1,
+        register=0xA3,
+        register_total=93,
+        registers_sent=1,
+        pass_index=1,
+        pass_total=1,
+        sub_byte="04",
+    )
+    asyncio.run(coord._handle_discovery_progress(progress))
+    message = update.call_args.kwargs["message"]
+    assert "pass" not in message.lower()
+    assert "8C49" in message
+
+
+def test_handler_no_register_total_uses_240_fallback() -> None:
+    """Forensic-mode scans may not supply register_total — fallback
+    keeps the bar from going to infinity."""
+    coord, update = _make_coordinator()
+    progress = _FakeProgress(
+        phase="register_scan",
+        module_address="C7C1",
+        module_index=1,
+        module_total=1,
+        register=0x20,
+        register_total=0,
+        registers_sent=0,
+    )
+    asyncio.run(coord._handle_discovery_progress(progress))
+    kwargs = update.call_args.kwargs
+    assert kwargs["registers_total"] == 240


### PR DESCRIPTION
## Summary

Consume the new `DiscoveryProgress` fields shipped in `nikobus-connect>=0.16.1` so the HA-side progress UI works correctly under the vendor-aligned scan plan.

**Depends on:** [nikobus-connect#80](https://github.com/fdebrus/nikobus-connect/pull/80) (library 0.16.1)

## Problem

The 0.16.0 library scan plan reads non-contiguous registers across multiple passes per module (sub=00 6 regs + sub=01 37 regs + sub=04 5 regs = 48 reads per output module). The pre-0.16.1 HA-side math `done = register - 0x10 + 1` produced wildly wrong percentages — `register = 0x70` against `total = 37` would compute 262 % progress on the first link-table read.

## Change

- Read `progress.registers_sent` directly as the cumulative per-module numerator.
- Surface `pass_index / pass_total` and `sub_byte` in the status message for multi-pass scans so the UI shows "pass 2/3 sub=01" between passes (otherwise the bar appears frozen at pass transitions).
- Use the library's accurate `register_total` directly — removed the old HA-side `92` cap for PC-Link inventory; the library now reports cumulative targets per module accurately (48 for output modules + PC-Logic, 93 for PC-Link).
- Keep the legacy `register - 0x10 + 1` math as a fallback for pre-0.16.1 library versions and forensic-mode scans that don't supply `registers_sent`.

## Manifest

- `version`: 2.9.2 → **2.10.0**
- `nikobus-connect`: `>=0.15.0` → **`>=0.16.1`**

## What the user sees during a typical discovery

Before (under 0.16.0 library without this PR):
```
Scanning module C7C1 (2/5) — register 0x70 of 0x96 (3 records)   ← percent bar at 262%
```

After (with this PR + 0.16.1):
```
Scanning module C7C1 (2/5) — pass 2/3 sub=01 — 15/48 regs (3 records)   ← percent bar at 31%
```

## Reference numbers

| Module | Scan target (regs) |
|---|---|
| Switch / Roller / Dimmer / PC-Logic | 48 |
| PC-Link | 93 |
| Switch / Roller / Dimmer / PC-Logic with broad_scan | 112 |

Typical install (PC-Link + PC-Logic + 3 switches + 1 dimmer): ~333 reads/sweep vs ~1170 pre-0.16.0 (3.5× faster).

## Test plan

- [x] New `test_discovery_progress_vendor_aligned.py` (5 tests):
  - `registers_sent` consumed as the progress numerator
  - Fallback to `register - 0x10 + 1` when `registers_sent` is 0 (pre-0.16.1 lib)
  - Multi-pass status message includes "pass N/M sub=XX"
  - Single-pass status message omits the pass info (PC-Link)
  - Missing `register_total` falls back to 240 (forensic safety net)
- [x] Full HA suite: **183 passed**
- [ ] Smoke-test against a real install (verify the percent bar advances smoothly across passes)

https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5)_