### PR TITLE
2.11.0: bump nikobus-connect to 0.19.1 + reset cached counters on phase transition

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -491,6 +491,17 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 sub_phase, self.discovery_phase
             )
 
+            # On sub-phase transition, zero out the register counters
+            # so the FIRST emit of the new phase doesn't display the
+            # previous phase's totals (e.g. identity's 96/96 leaking
+            # into the first register-scan emit). nikobus-connect
+            # 0.19.1 also resets these library-side; this is a
+            # defence-in-depth so older lib versions get the same
+            # behaviour.
+            if sub_phase != self.discovery_sub_phase:
+                self.discovery_registers_done = 0
+                self.discovery_registers_total = 0
+
             module_address = getattr(progress, "module_address", None)
             module_index = int(getattr(progress, "module_index", 0) or 0)
             module_total = int(getattr(progress, "module_total", 0) or 0)

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.16.2"
+    "nikobus-connect>=0.19.1"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }

--- a/tests/test_discovery_progress_vendor_aligned.py
+++ b/tests/test_discovery_progress_vendor_aligned.py
@@ -162,3 +162,38 @@ def test_handler_no_register_total_uses_240_fallback() -> None:
     asyncio.run(coord._handle_discovery_progress(progress))
     kwargs = update.call_args.kwargs
     assert kwargs["registers_total"] == 240
+
+
+def test_handler_resets_counters_on_sub_phase_transition() -> None:
+    """2.11.0: when the library transitions from identity to register_scan
+    (or any sub-phase change), the HA-side handler must zero out the
+    cached register counters so the first emit of the new phase doesn't
+    display the previous phase's leftover total. Without this, the
+    identity end-state of 96/96 leaks into the first register-scan
+    event of the first module, showing 100%."""
+    coord, update = _make_coordinator()
+    # Simulate identity phase end-state: 96/96 cached.
+    coord.discovery_sub_phase = "identity"
+    coord.discovery_registers_done = 96
+    coord.discovery_registers_total = 96
+
+    # First register-scan emit arrives. nikobus-connect 0.19.1 resets
+    # register_total to 0 at the identity-end, so the emit has 0/0
+    # initially. The HA handler must NOT carry forward the cached 96/96.
+    progress = _FakeProgress(
+        phase="register_scan",
+        module_address="C9A5",
+        module_index=1,
+        module_total=8,
+        register=None,
+        register_total=0,
+        registers_sent=0,
+    )
+    asyncio.run(coord._handle_discovery_progress(progress))
+    kwargs = update.call_args.kwargs
+    # Before this fix, registers_done would have been carried over from
+    # identity (96) — now it's 0.
+    assert kwargs["registers_done"] == 0
+    # Fallback to 240 when register_total=0 (legacy/forensic guard)
+    # is still applied, but the cached identity-phase total is gone.
+    assert kwargs["registers_total"] == 240


### PR DESCRIPTION
## Summary

Two coordinated changes:

### 1. Bump `nikobus-connect` dependency to >=0.19.1

Brings in the four upstream PRs that landed since 2.10.0:

| Upstream PR | What it does |
|---|---|
| [#86](https://github.com/fdebrus/nikobus-connect/pull/86) | 0.18.0 anchored productive-band scan for switch & roller |
| [#87](https://github.com/fdebrus/nikobus-connect/pull/87) | 0.18.1 PC-Link restored to PC-software COM-trace plan |
| [#88](https://github.com/fdebrus/nikobus-connect/pull/88) | 0.19.0 COM-trace-aligned profiles for every module type + parser-driven FF-tail early-stop + cleanup |
| [#89](https://github.com/fdebrus/nikobus-connect/pull/89) | 0.19.1 progress-counter resets at identity→register-scan transition + multi-pass cumulative fix |

The pc_logic profile is the highest-impact change: the 0.17.0 plan scanned at sub=04 (wrong sub-byte from a DLL-section misinterpretation), so PC-Logic modules returned 0 decoded records. 0.19.0 fixes that by aligning to the PC software's actual sub=00/02/03 reads.

### 2. HA-side progress-bar fix

When the library's `phase` field transitions (e.g. `identity` → `register_scan`), the coordinator must zero the cached `discovery_registers_done` / `discovery_registers_total`. Otherwise the identity end-state of **96/96 = 100%** leaks into the first register-scan emit and the bar briefly shows complete before the per-pass loop populates correct values.

`nikobus-connect` 0.19.1 also resets these counters library-side; this HA reset is defence-in-depth so the bar is correct even if a user has an older library version pinned to the 0.19 series.

## Test plan

- [x] All 192 tests pass (`pytest tests/`)
- [x] New regression test `test_handler_resets_counters_on_sub_phase_transition`
- [ ] Run a live discovery on real hardware and confirm the progress bar no longer jumps to 100% on the first module's first register-scan event

https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5)_