### PR TITLE
2.11.6: fix step-1 probe — wait on first PC-Link response, not full inventory

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -174,6 +174,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self.discovery_last_error: str | None = None
         self._discovery_finished_event: asyncio.Event = asyncio.Event()
         self._discovery_finished_event.set()  # idle = already set
+        self._pclink_first_response_event: asyncio.Event = asyncio.Event()
         self._discovery_auto_reload: bool = True
         self._discovery_module_order: list[str] = []
         self._stopping: bool = False
@@ -423,6 +424,10 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         # "3-consecutive-empty-blocks" early-stop is redundant and was
         # removed. The per-module Stage-2 register scan has its own
         # consecutive-give-up logic in the library and is unrelated.
+        # Any PC-Link response proves PC-Link is alive — flag for the
+        # step-1 probe so it can stop waiting and commit to the PC-Link
+        # path instead of timing out and falling back to manual files.
+        self._pclink_first_response_event.set()
         await self.nikobus_discovery.parse_inventory_response(message)
 
         # Count this frame toward the PC Link progress bar.
@@ -1799,10 +1804,19 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             self.discovery_last_error = error
         async_dispatcher_send(self.hass, SIGNAL_DISCOVERY_STATE)
 
-    # Timeout for the PC-Link ``#A`` probe. PC-Link normally responds in
-    # well under 1 s; allowing 10 s leaves headroom for slow buses while
-    # keeping the no-PC-Link fallback responsive.
-    _PCLINK_PROBE_TIMEOUT = 10.0
+    # Timeout for the PC-Link ``#A`` *first-response* probe. PC-Link
+    # normally answers in well under 1 s; 8 s leaves headroom for slow
+    # buses. This is NOT the inventory-completion timeout — the library
+    # owns that (its own 10 s inactivity timer fires
+    # ``on_discovery_finished``). Once we see any PC-Link response we
+    # commit to PC-Link and wait for the full inventory without a
+    # coordinator-side timeout.
+    _PCLINK_PROBE_TIMEOUT = 8.0
+    # After a first-response probe times out we still wait briefly for
+    # the library's inactivity timer (default 10 s) to fire
+    # ``on_discovery_finished`` so state resets cleanly before the
+    # manual-files fallback. Tests override this to keep run-time short.
+    _PCLINK_FINALIZE_WAIT_AFTER_TIMEOUT = 15.0
 
     async def start_pc_link_inventory(self, *, auto_reload: bool = True) -> None:
         """Step 1 of discovery — unified inventory source + friendly-name overlay.
@@ -1892,29 +1906,57 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             _LOGGER.exception("Friendly-name overlay failed; continuing")
 
     async def _try_pclink_inventory(self) -> bool:
-        """Send the ``#A`` broadcast and wait up to
-        ``_PCLINK_PROBE_TIMEOUT`` for the library's discovery-finished
-        callback to fire. Returns True if PC-Link responded, False on
-        timeout. Caller decides what to do with the False case.
+        """Kick off the ``#A`` broadcast and decide if PC-Link is present.
+
+        Two-phase wait:
+
+        1. **First-response probe** — wait up to
+           ``_PCLINK_PROBE_TIMEOUT`` for the *first* inventory frame
+           (``_pclink_first_response_event``, set in
+           ``_discovery_frame_callback``). Any response proves PC-Link is
+           alive on the bus.
+        2. **Full completion** — once PC-Link is confirmed, wait
+           ``_discovery_finished_event`` with NO coordinator timeout
+           (real inventories on big installs take 30–60 s; the library
+           owns inventory-completion timing via its own 10 s inactivity
+           timer).
+
+        Returns True if PC-Link responded, False if the first-response
+        probe times out (caller falls back to manual files). On False
+        we also wait briefly for the library's own ``on_discovery_finished``
+        so the discovery state machine resets cleanly before fallback.
         """
+        self._pclink_first_response_event.clear()
         try:
             await self.nikobus_discovery.start_inventory_discovery()
-            await asyncio.wait_for(
-                self._discovery_finished_event.wait(),
-                timeout=self._PCLINK_PROBE_TIMEOUT,
-            )
-            # If the library populated pc_link in the module store,
-            # PC-Link is present. If it populated nothing or only
-            # output modules, treat as success regardless — the
-            # discovery completed cleanly.
+            try:
+                await asyncio.wait_for(
+                    self._pclink_first_response_event.wait(),
+                    timeout=self._PCLINK_PROBE_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                _LOGGER.info(
+                    "Step 1: no PC-Link response within %.1fs — falling "
+                    "back to manual config files.",
+                    self._PCLINK_PROBE_TIMEOUT,
+                )
+                # Library's inactivity timer will fire on_discovery_finished
+                # shortly; wait for it so state resets before fallback.
+                try:
+                    await asyncio.wait_for(
+                        self._discovery_finished_event.wait(),
+                        timeout=self._PCLINK_FINALIZE_WAIT_AFTER_TIMEOUT,
+                    )
+                except asyncio.TimeoutError:
+                    _LOGGER.warning(
+                        "Step 1: library did not finalise inventory after "
+                        "probe timeout; proceeding with fallback anyway."
+                    )
+                return False
+
+            # PC-Link answered — let the full inventory complete.
+            await self._discovery_finished_event.wait()
             return True
-        except asyncio.TimeoutError:
-            _LOGGER.info(
-                "Step 1: no PC-Link response within %.1fs — falling back "
-                "to manual config files.",
-                self._PCLINK_PROBE_TIMEOUT,
-            )
-            return False
         except asyncio.CancelledError:
             self.discovery_running = False
             self._discovery_finished_event.set()

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.11.5",
+  "version": "2.11.6",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1568,11 +1568,13 @@ class TestUnifiedStep1Discovery(unittest.IsolatedAsyncioTestCase):
         coord.dict_button_data = {"nikobus_button": {}}
         coord.hass = MagicMock()
         coord._discovery_finished_event = asyncio.Event()
+        coord._pclink_first_response_event = asyncio.Event()
         coord._discovery_auto_reload = False
         coord._last_module_scan_was_full = False
         coord._update_discovery_state = MagicMock()
         coord._rebuild_dict_module_data = MagicMock()
-        coord._PCLINK_PROBE_TIMEOUT = 0.05  # speed up timeout in tests
+        coord._PCLINK_PROBE_TIMEOUT = 0.05  # speed up first-response wait
+        coord._PCLINK_FINALIZE_WAIT_AFTER_TIMEOUT = 0.05  # and finalize wait
         coord._try_pclink_inventory = (
             lambda self_=coord:
             NikobusDataCoordinator._try_pclink_inventory(self_)
@@ -1591,7 +1593,9 @@ class TestUnifiedStep1Discovery(unittest.IsolatedAsyncioTestCase):
         coord = self._make_coord()
 
         async def fake_start():
-            # Library "succeeds" — signal completion immediately.
+            # Library "succeeds" — simulate first PC-Link response then
+            # full-completion event (mirrors the real callback sequence).
+            coord._pclink_first_response_event.set()
             coord._discovery_finished_event.set()
 
         coord.nikobus_discovery.start_inventory_discovery.side_effect = (


### PR DESCRIPTION
## The bug

2.11.5 just shipped a unified step-1 (`start_pc_link_inventory`) that probes PC-Link with a 10s timeout, then falls back to manual config files on timeout. On a healthy PC-Link install the user got:

```
22:29:47.076  Sending command: $1410F586B70478BAC9          ← inventory kicks off
22:29:47.154  Bus Frame: $2EF5860900...                       ← PC-Link answers
22:29:47.155  Discovered Button … at Address: 0FFEC0          ← discovery streaming
…  (hundreds of buttons over the next 6 seconds)  …
22:29:53.432  Step 1: no PC-Link response within 10.0s — falling back to manual config files
22:29:53.433  WARNING … neither nikobus_module_config.json nor nikobus_button_config.json was found
22:29:53.434  ERROR … No PC-Link detected on the bus and no manual config files found
```

Discovery is clearly working. The probe is wrong.

**Root cause:** the probe waited on `_discovery_finished_event`, but that event only fires after the *entire* inventory + reconciliation completes (30–60 s on a real install). The 10s coordinator-side timeout always fired first, mis-classified PC-Link as absent, then crashed on the missing manual files.

## The fix

Two-phase wait keyed on the right signals:

| Phase | Waits for | Timeout | Reason |
|---|---|---|---|
| 1. Presence probe | `_pclink_first_response_event` (set on first `$2E` frame in `_discovery_frame_callback`) | 8 s | Any PC-Link response proves it's alive — PC-Link normally answers in <1 s |
| 2. Full inventory | `_discovery_finished_event` | **None** | Library owns inventory-completion timing via its own 10s inactivity timer; coordinator must not race it |

If phase 1 times out (real no-PC-Link install), we wait up to `_PCLINK_FINALIZE_WAIT_AFTER_TIMEOUT` (15 s) for the library's inactivity timer to fire `on_discovery_finished` so state resets cleanly, then fall back to manual files.

## Diff highlights

`coordinator.py`:
- Add `self._pclink_first_response_event` to `__init__`
- Set it in `_discovery_frame_callback` on every PC-Link inventory response (idempotent — only the first one matters)
- Rewrite `_try_pclink_inventory` as the two-phase wait above
- New class attr `_PCLINK_FINALIZE_WAIT_AFTER_TIMEOUT = 15.0`

`tests/test_coordinator.py`:
- `_make_coord()` now adds `_pclink_first_response_event` and overrides `_PCLINK_FINALIZE_WAIT_AFTER_TIMEOUT = 0.05`
- `test_pclink_present_completes_without_fallback` now sets `_pclink_first_response_event` before `_discovery_finished_event` to mirror the real callback sequence

## Test plan

- [x] All 191 tests pass (`pytest tests/`)
- [x] 3 `TestUnifiedStep1Discovery` tests still cover the three branches (PC-Link present / probe-timeout-with-files / probe-timeout-no-files)
- [ ] Live test on the affected PC-Link install: trigger discovery, confirm modules and buttons appear instead of falling back to the manual error

## What changed since 2.11.5

Just the probe semantics. 2.11.5's overall design (unified step-1, manual-files fallback, friendly-name overlay) is intact — only the "is PC-Link present?" detection switched from "did the entire inventory complete in 10s?" to "did we see any inventory response in 8s?".


---
_Generated by [Claude Code](https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5)_