### PR TITLE
2.11.9: silence misleading "no manual files" warning on PC-Link startup

### DIFF
--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.11.8",
+  "version": "2.11.9",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/custom_components/nikobus/nkbmanual.py
+++ b/custom_components/nikobus/nkbmanual.py
@@ -829,9 +829,13 @@ async def async_apply_manual_config(
         button_path = None
 
     if module_path is None and button_path is None:
-        _LOGGER.warning(
-            "Manual-config enabled but neither %s nor %s was found in %s. "
-            "Place at least one file there and reload the integration.",
+        # No manual files present — normal state for PC-Link users.
+        # The no-PC-Link fallback path raises ``no_inventory_source``
+        # via the discovery flow if the user actually needs files;
+        # silently no-op here so PC-Link installs don't log noise on
+        # every startup.
+        _LOGGER.debug(
+            "Manual-config: neither %s nor %s present in %s; skipping import.",
             MANUAL_MODULE_CONFIG_FILENAME,
             MANUAL_BUTTON_CONFIG_FILENAME,
             hass.config.path(""),


### PR DESCRIPTION
## The bug

PC-Link users see this in the log on every integration startup:

```
WARNING (MainThread) [custom_components.nikobus.nkbmanual]
Manual-config enabled but neither nikobus_module_config.json nor nikobus_button_config.json
was found in /config/. Place at least one file there and reload the integration.
```

The user does not have manual-config "enabled" — they have a PC-Link and never needed manual files. The message is misleading and not actionable.

## Root cause

`coordinator.py:260` calls `async_apply_manual_config` unconditionally at startup (a 2.11.4-era declarative-import hook). The function fires the WARNING when no files exist, regardless of whether they were ever meant to.

## The fix

Downgrade the no-files message at `nkbmanual.py:831` to DEBUG. Rationale:

- "No manual files at startup" is the **normal state** for PC-Link users — there's nothing to fix.
- For no-PC-Link users who genuinely need files, the discovery flow has its own explicit guard: `_apply_manual_inventory_as_fallback` raises `HomeAssistantError(translation_key="no_inventory_source")` with a translated, user-facing message when the probe times out AND no files exist. That's where the error belongs — it's actionable then.

So the only callers that lose the warning are the ones where no warning was warranted in the first place.

## Test plan

- [x] All 202 tests pass (`pytest tests/`)
- [ ] Live: PC-Link install reload — confirm no warning in logs
- [ ] Live: no-PC-Link install with no files — press discovery, confirm the i18n `no_inventory_source` error still surfaces in the UI


---
_Generated by [Claude Code](https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5)_