### PR TITLE
2.11.8: consolidate legacy 1A-only buttons into canonical multi-key form (no-PC-Link only)

### DIFF
--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.11.5",
+  "version": "2.11.8",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/custom_components/nikobus/nkbmanual.py
+++ b/custom_components/nikobus/nkbmanual.py
@@ -519,8 +519,269 @@ async def _apply_button_config(
             )
             op_points_total += 1
 
-    button_data["nikobus_button"] = new_buttons
+    button_data["nikobus_button"] = _consolidate_legacy_1a_only_buttons(new_buttons)
     return len(new_buttons), op_points_total, path
+
+
+# ---------------------------------------------------------------------------
+# Legacy 1A-only → canonical multi-key consolidation (2.11.8+)
+# ---------------------------------------------------------------------------
+#
+# Manual button-config files authored before the multi-key format list each
+# physical wall-button key face as a SEPARATE ``channels=1`` entry with a
+# single ``1A`` operation point — e.g. a 4-key wall plate becomes 4
+# unrelated 1-channel entries. A PC-Link inventory would produce ONE
+# ``channels=4`` entry with ``1A``/``1B``/``1C``/``1D`` op-points instead.
+#
+# The wall-button bus-address encoding is fully reversible: for a 4-key
+# button the top 2 bits of the first hex nibble encode the key face (per
+# ``nikobus_connect.discovery.mapping.KEY_MAPPING``), and the remaining
+# 22 bits identify the physical button. For 8-key buttons the top 3 bits
+# carry the key, leaving 21 bits of identity. We use that to find sibling
+# 1A-only entries and merge them into the canonical multi-key form.
+#
+# Scope: this runs ONLY from the no-PC-Link manual-import path
+# (``_apply_button_config`` → ``async_apply_manual_config`` →
+# coordinator's ``_apply_manual_inventory_as_fallback``). PC-Link installs
+# never hit it; their inventory arrives in canonical form from the library.
+
+# Key-face offset → label, indexed by channel count. Mirror of the
+# library's KEY_MAPPING with the offset as the key for fast lookup.
+_KEY_OFFSET_TO_LABEL: dict[int, dict[int, str]] = {
+    1: {0x8: "1A"},
+    2: {0x8: "1A", 0xC: "1B"},
+    4: {0x8: "1A", 0xC: "1B", 0x0: "1C", 0x4: "1D"},
+    8: {
+        0xA: "1A", 0xE: "1B", 0x2: "1C", 0x6: "1D",
+        0x8: "2A", 0xC: "2B", 0x0: "2C", 0x4: "2D",
+    },
+}
+
+# Physical-id mask per channel count. The bits NOT in the mask encode
+# the key face: 4-key uses top 2 bits of first nibble (mask 0x3FFFFF =
+# 22-bit identity), 8-key uses top 3 bits (mask 0x1FFFFF = 21-bit
+# identity). 1- and 2-key share the 22-bit mask since their offsets
+# all live in the top-2-bits-of-first-nibble space.
+_PHYSICAL_ID_MASK: dict[int, int] = {1: 0x3FFFFF, 2: 0x3FFFFF, 4: 0x3FFFFF, 8: 0x1FFFFF}
+
+
+def _addr_int(addr: str) -> int | None:
+    try:
+        return int(addr, 16)
+    except ValueError:
+        return None
+
+
+def _physical_id_for(addr: str, channels: int) -> str | None:
+    val = _addr_int(addr)
+    mask = _PHYSICAL_ID_MASK.get(channels)
+    if val is None or mask is None:
+        return None
+    return f"{val & mask:06X}"
+
+
+def _key_offset_for(addr: str, channels: int) -> int | None:
+    """Extract the key-face offset value from the first nibble.
+
+    4-key: top 2 bits → offset ∈ {0x0, 0x4, 0x8, 0xC}.
+    8-key: top 3 bits → offset ∈ {0x0, 0x2, 0x4, 0x6, 0x8, 0xA, 0xC, 0xE}.
+    """
+    if not addr:
+        return None
+    try:
+        nib = int(addr[0], 16)
+    except ValueError:
+        return None
+    if channels == 8:
+        return nib & 0xE
+    return nib & 0xC
+
+
+def _try_group(addresses: list[str], channels: int) -> dict[str, str] | None:
+    """Return ``{address: key_label}`` if ``addresses`` form a clean
+    group for the given channel count. ``None`` on any mismatch — the
+    caller falls back to leaving the entries singleton.
+
+    8-key extra check: KEY_MAPPING[8]'s offsets all have bit 0 = 0
+    (values 0,2,4,6,8,A,C,E are all even). A real 8-key button's
+    addresses therefore all have first-nibble bit 0 = 0. Without this
+    guard, two 4-key wall buttons sharing the same lower 21 bits but
+    differing in first-nibble bit 0 would falsely look like one 8-key
+    button — that's exactly the Living_buro case in the user's data.
+    """
+    labels = _KEY_OFFSET_TO_LABEL.get(channels)
+    if labels is None or len(addresses) != channels:
+        return None
+    expected = set(labels.keys())
+    actual: dict[str, int] = {}
+    for a in addresses:
+        try:
+            first_nibble = int(a[0], 16)
+        except (ValueError, IndexError):
+            return None
+        if channels == 8 and (first_nibble & 0x1) != 0:
+            return None
+        offset = _key_offset_for(a, channels)
+        if offset is None or offset not in expected:
+            return None
+        actual[a] = offset
+    if set(actual.values()) != expected:
+        return None
+    return {a: labels[off] for a, off in actual.items()}
+
+
+def _is_consolidation_candidate(entry: dict[str, Any]) -> bool:
+    """True iff ``entry`` is a 1A-only single-face fallback that could
+    be merged into a larger multi-key group."""
+    if entry.get("channels") != 1:
+        return False
+    ops = entry.get("operation_points")
+    if not isinstance(ops, dict) or list(ops.keys()) != ["1A"]:
+        return False
+    return True
+
+
+def _common_description_prefix(descriptions: list[str]) -> str:
+    """Longest shared starting substring, trimmed of trailing separators."""
+    cleaned = [d for d in descriptions if d]
+    if not cleaned:
+        return ""
+    if len(cleaned) == 1:
+        return cleaned[0]
+    common = cleaned[0]
+    for s in cleaned[1:]:
+        while common and not s.startswith(common):
+            common = common[:-1]
+        if not common:
+            return ""
+    return common.rstrip("_- .")
+
+
+def _build_consolidated_entry(
+    source_buttons: dict[str, dict[str, Any]],
+    label_map: dict[str, str],
+    channels: int,
+) -> dict[str, Any]:
+    """Build a canonical multi-key button entry from N 1A-only siblings.
+
+    Each sibling's ``description`` and ``bus_address`` move into the
+    matching op-point. ``linked_modules`` is left empty — step 2 will
+    populate links from the bus. Carries the first sibling's
+    ``type`` / ``model`` if set; uses a common description prefix
+    when one exists, else the first sibling's description.
+    """
+    op_points: dict[str, Any] = {}
+    descriptions: list[str] = []
+    type_str = ""
+    model = ""
+    for addr, label in label_map.items():
+        src = source_buttons[addr]
+        op = src.get("operation_points", {}).get("1A", {})
+        desc = str(src.get("description") or op.get("description") or "").strip()
+        descriptions.append(desc)
+        op_points[label] = {
+            "bus_address": addr,
+            "description": desc or f"#N{addr}",
+            "linked_modules": [],
+        }
+        type_str = type_str or str(src.get("type") or "").strip()
+        model = model or str(src.get("model") or "").strip()
+
+    parent_desc = _common_description_prefix(descriptions) or (descriptions[0] if descriptions else "")
+    return {
+        "type": type_str or "Push button",
+        "model": model,
+        "channels": channels,
+        "description": parent_desc,
+        "operation_points": op_points,
+        "discovered_info": {"source": "manual_config_consolidated"},
+    }
+
+
+def _consolidate_legacy_1a_only_buttons(
+    buttons: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Group legacy 1A-only per-face entries into canonical multi-key
+    buttons by reversing the address-bit encoding.
+
+    Best-effort: candidates that don't form a clean 1/2/4/8-key group
+    stay as singletons. Already-multi-key entries (``channels > 1``)
+    are untouched — the existing grouping wins. Entries whose inferred
+    ``physical_id`` collides with an existing non-candidate entry are
+    also left alone to avoid clobbering authored data.
+
+    Only invoked from the no-PC-Link manual-import path.
+    """
+    # Index candidates by 21-bit physical_id (for 8-key matching) and
+    # by 22-bit physical_id (for 1/2/4-key). A given address goes into
+    # both indexes; the 8-key pass below claims first when applicable.
+    by_21: dict[str, list[str]] = {}
+    by_22: dict[str, list[str]] = {}
+    for addr, entry in buttons.items():
+        if not _is_consolidation_candidate(entry):
+            continue
+        pid_22 = _physical_id_for(addr, 4)
+        if pid_22 is not None:
+            by_22.setdefault(pid_22, []).append(addr)
+        pid_21 = _physical_id_for(addr, 8)
+        if pid_21 is not None:
+            by_21.setdefault(pid_21, []).append(addr)
+
+    consumed: set[str] = set()
+    new_entries: dict[str, dict[str, Any]] = {}
+
+    # Pass 1 — 8-key groups (most constrained; claim these first so
+    # they don't get mis-claimed as a 4-key + half-group of strays).
+    for pid, members in by_21.items():
+        if len(members) != 8:
+            continue
+        if pid in buttons and not _is_consolidation_candidate(buttons[pid]):
+            continue
+        label_map = _try_group(members, 8)
+        if label_map is None:
+            continue
+        new_entries[pid] = _build_consolidated_entry(buttons, label_map, 8)
+        consumed.update(members)
+
+    # Pass 2 — 4/2-key groups from the 22-bit index, skipping anything
+    # already consumed by the 8-key pass. Singletons (would-be 1-key
+    # groups) stay as-is; consolidating them changes nothing and would
+    # mask runtime-auto-add provenance.
+    for pid, members in by_22.items():
+        rem = [a for a in members if a not in consumed]
+        if not rem:
+            continue
+        if pid in buttons and not _is_consolidation_candidate(buttons[pid]):
+            continue
+        for n in (4, 2):
+            if len(rem) != n:
+                continue
+            label_map = _try_group(rem, n)
+            if label_map is None:
+                continue
+            new_entries[pid] = _build_consolidated_entry(buttons, label_map, n)
+            consumed.update(rem)
+            break
+
+    if not consumed:
+        return buttons
+
+    out: dict[str, dict[str, Any]] = {}
+    for addr, entry in buttons.items():
+        if addr in consumed:
+            continue
+        if addr in new_entries:
+            # Singleton at the physical_id itself — defensive; the
+            # consolidated form is the canonical one to keep.
+            continue
+        out[addr] = entry
+    out.update(new_entries)
+    _LOGGER.info(
+        "Manual-config: consolidated %d 1A-only button faces into "
+        "%d canonical multi-key button(s).",
+        len(consumed), len(new_entries),
+    )
+    return out
 
 
 async def async_apply_manual_config(

--- a/tests/test_manual_config.py
+++ b/tests/test_manual_config.py
@@ -1102,5 +1102,308 @@ class TestApplyFriendlyNameOverlay(unittest.TestCase):
         )
 
 
+class TestConsolidateLegacy1AOnlyButtons(unittest.TestCase):
+    """2.11.8: no-PC-Link installs whose manual button-config lists each
+    wall-button key face as a separate ``channels=1`` / 1A-only entry
+    get those siblings consolidated into the canonical multi-key form
+    that PC-Link inventory would have produced.
+
+    Math under test (mirror of nikobus_connect KEY_MAPPING):
+
+      4-key wall button: first nibble's top 2 bits encode the key face
+        0x8 → 1A,  0xC → 1B,  0x0 → 1C,  0x4 → 1D
+      8-key: top 3 bits encode the face
+        0xA → 1A, 0xE → 1B, 0x2 → 1C, 0x6 → 1D,
+        0x8 → 2A, 0xC → 2B, 0x0 → 2C, 0x4 → 2D
+    """
+
+    def _candidate(self, bus_addr: str, description: str) -> dict:
+        return {
+            "type": "Manual button",
+            "model": "",
+            "channels": 1,
+            "description": description,
+            "operation_points": {
+                "1A": {
+                    "bus_address": bus_addr,
+                    "description": description,
+                    "linked_modules": [],
+                }
+            },
+        }
+
+    def test_buro_deur_real_user_data_consolidates_to_one_4key_button(self):
+        """The user's actual Buro_deur wall plate: 4 siblings sharing
+        physical_id 11C5CE, top 2 bits 10/11/00/01 → 1A/1B/1C/1D."""
+        raw = {
+            "91C5CE": self._candidate("91C5CE", "Buro_deur_B1"),
+            "D1C5CE": self._candidate("D1C5CE", "Buro_deur_O1"),
+            "11C5CE": self._candidate("11C5CE", "Buro_deur_B2"),
+            "51C5CE": self._candidate("51C5CE", "Buro_deur_O2"),
+        }
+
+        result = nkbmanual._consolidate_legacy_1a_only_buttons(raw)
+
+        # All 4 face entries replaced by one canonical entry at physical_id.
+        self.assertEqual(list(result.keys()), ["11C5CE"])
+        entry = result["11C5CE"]
+        self.assertEqual(entry["channels"], 4)
+        self.assertEqual(entry["description"], "Buro_deur")  # common prefix
+        self.assertEqual(
+            set(entry["operation_points"].keys()), {"1A", "1B", "1C", "1D"}
+        )
+        # Bus addresses preserved under correct labels.
+        self.assertEqual(entry["operation_points"]["1A"]["bus_address"], "91C5CE")
+        self.assertEqual(entry["operation_points"]["1B"]["bus_address"], "D1C5CE")
+        self.assertEqual(entry["operation_points"]["1C"]["bus_address"], "11C5CE")
+        self.assertEqual(entry["operation_points"]["1D"]["bus_address"], "51C5CE")
+        # Descriptions preserved per face.
+        self.assertEqual(
+            entry["operation_points"]["1A"]["description"], "Buro_deur_B1"
+        )
+        # linked_modules always empty after step 1.
+        self.assertEqual(entry["operation_points"]["1A"]["linked_modules"], [])
+        # Provenance tag distinguishes from manual_config (un-consolidated).
+        self.assertEqual(
+            entry["discovered_info"]["source"], "manual_config_consolidated"
+        )
+
+    def test_living_buro_8_addresses_split_into_two_4key_buttons(self):
+        """Living_buro has 8 buttons that share trailing hex 9E0CE but
+        differ in the bottom 2 bits of the first nibble — that's TWO
+        physical 4-key buttons, not one 8-key. Bottom bits 01 → 19E0CE,
+        bottom bits 11 → 39E0CE."""
+        raw = {
+            # Group 1: physical_id 19E0CE (first-nibble bottom bits = 01)
+            "99E0CE": self._candidate("99E0CE", "Living_buro_B3"),
+            "D9E0CE": self._candidate("D9E0CE", "Living_buro_O3"),
+            "19E0CE": self._candidate("19E0CE", "Living_buro_B4"),
+            "59E0CE": self._candidate("59E0CE", "Living_buro_O4"),
+            # Group 2: physical_id 39E0CE (first-nibble bottom bits = 11)
+            "B9E0CE": self._candidate("B9E0CE", "Living_buro_B1"),
+            "F9E0CE": self._candidate("F9E0CE", "Living_buro_O1"),
+            "39E0CE": self._candidate("39E0CE", "Living_buro_B2"),
+            "79E0CE": self._candidate("79E0CE", "Living_buro_O2"),
+        }
+
+        result = nkbmanual._consolidate_legacy_1a_only_buttons(raw)
+
+        self.assertEqual(set(result.keys()), {"19E0CE", "39E0CE"})
+        for pid in ("19E0CE", "39E0CE"):
+            self.assertEqual(result[pid]["channels"], 4)
+            self.assertEqual(
+                set(result[pid]["operation_points"].keys()),
+                {"1A", "1B", "1C", "1D"},
+            )
+
+    def test_partial_3_of_4_group_is_NOT_consolidated(self):
+        """Best-effort: if the user only listed 3 of 4 faces, leave
+        them as singletons rather than mis-grouping as 2-key + orphan."""
+        raw = {
+            "91C5CE": self._candidate("91C5CE", "Half_B1"),
+            "D1C5CE": self._candidate("D1C5CE", "Half_O1"),
+            "11C5CE": self._candidate("11C5CE", "Half_B2"),
+            # 51C5CE (1D) intentionally absent
+        }
+
+        result = nkbmanual._consolidate_legacy_1a_only_buttons(raw)
+
+        # Nothing matched a clean 1/2/4/8-key group → all kept singleton.
+        self.assertEqual(set(result.keys()), {"91C5CE", "D1C5CE", "11C5CE"})
+        for entry in result.values():
+            self.assertEqual(entry["channels"], 1)
+
+    def test_two_key_button_consolidates(self):
+        """2-key wall button: two siblings with top 2 bits 10 and 11."""
+        raw = {
+            "8A5500": self._candidate("8A5500", "Toggle_on"),
+            "CA5500": self._candidate("CA5500", "Toggle_off"),
+        }
+
+        result = nkbmanual._consolidate_legacy_1a_only_buttons(raw)
+
+        self.assertEqual(list(result.keys()), ["0A5500"])
+        entry = result["0A5500"]
+        self.assertEqual(entry["channels"], 2)
+        self.assertEqual(set(entry["operation_points"].keys()), {"1A", "1B"})
+        self.assertEqual(entry["operation_points"]["1A"]["bus_address"], "8A5500")
+        self.assertEqual(entry["operation_points"]["1B"]["bus_address"], "CA5500")
+
+    def test_eight_key_button_consolidates(self):
+        """8-key wall button: 8 siblings with all even high nibbles
+        sharing the same lower 21 bits."""
+        # physical_id = 0x000123 (21 bits). All members have bit 0 of
+        # first nibble = 0, and first nibble's top 3 bits cover all 8
+        # values from KEY_MAPPING[8].
+        raw = {
+            "A00123": self._candidate("A00123", "Kitchen_1A"),
+            "E00123": self._candidate("E00123", "Kitchen_1B"),
+            "200123": self._candidate("200123", "Kitchen_1C"),
+            "600123": self._candidate("600123", "Kitchen_1D"),
+            "800123": self._candidate("800123", "Kitchen_2A"),
+            "C00123": self._candidate("C00123", "Kitchen_2B"),
+            "000123": self._candidate("000123", "Kitchen_2C"),
+            "400123": self._candidate("400123", "Kitchen_2D"),
+        }
+
+        result = nkbmanual._consolidate_legacy_1a_only_buttons(raw)
+
+        # Single consolidated entry at the 21-bit physical_id.
+        self.assertEqual(list(result.keys()), ["000123"])
+        entry = result["000123"]
+        self.assertEqual(entry["channels"], 8)
+        self.assertEqual(
+            set(entry["operation_points"].keys()),
+            {"1A", "1B", "1C", "1D", "2A", "2B", "2C", "2D"},
+        )
+
+    def test_singleton_orphan_passes_through(self):
+        """A lone 1A-only entry with no siblings stays as it is —
+        consolidating a 1-key would change nothing meaningful and would
+        mask runtime-auto-add provenance."""
+        raw = {"E39EF7": self._candidate("E39EF7", "Lone runtime button")}
+
+        result = nkbmanual._consolidate_legacy_1a_only_buttons(raw)
+
+        self.assertEqual(result, raw)
+
+    def test_already_multi_key_entry_is_untouched(self):
+        """An entry authored in canonical form (channels>1) is left
+        completely alone — explicit grouping wins over inference."""
+        raw = {
+            "11C5CE": {
+                "type": "Push button",
+                "model": "05-064",
+                "channels": 4,
+                "description": "Already grouped",
+                "operation_points": {
+                    "1A": {"bus_address": "91C5CE", "description": "A",
+                           "linked_modules": []},
+                    "1B": {"bus_address": "D1C5CE", "description": "B",
+                           "linked_modules": []},
+                    "1C": {"bus_address": "11C5CE", "description": "C",
+                           "linked_modules": []},
+                    "1D": {"bus_address": "51C5CE", "description": "D",
+                           "linked_modules": []},
+                },
+            },
+            # A stray 1A-only sibling that would *naïvely* group at
+            # 11C5CE — must NOT clobber the authored entry above.
+            "BEEF00": self._candidate("BEEF00", "Unrelated stray"),
+        }
+
+        result = nkbmanual._consolidate_legacy_1a_only_buttons(raw)
+
+        self.assertEqual(result["11C5CE"]["description"], "Already grouped")
+        self.assertEqual(result["11C5CE"]["channels"], 4)
+        # Stray stays singleton.
+        self.assertEqual(result["BEEF00"]["channels"], 1)
+
+    def test_collision_with_existing_authored_entry_skips_consolidation(self):
+        """If 4 candidate siblings would consolidate to a physical_id
+        that ALREADY has a non-candidate entry, leave the candidates
+        alone rather than overwrite authored data."""
+        raw = {
+            "11C5CE": {
+                "type": "Authored",
+                "model": "",
+                "channels": 1,
+                "description": "Not a candidate (extra field)",
+                "operation_points": {
+                    "1A": {"bus_address": "11C5CE", "description": "A",
+                           "linked_modules": []},
+                    "scene_1": {"bus_address": "11C5CE", "description": "scene",
+                                "linked_modules": []},
+                },
+            },
+            "91C5CE": self._candidate("91C5CE", "would_be_1A"),
+            "D1C5CE": self._candidate("D1C5CE", "would_be_1B"),
+            "51C5CE": self._candidate("51C5CE", "would_be_1D"),
+        }
+
+        result = nkbmanual._consolidate_legacy_1a_only_buttons(raw)
+
+        # 11C5CE stays as authored (multi op-point on a 1-channel entry).
+        self.assertIs(result["11C5CE"], raw["11C5CE"])
+        # The 3 candidate siblings can't form a clean 4-key group (only
+        # 3 of 4 offsets present) so they stay singleton anyway.
+        for addr in ("91C5CE", "D1C5CE", "51C5CE"):
+            self.assertEqual(result[addr]["channels"], 1)
+
+    def test_runtime_discovered_singletons_are_kept_untouched(self):
+        """The `DISCOVERED -` runtime-auto-add entries with no siblings
+        in the manual file (e.g. bus-noise FF-prefix addresses) stay as
+        singletons — we don't have enough info to safely group them."""
+        raw = {
+            "FFFB82": self._candidate(
+                "FFFB82", "DISCOVERED - Nikobus Button #NFFFB82"
+            ),
+            "050000": self._candidate(
+                "050000", "DISCOVERED - Nikobus Button #N050000"
+            ),
+        }
+
+        result = nkbmanual._consolidate_legacy_1a_only_buttons(raw)
+
+        self.assertEqual(set(result.keys()), {"FFFB82", "050000"})
+        for entry in result.values():
+            self.assertEqual(entry["channels"], 1)
+
+    def test_empty_input_returns_empty(self):
+        self.assertEqual(nkbmanual._consolidate_legacy_1a_only_buttons({}), {})
+
+
+class TestConsolidationEndToEnd(unittest.TestCase):
+    """End-to-end: apply_manual_config with the user's actual file shape
+    consolidates 1A-only entries into multi-key buttons."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.config_dir = self.tmp.name
+        self.hass = _FakeHass(self.config_dir)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _write(self, filename: str, data: dict) -> str:
+        path = os.path.join(self.config_dir, filename)
+        with open(path, "w") as fh:
+            json.dump(data, fh)
+        return path
+
+    def test_user_reported_file_shape_consolidates(self):
+        """Replays the user's manual button file shape end-to-end through
+        async_apply_manual_config. The v1 input format is a list of
+        ``{address, description}`` entries with no ``linked_button``
+        block — every entry takes the ``_single_key_fallback`` branch,
+        producing 1A-only fallback entries that consolidation merges."""
+        self._write(
+            "nikobus_button_config.json",
+            {
+                "nikobus_button": [
+                    {"address": "91C5CE", "description": "Buro_deur_B1"},
+                    {"address": "D1C5CE", "description": "Buro_deur_O1"},
+                    {"address": "11C5CE", "description": "Buro_deur_B2"},
+                    {"address": "51C5CE", "description": "Buro_deur_O2"},
+                ]
+            }
+        )
+        store = _InMemoryModuleStore()
+        button_data = {"nikobus_button": {}}
+
+        changed = _run(
+            nkbmanual.async_apply_manual_config(self.hass, store, button_data)
+        )
+
+        self.assertTrue(changed)
+        # 4 face entries collapsed to one canonical multi-key entry.
+        self.assertEqual(list(button_data["nikobus_button"].keys()), ["11C5CE"])
+        entry = button_data["nikobus_button"]["11C5CE"]
+        self.assertEqual(entry["channels"], 4)
+        self.assertEqual(
+            set(entry["operation_points"].keys()), {"1A", "1B", "1C", "1D"}
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What this does

Reconstructs the canonical multi-key button form (`channels=4`, op-points `1A`/`1B`/`1C`/`1D`) from the legacy 1A-only single-face entries that no-PC-Link manual config files carry. Reverses the well-known wall-button address-bit encoding to identify siblings.

**Strict scope guarantee:** invoked only from `_apply_button_config` → `_apply_manual_inventory_as_fallback`, which only runs when the PC-Link probe fails. PC-Link install logic and the friendly-name overlay (`async_apply_friendly_name_overlay`) are untouched.

## The encoding (mirror of `nikobus_connect.discovery.mapping.KEY_MAPPING`)

For a **4-key** wall button, the top 2 bits of the first hex nibble encode the key face; the remaining 22 bits are the physical button identity:

| Key | Offset | Top 2 bits |
|---|---|---|
| 1A | `0x8` | `10` |
| 1B | `0xC` | `11` |
| 1C | `0x0` | `00` |
| 1D | `0x4` | `01` |

For **8-key** buttons, the top 3 bits carry the face (all offsets `{0,2,4,6,8,A,C,E}` are even → bit 0 must equal 0), and the remaining 21 bits identify the button.

## Worked example from real user data

User's `Buro_deur` wall plate (4 separate entries in the file):

| Bus addr | First nibble | Top 2 bits | Physical id | Label |
|---|---|---|---|---|
| `91C5CE` | 1001 | 10 | `11C5CE` | 1A |
| `D1C5CE` | 1101 | 11 | `11C5CE` | 1B |
| `11C5CE` | 0001 | 00 | `11C5CE` | 1C |
| `51C5CE` | 0101 | 01 | `11C5CE` | 1D |

→ consolidates to ONE entry at `11C5CE` with four op-points, descriptions preserved per face.

`Living_buro` (8 entries, all with first-nibble bit 0 = 1) correctly splits into TWO 4-key buttons (`19E0CE` and `39E0CE`), NOT one 8-key — because real 8-key buttons require bit 0 = 0 on every member.

## Safety rails

- **Partial groups** (e.g. 3 of 4 faces listed) stay as singletons — no false merging.
- **Already-multi-key entries** (channels > 1) are untouched. Explicit grouping wins over inference.
- **Physical-id collisions** with authored entries skip consolidation.
- **Runtime auto-adds** (`DISCOVERED - …` placeholders, often bus noise) stay as singletons when they have no siblings.

## Files

- `custom_components/nikobus/nkbmanual.py` — adds `_consolidate_legacy_1a_only_buttons` and the supporting math helpers. Wired into `_apply_button_config` only.
- `tests/test_manual_config.py` — 10 new tests covering the user's actual data shape, both 4-key and 8-key groupings, edge cases (partial groups, collisions, runtime auto-adds, singletons, 2-key, 8-key) and one end-to-end test through `async_apply_manual_config`.

## Test plan

- [x] All 202 tests pass (`pytest tests/`)
- [x] Real-world user data (Buro_deur, Living_buro) produces expected canonical form
- [ ] Live verification on the affected no-PC-Link install: drop manual file, reload, confirm canonical multi-key entries in the storage; then run "Scan all module links" and verify `linked_modules` populates correctly through the library's bus-address-lookup path

## PC-Link users — explicit invariant

`async_apply_friendly_name_overlay` (which runs for both PC-Link and no-PC-Link users) does NOT call the consolidation. It enriches user-editable fields (descriptions, entity_type, LED triggers) on existing live entries only. PC-Link's authoritative inventory shape is preserved.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5)_