### PR TITLE
2.11.2: fix progress bar stuck at 10% / stale "PC Link inventory" status message

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -432,15 +432,24 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             self.discovery_registers_total,
             self.discovery_registers_done + 1,
         )
-        devices_found = len(getattr(self.nikobus_discovery, "discovered_devices", {}) or {})
-        self._update_discovery_state(
-            phase=DISCOVERY_PHASE_PC_LINK,
-            message=(
-                f"PC Link inventory: {self.discovery_registers_done}/"
-                f"{self.discovery_registers_total} registers, "
-                f"{devices_found} device(s) found"
-            ),
-        )
+        # Only own the status message while we're ACTUALLY in the
+        # PC-Link inventory sub-phase. ``parse_inventory_response`` also
+        # receives the per-register ``$2E`` frames during the library's
+        # identity phase (96 reads × N modules), and writing the "PC
+        # Link inventory: X/Y" message here would overwrite the
+        # "Identifying modules (i/N)…" message that
+        # ``_handle_discovery_progress`` just wrote — making the user
+        # think discovery is still in inventory long after it's moved on.
+        if self.discovery_sub_phase == DISCOVERY_SUB_PHASE_INVENTORY:
+            devices_found = len(getattr(self.nikobus_discovery, "discovered_devices", {}) or {})
+            self._update_discovery_state(
+                phase=DISCOVERY_PHASE_PC_LINK,
+                message=(
+                    f"PC Link inventory: {self.discovery_registers_done}/"
+                    f"{self.discovery_registers_total} registers, "
+                    f"{devices_found} device(s) found"
+                ),
+            )
 
     # ------------------------------------------------------------------
     # Phase-aware progress (consumes nikobus-connect 0.3.5+ on_progress)
@@ -1687,13 +1696,34 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         if self.discovery_sub_phase == DISCOVERY_SUB_PHASE_INVENTORY:
             floor = 0
             phase_weight = DISCOVERY_WEIGHT_INVENTORY
-            phase_frac = 0.5  # can't measure inventory fraction directly
+            # 2.11.2: ``parse_inventory_response`` counts each PC-Link
+            # inventory frame into ``discovery_registers_done``, so the
+            # bar can track real progress rather than parking at the
+            # midpoint of the inventory weight. Fall back to 0.5 only
+            # when the total isn't set yet (transition window).
+            if self.discovery_registers_total:
+                phase_frac = min(
+                    1.0,
+                    self.discovery_registers_done / self.discovery_registers_total,
+                )
+            else:
+                phase_frac = 0.5
         elif self.discovery_sub_phase == DISCOVERY_SUB_PHASE_IDENTITY:
             floor = DISCOVERY_WEIGHT_INVENTORY
             phase_weight = DISCOVERY_WEIGHT_IDENTITY
             total = self.discovery_modules_total or 1
             done = self.discovery_modules_done
-            phase_frac = min(1.0, done / total)
+            # 2.11.2: include per-module register progress so the bar
+            # moves smoothly during the ~30 s the library takes to scan
+            # one module's 96 identity registers, instead of jumping
+            # per-module (~0.4 % per step on a 47-module install).
+            per_module = 0.0
+            if self.discovery_registers_total:
+                per_module = min(
+                    1.0,
+                    self.discovery_registers_done / self.discovery_registers_total,
+                )
+            phase_frac = min(1.0, (done + per_module) / total)
         elif self.discovery_sub_phase == DISCOVERY_SUB_PHASE_REGISTER_SCAN:
             floor = DISCOVERY_WEIGHT_INVENTORY + DISCOVERY_WEIGHT_IDENTITY
             phase_weight = DISCOVERY_WEIGHT_REGISTER_SCAN

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7,6 +7,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from nikobus_connect.command import NikobusCommandHandler
 from nikobus_connect.discovery import InventoryQueryType
 
+from custom_components.nikobus.const import (
+    DISCOVERY_SUB_PHASE_IDENTITY,
+    DISCOVERY_SUB_PHASE_INVENTORY,
+)
 from custom_components.nikobus.coordinator import NikobusDataCoordinator
 
 
@@ -365,6 +369,7 @@ class TestDiscoveryFrameRouting(unittest.IsolatedAsyncioTestCase):
         coord.inventory_query_type = InventoryQueryType.PC_LINK
         coord.discovery_registers_done = 0
         coord.discovery_registers_total = 96
+        coord.discovery_sub_phase = DISCOVERY_SUB_PHASE_INVENTORY
         coord._update_discovery_state = MagicMock()
         coord.nikobus_command = MagicMock()
         coord.nikobus_command._command_queue = asyncio.Queue()
@@ -401,6 +406,33 @@ class TestDiscoveryFrameRouting(unittest.IsolatedAsyncioTestCase):
 
         coord.nikobus_discovery.parse_inventory_response.assert_awaited_once_with(data)
         self.assertEqual(coord.discovery_registers_done, 1)
+
+    async def test_inventory_message_written_only_during_inventory_sub_phase(self):
+        """2.11.2: ``parse_inventory_response`` receives BOTH the PC-Link
+        broadcast frames during inventory AND the per-register ``$2E``
+        responses during the library's identity phase (96 reads × N
+        modules). Writing the "PC Link inventory: X/Y" message
+        unconditionally — as pre-2.11.2 did — overwrites the
+        "Identifying modules…" message ``_handle_discovery_progress``
+        sets when the library transitions to identity, freezing the
+        UI in apparent-inventory state long after discovery has moved on.
+
+        Gate: only write the inventory-style message while
+        ``discovery_sub_phase == DISCOVERY_SUB_PHASE_INVENTORY``.
+        """
+        coord = self._make_coordinator_stub()
+        coord.discovery_sub_phase = DISCOVERY_SUB_PHASE_IDENTITY
+        data = "$2EF58603000000030000006C0E000001000000F938E8"
+
+        await coord._discovery_frame_callback(data)
+
+        # Frame still counted toward the register progress bar
+        # (parse_inventory_response is the per-frame increment hook).
+        coord.nikobus_discovery.parse_inventory_response.assert_awaited_once_with(data)
+        self.assertEqual(coord.discovery_registers_done, 1)
+        # But the status message must NOT be touched — keeps whatever
+        # _handle_discovery_progress wrote for the identity phase.
+        coord._update_discovery_state.assert_not_called()
 
     async def test_frame_dropped_when_discovery_not_running(self):
         coord = self._make_coordinator_stub()


### PR DESCRIPTION
## Summary

Fixes two layered bugs that made the discovery progress bar look frozen on installs with many modules:

> Discovery progress: **10.0%**
> Discovery status: **PC Link inventory: 96/96 registers, 47 device(s) found**
> *(while the library is still busy scanning)*

## Bug 1 — Status message clobbered by per-frame callback

`parse_inventory_response` is the bus-frame hook for every PC-Link inventory response (`$18`) **and** every per-register answer (`$2E`) the library receives during the identity phase. Pre-2.11.2 it unconditionally wrote `"PC Link inventory: X/Y registers, Z device(s) found"` every time it ran — so during identity (96 reads × N modules ≈ thousands of frames), the message `_handle_discovery_progress` sets to `"Identifying modules (i/N)…"` got overwritten back to `"PC Link inventory: …"` within milliseconds.

User-visible effect: the UI stays frozen in apparent-inventory state with stale 96/96 numbers (96 = the per-address identity register count, leaked from identity emits into the same counter) while discovery has actually moved on to identity / register-scan.

**Fix:** gate the message write on `discovery_sub_phase == DISCOVERY_SUB_PHASE_INVENTORY`. The per-frame register count still increments (so the bar tracks identity progress); only the status text is left for `_handle_discovery_progress` to own once we're past inventory.

## Bug 2 — Progress percent had two hard-coded 0.5 approximations

`discovery_progress_percent` had:

```python
if self.discovery_sub_phase == DISCOVERY_SUB_PHASE_INVENTORY:
    phase_frac = 0.5  # can't measure inventory fraction directly
elif self.discovery_sub_phase == DISCOVERY_SUB_PHASE_IDENTITY:
    phase_frac = min(1.0, done / total)  # per-module only
```

**Inventory:** the comment is out of date — `parse_inventory_response` already counts PC-Link frames into `discovery_registers_done`. Replaced the hardcoded 0.5 with the real ratio; fall back to 0.5 only during the transition window before `discovery_registers_total` is set.

**Identity:** the previous formula advanced per-module, meaning the bar moved roughly 0.4 % per step on a 47-module install — one step every ~30 s while the library reads that module's 96 identity registers. Now includes a per-module fraction using `registers_done / registers_total` (same pattern as the existing REGISTER_SCAN branch), so the bar moves smoothly within each module.

## Result

Before:
- Bar: stuck at 10 % during entire identity phase (~22 min on 47 modules)
- Text: "PC Link inventory: 96/96 registers, 47 device(s) found" — clobbered by frame callback throughout identity, never updates to "Identifying modules…"

After:
- Bar: 0 % → 10 % over the brief inventory phase, 10 % → 30 % smoothly during identity (per-register granularity inside each module), 30 % → 95 % during register-scan, 95 → 100 % during finalize.
- Text: correctly tracks the active sub-phase — "PC Link inventory: X/96…" during inventory only, then "Identifying modules (i/N)…" during identity, then "Scanning module X (i/N) — pass i/p sub=N — j/k regs" during register-scan.

## Test plan

- [x] All 194 tests pass locally (`pytest tests/`)
- [x] New regression test `test_inventory_message_written_only_during_inventory_sub_phase` in `TestDiscoveryFrameRouting` proves the gate prevents identity-phase message overwrites while still counting frames.
- [ ] Live discovery on a multi-module install: confirm the bar moves smoothly through identity (visible movement every few seconds, not every 30 s), and the status text correctly says "Identifying modules…" not "PC Link inventory…" once inventory has finished.

https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5)_