### PR TITLE
2.11.3: jump to FINALIZING phase during _reconcile_post_discovery

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -1636,6 +1636,22 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         # log — even ``1CEC`` regressed on the retry attempt). We land
         # on FINISHED + clear ``discovery_running`` only after the
         # reconciler returns.
+        #
+        # 2.11.3: bridge the reconciliation gap with FINALIZING so the
+        # progress bar shows real movement (bar jumps to floor of
+        # finalizing = 95%) during the multi-second reconcile/probe/save
+        # window — without this, the bar would freeze at whatever phase
+        # was last live (30% after a PC-Link inventory-only scan that
+        # skips register-scan; 95% after a Scan-All) until the entire
+        # reconciliation completed and we jumped to FINISHED.
+        self.discovery_sub_phase = DISCOVERY_SUB_PHASE_FINALIZING
+        self._update_discovery_state(
+            message=(
+                f"Merging {self.discovery_decoded_records} discovered records…"
+                if self.discovery_decoded_records
+                else "Finalising discovery…"
+            ),
+        )
         await self._reconcile_post_discovery(
             discovered_devices, inventory_query_type
         )

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1485,6 +1485,62 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(coord_with_pc_logic._has_pc_logic_module())
 
 
+class TestHandleDiscoveryFinishedFinalizing(unittest.IsolatedAsyncioTestCase):
+    """2.11.3: ``_handle_discovery_finished`` must transition the sub-phase
+    to FINALIZING *before* ``_reconcile_post_discovery`` runs, so the
+    progress bar moves to the 95% floor instead of staying frozen at
+    whatever the previous phase showed (30% for PC-Link inventory-only,
+    95% for Scan-All) during the multi-second reconciliation work.
+
+    Before this fix, a PC-Link inventory-only scan looked broken end-to-end:
+    bar would climb to 30% during identity, then sit at 30% for the entire
+    reconcile/probe/save window before jumping straight to 100% at the
+    very end. Now the bar jumps to 95% the moment reconciliation starts,
+    so the user sees clear visual progress.
+    """
+
+    async def test_finalizing_set_before_reconcile_runs(self):
+        from custom_components.nikobus.const import (
+            DISCOVERY_SUB_PHASE_FINALIZING,
+            DISCOVERY_SUB_PHASE_IDENTITY,
+        )
+        from custom_components.nikobus.coordinator import NikobusDataCoordinator
+
+        captured: list[str] = []
+
+        coord = MagicMock()
+        coord.discovery_register_current = None
+        coord.discovery_sub_phase = DISCOVERY_SUB_PHASE_IDENTITY
+        coord.discovery_decoded_records = 0
+        coord.discovery_running = True
+        coord._discovery_finished_event = MagicMock()
+        coord._discovery_finished_event.set = MagicMock()
+        coord._discovery_auto_reload = False
+        coord.async_request_refresh = AsyncMock()
+
+        async def fake_reconcile(*args, **kwargs):
+            # Sample what sub_phase looks like the moment reconcile
+            # starts — must be FINALIZING by this point, not IDENTITY.
+            captured.append(coord.discovery_sub_phase)
+
+        coord._reconcile_post_discovery = fake_reconcile
+
+        # Bind real _handle_discovery_finished to the mock
+        coord._handle_discovery_finished = (
+            lambda *args, self_=coord, **kw:
+            NikobusDataCoordinator._handle_discovery_finished(self_, *args, **kw)
+        )
+
+        await coord._handle_discovery_finished()
+
+        self.assertEqual(
+            captured,
+            [DISCOVERY_SUB_PHASE_FINALIZING],
+            "Sub-phase must be FINALIZING before _reconcile_post_discovery runs "
+            f"so the bar advances to the 95% floor; was {captured!r}",
+        )
+
+
 class TestSurfaceLegacyUndecodedButtons(unittest.IsolatedAsyncioTestCase):
     """Direct tests for ``_surface_legacy_undecoded_buttons``.
 


### PR DESCRIPTION
## Summary

Fixes the progress bar freezing during the post-scan reconciliation window. After `_handle_discovery_finished` fires, the coordinator does several seconds of bus probing + button-file saving in `_reconcile_post_discovery` — but the sub-phase stayed at IDENTITY (or REGISTER_SCAN), so the bar parked at whatever percentage that phase reached and didn't move until reconcile completed and we jumped straight to FINISHED.

User-visible effect, especially on **PC-Link inventory-only** scans (which skip REGISTER_SCAN entirely):

```
Discovery progress: 30.0%
Discovery status: Identifying modules (1/1)…
```

…held for the entire post-scan period, then snapped to 100%.

## Fix

The bar formula already had a `FINALIZING` branch (floor=95, weight=5). Nothing transitioned the coordinator into it. Now `_handle_discovery_finished` sets `sub_phase = FINALIZING` and emits the state update **immediately**, before reconciliation begins:

```python
self.discovery_sub_phase = DISCOVERY_SUB_PHASE_FINALIZING
self._update_discovery_state(
    message=(
        f"Merging {self.discovery_decoded_records} discovered records…"
        if self.discovery_decoded_records
        else "Finalising discovery…"
    ),
)
await self._reconcile_post_discovery(discovered_devices, inventory_query_type)
```

## Effect across scan types

| Scan type | Before fix | After fix |
|---|---|---|
| **PC-Link inventory only** | 0→30% (identity), **frozen at 30% during reconcile**, then 100% | 0→30% (identity), **jumps to 95% at reconcile start**, then 100% |
| **Scan-All** | 0→95% (through register-scan), **frozen at 95% during reconcile**, then 100% | unchanged user experience (already at the right floor) |

## Test plan

- [x] All 195 tests pass (`pytest tests/`)
- [x] New `TestHandleDiscoveryFinishedFinalizing::test_finalizing_set_before_reconcile_runs` proves the sub-phase is FINALIZING by the time the reconciler starts executing — captured via a fake reconcile that samples sub_phase on entry.
- [ ] Live test: trigger the PC-Link inventory-only action and confirm the bar visibly jumps to 95% (instead of staying at 30%) the moment identity finishes, then to 100% when reconciliation completes.

https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5)_