### PR TITLE
2.11.1: tag Universal Interface (05-058) as input_only instead of legacy_undecoded

### DIFF
--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -597,10 +597,11 @@ class NikobusButtonEntity(NikobusEntity, ButtonEntity):
             attrs["wall_button_type"] = wall_info.get("type")
             # ``status`` comes from post-discovery reconciliation
             # (coordinator._reconcile_post_discovery): one of "active",
-            # "legacy_orphan", "legacy_undecoded", "synthesized_input".
-            # Surface only the legacy flags so healthy buttons (active
-            # wall buttons and synthesized PC-Logic / 05-206 inputs)
-            # aren't cluttered.
+            # "legacy_orphan", "legacy_undecoded", "synthesized_input",
+            # "input_only". Surface only the legacy flags so healthy
+            # buttons (active wall buttons, synthesized PC-Logic /
+            # 05-206 inputs, and input-only Universal Interfaces) don't
+            # get cluttered.
             status = wall_info.get("status")
             if status in ("legacy_orphan", "legacy_undecoded"):
                 attrs["wall_button_status"] = status

--- a/custom_components/nikobus/const.py
+++ b/custom_components/nikobus/const.py
@@ -107,6 +107,27 @@ ISSUE_STALE_INVENTORY_PRESENT: Final[str] = "stale_inventory_present"
 # decision to the user via a Repairs flow.
 ISSUE_LEGACY_UNDECODED_BUTTONS: Final[str] = "legacy_undecoded_buttons"
 
+# Physical button types that are INPUT-ONLY by design — they generate
+# bus press telegrams when their contacts change state but they don't
+# write into output-module link tables (their inputs feed PC-Logic
+# conditions instead). Discovery's per-module register scan therefore
+# never finds link records pointing back at them, and they'd otherwise
+# be tagged ``legacy_undecoded`` and trigger a false-positive Repairs
+# alert.
+#
+# Tagged ``input_only`` instead so the Repairs flow and per-entity
+# ``wall_button_status`` treat them like ``synthesized_input`` (already
+# an exclusion for the same reason: PC-Logic Logical Inputs also have
+# no link table by design).
+#
+# Match is by the human-readable ``type`` string discovery writes into
+# each button entry, which already reflects device_type 0x43 vs 0x44
+# for the two 05-058 modes.
+INPUT_ONLY_BUTTON_TYPES: Final[frozenset[str]] = frozenset({
+    "Universal interface, switch mode",        # Niko 05-058, dtype 0x44 (8-ch)
+    "Universal interface, push-button mode",   # Niko 05-058, dtype 0x43 (4-ch)
+})
+
 # =============================================================================
 # Configuration Keys
 # =============================================================================

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -50,6 +50,7 @@ from .const import (
     DISCOVERY_WEIGHT_INVENTORY,
     DISCOVERY_WEIGHT_REGISTER_SCAN,
     DOMAIN,
+    INPUT_ONLY_BUTTON_TYPES,
     ISSUE_LEGACY_UNDECODED_BUTTONS,
     ISSUE_NO_BUTTONS_CONFIGURED,
     RECONNECT_DELAY_INITIAL,
@@ -1499,6 +1500,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             "legacy_orphan": 0,
             "legacy_undecoded": 0,
             "synthesized_input": 0,
+            "input_only": 0,
         }
         buttons = self.dict_button_data.setdefault("nikobus_button", {})
         # Topology gate for the registry-only residue check. With no
@@ -1523,6 +1525,18 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             if phys.get("pc_logic_parent_address"):
                 phys["status"] = "synthesized_input"
                 bucket_counts["synthesized_input"] += 1
+                continue
+            # Universal Interface (Niko 05-058) in either mode is
+            # input-only — its 4/8 contacts emit press telegrams but
+            # don't write into output-module link tables (they're
+            # designed to feed PC-Logic conditions). Same shape as a
+            # synthesized PC-Logic input from the bucket-decision
+            # perspective: empty ``linked_modules`` is the steady state.
+            # Tag separately so the legacy-undecoded Repairs alert
+            # doesn't false-positive on them.
+            if phys.get("type") in INPUT_ONLY_BUTTON_TYPES:
+                phys["status"] = "input_only"
+                bucket_counts["input_only"] += 1
                 continue
             linked = self._collect_button_linked_modules(phys)
             outputs = self._collect_button_outputs(phys)

--- a/custom_components/nikobus/diagnostics.py
+++ b/custom_components/nikobus/diagnostics.py
@@ -161,17 +161,21 @@ def _button_decode_metrics(coordinator) -> dict[str, Any]:
             "op_points_with_links": 0,
             "op_points_without_links": 0,
             "synthesized_input_count": 0,
+            "input_only_count": 0,
         }
 
     op_total = 0
     op_with_links = 0
     op_without_links = 0
     synthesized = 0
+    input_only = 0
     for phys in buttons.values():
         if not isinstance(phys, dict):
             continue
         if phys.get("pc_logic_parent_address"):
             synthesized += 1
+        if phys.get("status") == "input_only":
+            input_only += 1
         op_points = phys.get("operation_points") or {}
         if not isinstance(op_points, dict):
             continue
@@ -189,6 +193,7 @@ def _button_decode_metrics(coordinator) -> dict[str, Any]:
         "op_points_with_links": op_with_links,
         "op_points_without_links": op_without_links,
         "synthesized_input_count": synthesized,
+        "input_only_count": input_only,
     }
 
 

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -788,6 +788,68 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
         # be scoped to pc_logic_parent-bearing entries only.
         self.assertEqual(buttons["112233"]["status"], "legacy_undecoded")
 
+    async def test_universal_interface_is_tagged_input_only(self):
+        """Niko 05-058 Universal Interface (both switch and push-button
+        modes) emits bus press telegrams from its 4/8 dry contacts but
+        never writes into output-module link tables — its inputs feed
+        PC-Logic conditions, like the synthesized PC-Logic Logical
+        Inputs already handled above.
+
+        Pre-fix the bucketing tagged it as ``legacy_undecoded`` and the
+        Repairs flow false-positive'd asking the user to purge a
+        perfectly-functional input device (1634DC in the test install,
+        wired to garage-door reed switches). Fix routes input-only
+        types to a dedicated ``input_only`` bucket the Repairs alert
+        ignores.
+        """
+        no_links = {
+            "1A": {"bus_address": "AECB1A"},
+            "1B": {"bus_address": "EECB1A"},
+            "1C": {"bus_address": "2ECB1A"},
+            "1D": {"bus_address": "6ECB1A"},
+            "2A": {"bus_address": "8ECB1A"},
+            "2B": {"bus_address": "CECB1A"},
+            "2C": {"bus_address": "0ECB1A"},
+            "2D": {"bus_address": "4ECB1A"},
+        }
+        switch_mode = {
+            "type": "Universal interface, switch mode",
+            "model": "05-058",
+            "channels": 8,
+            "operation_points": no_links,
+        }
+        push_mode = {
+            "type": "Universal interface, push-button mode",
+            "model": "05-058",
+            "channels": 4,
+            "operation_points": {k: no_links[k] for k in ("1A", "1B", "1C", "1D")},
+        }
+        coord = self._make_coordinator_stub(
+            modules={"AABB": {"module_type": "switch_module"}},
+            buttons={
+                "1634DC": switch_mode,
+                "0FA001": push_mode,
+                # Control: a regular wall button with no links is still
+                # tagged legacy_undecoded — the input_only exclusion
+                # must be type-scoped, not blanket.
+                "112233": self._button(),
+            },
+            manifest={
+                "checked": ["AABB"],
+                "present_modules": ["AABB"],
+                "absent_modules": [],
+                "orphaned_buttons": [],
+            },
+        )
+
+        await coord._reconcile_post_discovery()
+
+        buttons = coord.dict_button_data["nikobus_button"]
+        self.assertEqual(buttons["1634DC"]["status"], "input_only")
+        self.assertEqual(buttons["0FA001"]["status"], "input_only")
+        # Real wall button still flagged.
+        self.assertEqual(buttons["112233"]["status"], "legacy_undecoded")
+
     async def test_button_with_at_least_one_present_link_is_active(self):
         # Button linked to AABB (in sweep, kept) + CCDD (absent in both,
         # evicted). At least one link survives → active.

--- a/tests/test_diagnostics_quality.py
+++ b/tests/test_diagnostics_quality.py
@@ -229,6 +229,7 @@ def test_button_metrics_empty_install() -> None:
         "op_points_with_links": 0,
         "op_points_without_links": 0,
         "synthesized_input_count": 0,
+        "input_only_count": 0,
     }
 
 


### PR DESCRIPTION
## Summary

Stops the `legacy_undecoded_buttons` Repairs alert from false-positive'ing on Niko 05-058 Universal Interface modules.

## The problem

The Universal Interface (model 05-058) is an input-only device:

- Switch mode (`device_type=0x44`, 8 dry contacts)
- Push-button mode (`device_type=0x43`, 4 dry contacts)

Both variants emit press telegrams on the bus when their contacts change state, but they don't write into output-module link tables — their inputs feed PC-Logic conditions. Discovery's per-module register scan therefore never finds link records pointing back at them.

Pre-fix, the post-discovery bucketing classified these as `legacy_undecoded` because of the empty-`linked_modules` shape, and the Repairs flow surfaced them as candidates to purge. False positive — the device is fully functional and was wired (in the reporter's install) to four garage-door reed switches, with all 8 entities exposed and working in HA.

## The fix

Pattern borrowed from how we already handle PC-Logic Logical Inputs (tagged `synthesized_input` via `pc_logic_parent_address`):

1. **`const.py`** — new `INPUT_ONLY_BUTTON_TYPES` frozenset listing the two 05-058 type strings discovery writes into each button entry.
2. **`coordinator.py`** — `_reconcile_post_discovery` checks `phys["type"]` against the set BEFORE the no-outputs branch and tags matching buttons as `input_only`.
3. **`coordinator.py`** `_surface_legacy_undecoded_buttons` already filters on the status list `("legacy_undecoded", "legacy_orphan")` — `input_only` is automatically excluded.
4. **`button.py`** — `wall_button_status` extra-state attribute already skips anything outside the legacy buckets; just a docstring update.
5. **`diagnostics.py`** — added `input_only_count` to the per-install metrics dump so the diagnostic export shows the bucket breakdown.

## Why `type` and not `device_type`

The button entries discovery writes don't carry a `device_type` field, but the human-readable `type` string is set from `mapping.py`'s product table and already discriminates 0x43 vs 0x44 ("Universal interface, switch mode" vs "Universal interface, push-button mode"). Matching on `type` keeps the fix self-contained on the HA side without needing a library bump.

## Test plan

- [x] New regression test `TestReconcilePostDiscovery::test_universal_interface_is_tagged_input_only` covers both 05-058 modes + a control case (regular wall button stays `legacy_undecoded`).
- [x] Updated `test_button_metrics_empty_install` to expect the new `input_only_count` field.
- [x] All 193 tests pass (`pytest tests/`).
- [ ] Verify on a live install with a 05-058 device that the Repairs alert no longer fires.

## Affected installs

Anyone using Niko 05-058 Universal Interfaces (typical wiring: garage doors, contact sensors, motion detectors). Future devices added to `mapping.py` as Category=Button + input-only can be appended to the same set.

https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5)_