### PR TITLE
2.11.7: pass previous brightness so dimmer LED-feedback gating works

### DIFF
--- a/custom_components/nikobus/light.py
+++ b/custom_components/nikobus/light.py
@@ -161,15 +161,36 @@ class NikobusDimmerEntity(NikobusBaseLight):
             self._optimistic_brightness = None
         super()._handle_nikobus_event(event)
 
+    def _previous_brightness(self) -> int:
+        """Best estimate of the wall LED's current "we last broadcast" state.
+
+        ``led_on`` / ``led_off`` are toggle-on-press button simulations,
+        so the library gates them on a real off ↔ on transition. The
+        gate needs the brightness AS THE LED LAST SAW IT, which is:
+        optimistic (= what we most recently sent, not yet bus-confirmed)
+        if set, otherwise the last bus-confirmed value. Mirrors the
+        composition in ``brightness`` but is read synchronously before
+        we mutate ``_optimistic_brightness`` for the new command.
+        """
+        if self._optimistic_brightness is not None:
+            return self._optimistic_brightness
+        return self.coordinator.get_light_brightness(self._address, self._channel)
+
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the dimmer with optimistic UI update and error fallback."""
-        self._is_on = True
         target_brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
+        prev_brightness = self._previous_brightness()
+        self._is_on = True
         self._optimistic_brightness = target_brightness
-        self.async_write_ha_state() 
-        
+        self.async_write_ha_state()
+
         try:
-            await self.coordinator.api.turn_on_light(self._address, self._channel, target_brightness)
+            await self.coordinator.api.turn_on_light(
+                self._address,
+                self._channel,
+                target_brightness,
+                current_brightness=prev_brightness,
+            )
         except asyncio.CancelledError:
             raise
         except Exception as err:
@@ -180,12 +201,17 @@ class NikobusDimmerEntity(NikobusBaseLight):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the dimmer with optimistic UI update and error fallback."""
+        prev_brightness = self._previous_brightness()
         self._is_on = False
         self._optimistic_brightness = None
-        self.async_write_ha_state() 
-        
+        self.async_write_ha_state()
+
         try:
-            await self.coordinator.api.turn_off_light(self._address, self._channel)
+            await self.coordinator.api.turn_off_light(
+                self._address,
+                self._channel,
+                current_brightness=prev_brightness,
+            )
         except asyncio.CancelledError:
             raise
         except Exception as err:

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.11.5",
+  "version": "2.11.7",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.19.1"
+    "nikobus-connect>=0.19.2"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }


### PR DESCRIPTION
## Summary

Pass the dimmer's previous brightness through to `turn_on_light` / `turn_off_light` so the library's LED-feedback gating (companion PR https://github.com/fdebrus/nikobus-connect/pull/90) actually works. Without this change, the library never knew whether a brightness change was a real off↔on transition, fired `led_on` / `led_off` on every command, and the toggle-on-press wall LED ended up out of sync with the light.

## What changed

`custom_components/nikobus/light.py`:

- New `_previous_brightness()` helper composes `optimistic-or-bus` (same priority the `brightness` property already uses).
- `async_turn_on` reads `prev = _previous_brightness()` **before** mutating `_optimistic_brightness`, then passes `current_brightness=prev`.
- `async_turn_off` same.

Why optimistic-first: during a rapid slider drag, multiple `async_turn_on` calls fire back-to-back before the bus confirms. The second call sees the first call's optimistic value and correctly suppresses the (now redundant) `led_on`. Using bus-confirmed-only would re-fire `led_on` and the LED would flip.

`custom_components/nikobus/manifest.json`:
- Version 2.11.5 → 2.11.7 (skipping 2.11.6 which is the in-flight probe-fix PR #373)
- `nikobus-connect >= 0.19.1` → `>= 0.19.2` to pull in the library-side gate

## Out of scope

- Switches: `turn_on_switch` / `turn_off_switch` go through the library's `_dispatch_action` which has its own pattern; symptoms not reported on switches.
- Covers: different button-face semantics, unconditional firing is correct.
- The "slider to 0 lands on brightness=1" side-issue mentioned in review (separate UI behavior; deferrable).

## Test plan

- [x] All 191 existing HA tests pass (`pytest tests/`)
- [x] Library-side regression tests in nikobus-connect#90 pin the gating contract (8 cases covering both methods)
- [ ] Live verification once both PRs merge: replay the user's trace
  - 0→80 → wall LED ON
  - 80→40 → wall LED stays ON
  - 40→80 → wall LED stays ON
  - 80→1 → wall LED stays ON
  - HA off button → wall LED OFF


---
_Generated by [Claude Code](https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5)_