### PR TITLE
2.12.0: surface library-classified CF activation broadcasts as HA scenes

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -59,7 +59,11 @@ from .const import (
 from .nkbactuator import NikobusActuator
 from .nkbconfig import NikobusConfig
 from .nkbmanual import async_apply_manual_config
-from .nkbstorage import NikobusButtonStorage, NikobusModuleStorage
+from .nkbstorage import (
+    NikobusButtonStorage,
+    NikobusCFStorage,
+    NikobusModuleStorage,
+)
 
 # Typed config entry alias used across the integration. A plain alias
 # (instead of PEP 695 `type X = ...`) keeps compatibility with older
@@ -121,6 +125,10 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self.nikobus_config = NikobusConfig(hass)
         self.button_storage = NikobusButtonStorage(hass)
         self.module_storage = NikobusModuleStorage(hass)
+        # CF broadcasts persisted across HA restarts. Populated by
+        # ``_ingest_cf_broadcasts`` after each discovery completes from
+        # the library's ``NikobusDiscovery.discovered_cf_broadcasts``.
+        self.cf_storage = NikobusCFStorage(hass)
         self.api: NikobusAPI | None = None
 
         # ``dict_module_data`` is a derived view of ``module_storage.data``,
@@ -249,6 +257,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             self._rebuild_dict_module_data()
 
             self.dict_button_data = await self.button_storage.async_load()
+            await self.cf_storage.async_load()
 
             # 2.11.4: manual config files are the step-1 inventory source
             # for installs without a PC-Link (Feedback-module-only users).
@@ -1406,6 +1415,85 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             },
         )
 
+    async def _ingest_cf_broadcasts(self) -> None:
+        """Persist the library's classified CF broadcasts into our store.
+
+        Library-side (nikobus-connect 0.20.0+):
+        ``NikobusDiscovery._classify_cf_broadcasts_from_unmatched`` runs
+        at end-of-scan, pulls the ``38 41 XX`` (switch-pair) and
+        ``38 80 XX`` (roller-pair) addresses out of the unmatched
+        accumulator, attaches their (module, channel, mode) members
+        from the command mapping, and exposes a ``CFBroadcast`` dict
+        on ``discovered_cf_broadcasts``.
+
+        We mirror that dict into ``cf_storage`` as a plain JSON-safe
+        shape: ``{"nikobus_cf": {bus_address: {pattern, outputs}}}``.
+        Persisting means scene entities survive across HA restarts;
+        the next discovery refreshes the data idempotently.
+        """
+        if self.nikobus_discovery is None:
+            return
+        broadcasts = getattr(
+            self.nikobus_discovery, "discovered_cf_broadcasts", None
+        )
+        if not broadcasts:
+            # Library didn't classify anything this scan — preserve
+            # whatever was persisted last time. (Don't wipe; a re-scan
+            # that hits an empty bus shouldn't lose the user's scenes.)
+            return
+
+        flat: dict[str, dict[str, Any]] = {}
+        for addr, cf in broadcasts.items():
+            outputs = [
+                {
+                    "module_address": str(m.module_address).upper(),
+                    "channel": int(m.channel),
+                    "mode": str(m.mode),
+                    "t1": getattr(m, "t1", None),
+                    "t2": getattr(m, "t2", None),
+                }
+                for m in getattr(cf, "outputs", [])
+            ]
+            flat[str(addr).upper()] = {
+                "bus_address": str(getattr(cf, "bus_address", addr)).upper(),
+                "pattern": str(getattr(cf, "pattern", "unknown")),
+                "outputs": outputs,
+            }
+
+        self.cf_storage.data["nikobus_cf"] = flat
+        await self.cf_storage.async_save()
+        _LOGGER.info(
+            "CF broadcasts persisted: %d entries (%s)",
+            len(flat),
+            sorted(flat.keys()),
+        )
+
+    async def async_activate_cf_broadcast(self, bus_address: str) -> None:
+        """Send the bus frame that activates a classified CF.
+
+        Each CF broadcast address (``38 41 XX`` or ``38 80 XX``) is
+        what PC-Logic emits when the CF is activated by a wall button
+        or remote. Output modules participating in the CF carry the
+        link records that trigger their channels on this address. From
+        HA we send the same frame format used for wall-button
+        simulations: ``#N{addr}\\r#E1``. The output modules then fire
+        in unison — single-frame atomic activation, no per-channel
+        round-trip.
+        """
+        if not bus_address:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="cf_no_address",
+            )
+        if not self.nikobus_command:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="not_connected",
+            )
+        addr = bus_address.upper()
+        _LOGGER.info("Activating Nikobus CF broadcast: %s", addr)
+        await self.nikobus_command.queue_command(f"#N{addr}\r#E1")
+
     async def _reconcile_post_discovery(
         self,
         discovered_devices: dict | None = None,
@@ -1585,6 +1673,13 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             and self._last_module_scan_was_full
         ):
             self._surface_legacy_undecoded_buttons(buttons)
+
+        # Ingest the library's classified CF activation broadcasts (the
+        # ``38 41 XX`` / ``38 80 XX`` addresses surfaced by
+        # ``_classify_cf_broadcasts_from_unmatched``). Persists into the
+        # CF store so scene entities survive HA restarts even when the
+        # next discovery hasn't run yet.
+        await self._ingest_cf_broadcasts()
 
         # Persist. Both stores save unconditionally so the ``status``
         # field on buttons + the eviction on modules land on disk.

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.11.9",
+  "version": "2.12.0",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.19.2"
+    "nikobus-connect>=0.20.0"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }

--- a/custom_components/nikobus/nkbstorage.py
+++ b/custom_components/nikobus/nkbstorage.py
@@ -42,6 +42,9 @@ BUTTON_STORAGE_VERSION = 1
 MODULE_STORAGE_KEY = "nikobus.modules"
 MODULE_STORAGE_VERSION = 1
 
+CF_STORAGE_KEY = "nikobus.cfs"
+CF_STORAGE_VERSION = 1
+
 
 class NikobusButtonStorage:
     """Wrap a HA ``Store`` for button discovery data."""
@@ -107,3 +110,42 @@ class NikobusModuleStorage:
     def is_empty(self) -> bool:
         """Return True when no modules are registered yet."""
         return not bool(self._data.get("nikobus_module"))
+
+
+class NikobusCFStorage:
+    """Wrap a HA ``Store`` for classified CF (Central Function) broadcasts.
+
+    Persists the dict the library populates on ``NikobusDiscovery.
+    discovered_cf_broadcasts`` after each discovery completes — each
+    entry is a ``{bus_address, pattern, outputs}`` record describing a
+    CF activation broadcast and its target output channels. Survives
+    across HA restarts so scene entities don't disappear when discovery
+    isn't re-run.
+
+    Storage shape: ``{"nikobus_cf": {bus_address: {...}}}``.
+    """
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        self._store: Store[dict[str, Any]] = Store(
+            hass, CF_STORAGE_VERSION, CF_STORAGE_KEY
+        )
+        self._data: dict[str, Any] = {"nikobus_cf": {}}
+
+    async def async_load(self) -> dict[str, Any]:
+        loaded = await self._store.async_load()
+        if isinstance(loaded, dict) and isinstance(loaded.get("nikobus_cf"), dict):
+            self._data = loaded
+        else:
+            self._data = {"nikobus_cf": {}}
+        return self._data
+
+    async def async_save(self) -> None:
+        await self._store.async_save(self._data)
+
+    @property
+    def data(self) -> dict[str, Any]:
+        return self._data
+
+    @property
+    def is_empty(self) -> bool:
+        return not bool(self._data.get("nikobus_cf"))

--- a/custom_components/nikobus/scene.py
+++ b/custom_components/nikobus/scene.py
@@ -36,29 +36,114 @@ async def async_setup_entry(
     entry: NikobusConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up Nikobus scenes from a config entry."""
+    """Set up Nikobus scenes from a config entry.
+
+    Two sources contribute scene entities:
+
+    1. **User-authored scenes** from ``nikobus_scene_config.json``
+       (legacy software-scene path: HA-side fan-out over individual
+       module channels). One :class:`NikobusSceneEntity` per entry.
+    2. **CF activation broadcasts** classified by the library during
+       discovery (``38 41 XX`` / ``38 80 XX`` addresses). One
+       :class:`NikobusCFSceneEntity` per entry — activation = single
+       bus-frame broadcast, output modules fire atomically via their
+       existing link records.
+    """
     coordinator: NikobusDataCoordinator = entry.runtime_data
-    entities: list[NikobusSceneEntity] = []
+    entities: list[Scene] = []
 
-    if not coordinator.dict_scene_data:
-        return
+    if coordinator.dict_scene_data:
+        scenes = coordinator.dict_scene_data.get("scene", [])
 
-    scenes = coordinator.dict_scene_data.get("scene", [])
+        for scene in scenes:
+            scene_id = scene.get("id")
+            if not scene_id:
+                _LOGGER.warning("Skipping Nikobus scene with missing ID")
+                continue
 
-    for scene in scenes:
-        scene_id = scene.get("id")
-        if not scene_id:
-            _LOGGER.warning("Skipping Nikobus scene with missing ID")
+            entities.append(
+                NikobusSceneEntity(
+                    coordinator=coordinator,
+                    scene_config=scene,
+                )
+            )
+
+    cf_data = coordinator.cf_storage.data.get("nikobus_cf", {}) if coordinator.cf_storage else {}
+    for bus_address, cf in cf_data.items():
+        if not isinstance(cf, dict):
             continue
-
         entities.append(
-            NikobusSceneEntity(
+            NikobusCFSceneEntity(
                 coordinator=coordinator,
-                scene_config=scene,
+                bus_address=bus_address,
+                cf_config=cf,
             )
         )
 
     async_add_entities(entities)
+
+
+class NikobusCFSceneEntity(NikobusEntity, Scene):
+    """A Central Function activation broadcast surfaced as an HA scene.
+
+    Activation sends a single bus frame (``#N<bus_address>\\r#E1``) —
+    the same shape a wall button or remote produces. Output modules
+    with link records pointing to ``bus_address`` fire their linked
+    actions in unison; no HA-side per-channel fan-out needed.
+
+    Pattern + member list are surfaced as entity attributes so a user
+    (or a future typed-mapping pass) can identify roller-pair vs
+    switch-pair CFs without reaching into storage.
+    """
+
+    def __init__(
+        self,
+        coordinator: NikobusDataCoordinator,
+        bus_address: str,
+        cf_config: dict[str, Any],
+    ) -> None:
+        addr = str(bus_address).upper()
+        pattern = str(cf_config.get("pattern") or "unknown")
+        outputs = cf_config.get("outputs") or []
+        member_count = len(outputs) if isinstance(outputs, list) else 0
+
+        # Build a default friendly name from what we know on the bus.
+        # The .nkb-derived user name (if/when the integration ingests
+        # the file) will replace this via the standard HA rename flow.
+        if pattern == "switch_pair":
+            name = f"Nikobus switch CF {addr} ({member_count} ch)"
+        elif pattern == "roller_pair":
+            name = f"Nikobus roller CF {addr} ({member_count} ch)"
+        else:
+            name = f"Nikobus CF {addr} ({member_count} ch)"
+
+        super().__init__(
+            coordinator=coordinator,
+            address=addr,
+            name=name,
+            model=f"CF Broadcast ({pattern})",
+            via_device=(DOMAIN, CATEGORY_SCENES),
+        )
+        self._bus_address = addr
+        self._pattern = pattern
+        self._outputs = outputs if isinstance(outputs, list) else []
+        self._attr_name = name
+        self._attr_unique_id = f"nikobus_cf_{addr.lower()}"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        parent = super().extra_state_attributes or {}
+        return {
+            **parent,
+            "bus_address": self._bus_address,
+            "pattern": self._pattern,
+            "member_count": len(self._outputs),
+            "outputs": self._outputs,
+        }
+
+    async def async_activate(self, **kwargs: Any) -> None:
+        """Send the CF activation broadcast on the bus."""
+        await self.coordinator.async_activate_cf_broadcast(self._bus_address)
 
 
 class NikobusSceneEntity(NikobusEntity, Scene):

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -149,6 +149,12 @@
         },
         "no_inventory_source": {
             "message": "No PC-Link detected on the bus and no manual config files found. Either install a PC-Link or create nikobus_module_config.json (and optionally nikobus_button_config.json) in your Home Assistant config directory, then retry."
+        },
+        "cf_no_address": {
+            "message": "Cannot activate a Nikobus CF without a bus address."
+        },
+        "not_connected": {
+            "message": "Nikobus bus is not connected — cannot send a command. Check the connection and retry."
         }
     },
     "options": {

--- a/tests/test_cf_ingest.py
+++ b/tests/test_cf_ingest.py
@@ -1,0 +1,158 @@
+"""Regression tests for ``coordinator._ingest_cf_broadcasts``.
+
+2.12.0: after each discovery completes, the coordinator pulls the
+library's classified CF activation broadcasts off
+``NikobusDiscovery.discovered_cf_broadcasts`` and persists them to
+``cf_storage``. These tests pin the conversion / dedup / persistence
+contract without exercising the full discovery state machine.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.nikobus.coordinator import NikobusDataCoordinator
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _stub_cf_member(module_address, channel, mode, t1=None, t2=None):
+    """Mimic the library's ``CFOutputMember`` dataclass shape using a
+    plain SimpleNamespace — the coordinator only reads attributes."""
+    m = MagicMock()
+    m.module_address = module_address
+    m.channel = channel
+    m.mode = mode
+    m.t1 = t1
+    m.t2 = t2
+    return m
+
+
+def _stub_cf_broadcast(bus_address, pattern, outputs):
+    cf = MagicMock()
+    cf.bus_address = bus_address
+    cf.pattern = pattern
+    cf.outputs = outputs
+    return cf
+
+
+def _make_coord_with_cf_storage(broadcasts):
+    """Build a coordinator-under-test with just enough wired to exercise
+    ``_ingest_cf_broadcasts``: a fake ``nikobus_discovery`` exposing
+    ``discovered_cf_broadcasts`` and a fake ``cf_storage`` that records
+    saves. Everything else is left as MagicMock."""
+    coord = MagicMock(spec=NikobusDataCoordinator)
+    coord.nikobus_discovery = MagicMock()
+    coord.nikobus_discovery.discovered_cf_broadcasts = broadcasts
+    coord.cf_storage = MagicMock()
+    coord.cf_storage.data = {"nikobus_cf": {}}
+    coord.cf_storage.async_save = AsyncMock()
+    coord._ingest_cf_broadcasts = (
+        lambda _self=coord: NikobusDataCoordinator._ingest_cf_broadcasts(_self)
+    )
+    return coord
+
+
+class TestIngestCFBroadcasts(unittest.TestCase):
+    def test_roller_pair_with_two_members_lands_in_storage(self):
+        coord = _make_coord_with_cf_storage(
+            {
+                "3880CA": _stub_cf_broadcast(
+                    "3880CA",
+                    "roller_pair",
+                    [
+                        _stub_cf_member("8CF5", 6, "M02", t1="30 s"),
+                        _stub_cf_member("8CF5", 6, "M03", t1="30 s"),
+                    ],
+                )
+            }
+        )
+
+        _run(coord._ingest_cf_broadcasts())
+
+        stored = coord.cf_storage.data["nikobus_cf"]
+        self.assertIn("3880CA", stored)
+        self.assertEqual(stored["3880CA"]["pattern"], "roller_pair")
+        self.assertEqual(len(stored["3880CA"]["outputs"]), 2)
+        modes = {o["mode"] for o in stored["3880CA"]["outputs"]}
+        self.assertEqual(modes, {"M02", "M03"})
+        # Save was actually issued.
+        coord.cf_storage.async_save.assert_awaited_once()
+
+    def test_switch_pair_alles_uit_spray_lands_full(self):
+        coord = _make_coord_with_cf_storage(
+            {
+                "384102": _stub_cf_broadcast(
+                    "384102",
+                    "switch_pair",
+                    [
+                        _stub_cf_member("81F6", i, "M03")
+                        for i in range(1, 13)
+                    ],
+                )
+            }
+        )
+
+        _run(coord._ingest_cf_broadcasts())
+
+        stored = coord.cf_storage.data["nikobus_cf"]["384102"]
+        self.assertEqual(stored["pattern"], "switch_pair")
+        self.assertEqual(len(stored["outputs"]), 12)
+        # Every entry is a plain JSON-safe dict.
+        for o in stored["outputs"]:
+            self.assertIsInstance(o, dict)
+            self.assertIn("module_address", o)
+            self.assertIn("channel", o)
+            self.assertIn("mode", o)
+
+    def test_module_address_normalised_to_uppercase(self):
+        """Library may emit lowercase hex; storage must normalise."""
+        coord = _make_coord_with_cf_storage(
+            {
+                "3880CB": _stub_cf_broadcast(
+                    "3880cb",
+                    "roller_pair",
+                    [_stub_cf_member("8b9c", 5, "M02")],
+                )
+            }
+        )
+
+        _run(coord._ingest_cf_broadcasts())
+
+        stored = coord.cf_storage.data["nikobus_cf"]
+        self.assertIn("3880CB", stored)
+        self.assertEqual(stored["3880CB"]["outputs"][0]["module_address"], "8B9C")
+
+    def test_no_broadcasts_preserves_existing_storage(self):
+        """When the library classifies nothing this scan (empty
+        broadcast dict), don't wipe the persisted store — preserve
+        whatever last scan put there."""
+        existing = {"3880CA": {"bus_address": "3880CA", "pattern": "roller_pair", "outputs": []}}
+        coord = _make_coord_with_cf_storage({})
+        coord.cf_storage.data = {"nikobus_cf": dict(existing)}
+
+        _run(coord._ingest_cf_broadcasts())
+
+        # Untouched.
+        self.assertEqual(coord.cf_storage.data["nikobus_cf"], existing)
+        coord.cf_storage.async_save.assert_not_called()
+
+    def test_no_discovery_object_is_safe(self):
+        coord = MagicMock(spec=NikobusDataCoordinator)
+        coord.nikobus_discovery = None
+        coord.cf_storage = MagicMock()
+        coord.cf_storage.data = {"nikobus_cf": {}}
+        coord.cf_storage.async_save = AsyncMock()
+        coord._ingest_cf_broadcasts = (
+            lambda _self=coord: NikobusDataCoordinator._ingest_cf_broadcasts(_self)
+        )
+        _run(coord._ingest_cf_broadcasts())
+        coord.cf_storage.async_save.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cf_storage.py
+++ b/tests/test_cf_storage.py
@@ -1,0 +1,110 @@
+"""Regression tests for ``NikobusCFStorage``.
+
+2.12.0: the library classifies ``38 41 XX`` and ``38 80 XX`` bus
+addresses as CF activation broadcasts and exposes them on
+``NikobusDiscovery.discovered_cf_broadcasts``. The coordinator
+mirrors that dict into a HA Store so scene entities survive HA
+restarts without re-running discovery. These tests pin the storage
+load / save contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest.mock import MagicMock
+
+from custom_components.nikobus.nkbstorage import NikobusCFStorage
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+class TestNikobusCFStorage(unittest.TestCase):
+    def test_initial_data_shape(self):
+        """A freshly-constructed storage has the canonical empty shape."""
+        store = NikobusCFStorage(MagicMock())
+        self.assertEqual(store.data, {"nikobus_cf": {}})
+        self.assertTrue(store.is_empty)
+
+    def test_load_returns_canonical_shape_when_disk_is_empty(self):
+        """The conftest stub's ``async_load`` returns ``None`` — the
+        storage must coerce that to the canonical empty shape rather
+        than leaving ``self._data`` as ``None``."""
+        store = NikobusCFStorage(MagicMock())
+        result = _run(store.async_load())
+        self.assertEqual(result, {"nikobus_cf": {}})
+        self.assertTrue(store.is_empty)
+
+    def test_data_round_trip_through_save(self):
+        """Mutating ``data`` and calling save preserves the dict
+        in-memory (and the conftest no-op store accepts the save)."""
+        store = NikobusCFStorage(MagicMock())
+        _run(store.async_load())
+        store.data["nikobus_cf"]["3880CA"] = {
+            "bus_address": "3880CA",
+            "pattern": "roller_pair",
+            "outputs": [
+                {"module_address": "8CF5", "channel": 6, "mode": "M02"},
+                {"module_address": "8CF5", "channel": 6, "mode": "M03"},
+            ],
+        }
+        _run(store.async_save())
+        self.assertFalse(store.is_empty)
+        self.assertIn("3880CA", store.data["nikobus_cf"])
+        self.assertEqual(
+            len(store.data["nikobus_cf"]["3880CA"]["outputs"]), 2
+        )
+
+    def test_load_accepts_persisted_shape(self):
+        """When the on-disk store holds a populated ``nikobus_cf`` dict,
+        load surfaces it verbatim."""
+        store = NikobusCFStorage(MagicMock())
+        # Inject the loaded shape directly into the underlying stub.
+        persisted = {
+            "nikobus_cf": {
+                "384102": {
+                    "bus_address": "384102",
+                    "pattern": "switch_pair",
+                    "outputs": [
+                        {"module_address": "81F6", "channel": 1, "mode": "M03"},
+                    ],
+                }
+            }
+        }
+        store._store._data = persisted  # type: ignore[attr-defined]
+
+        # Stub the conftest Store's async_load to return our persisted
+        # data this one time.
+        original_load = store._store.async_load
+
+        async def fake_load():
+            return persisted
+
+        store._store.async_load = fake_load  # type: ignore[method-assign]
+        try:
+            result = _run(store.async_load())
+            self.assertEqual(result, persisted)
+            self.assertEqual(
+                store.data["nikobus_cf"]["384102"]["pattern"], "switch_pair"
+            )
+        finally:
+            store._store.async_load = original_load  # type: ignore[method-assign]
+
+    def test_load_rejects_malformed_disk_shape(self):
+        """If the on-disk payload is corrupt (missing nikobus_cf key, or
+        the wrong type), fall back to the canonical empty shape rather
+        than propagate the garbage."""
+        store = NikobusCFStorage(MagicMock())
+
+        async def fake_load():
+            return {"unrelated": "junk"}
+
+        store._store.async_load = fake_load  # type: ignore[method-assign]
+        result = _run(store.async_load())
+        self.assertEqual(result, {"nikobus_cf": {}})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -629,6 +629,15 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
         # Repairs issue. Default False — the issue only surfaces when
         # the caller explicitly opts in via ``last_module_scan_was_full``.
         coord._last_module_scan_was_full = last_module_scan_was_full
+        # 2.12.0: ``_reconcile_post_discovery`` awaits
+        # ``_ingest_cf_broadcasts`` to mirror the library's classified
+        # CF activation broadcasts into ``cf_storage``. Stub here so
+        # the existing reconcile tests keep covering their original
+        # surface without needing to know about CFs.
+        coord._ingest_cf_broadcasts = AsyncMock()
+        coord.cf_storage = MagicMock()
+        coord.cf_storage.data = {"nikobus_cf": {}}
+        coord.cf_storage.async_save = AsyncMock()
         if has_method:
             coord.nikobus_discovery = MagicMock()
             default_manifest = manifest or {


### PR DESCRIPTION
## Companion to https://github.com/fdebrus/nikobus-connect/pull/91

The library PR classifies bus addresses of the form `38 41 XX` / `38 80 XX` as CF (Central Function) activation broadcasts and exposes them on `NikobusDiscovery.discovered_cf_broadcasts`. This integration PR makes those visible in HA as **scene entities**.

## What lands

- **`NikobusCFStorage`** in `nkbstorage.py` — new HA Store at `.storage/nikobus.cfs`, canonical shape `{"nikobus_cf": {bus_address: {pattern, outputs}}}`. Survives HA restarts so scene entities don't disappear when discovery isn't re-run.
- **Coordinator wiring**:
  - `cf_storage` loaded on setup alongside `module_storage` / `button_storage`.
  - `_ingest_cf_broadcasts()` runs inside `_reconcile_post_discovery`; mirrors `NikobusDiscovery.discovered_cf_broadcasts` to JSON-safe entries; **preserves prior data on empty classifications** (a re-scan on an idle bus must not wipe the user's scenes).
  - `async_activate_cf_broadcast(addr)` sends the bus frame `#N<addr>\r#E1` via the existing command handler. Surfaces `cf_no_address` / `not_connected` translated errors for bad input / disconnected bus.
- **`scene.py` grows `NikobusCFSceneEntity`** — one scene entity per classified CF; pattern + member list exposed as entity attributes; default friendly name encodes pattern + channel count for triage (`Nikobus roller CF 3880CA (2 ch)`); standard HA rename works.
- **Manifest**: 2.11.9 → 2.12.0, library floor 0.19.2 → 0.20.0.

## Scope choice

Scenes-only for this iteration. Each CF is a `scene.*` entity regardless of pattern. The pattern is stored as an attribute so a follow-up can map `roller_pair` to `cover.*` and `switch_pair` to `switch.*` once we have user-reported activation behavior.

Why: I have ground-truth `(module, channel, mode)` data for what each CF activation triggers, but **not yet** end-to-end empirical data on which exact frame format encodes "OPEN" vs "CLOSE" for roller-pair CFs (the library shows M02 + M03 link records sharing one source address — the bus may use a state-dependent toggle, an additional discriminator byte, or just the broadcast). Until the user tries an activation on real hardware and reports the behavior, committing to a typed cover entity risks the wrong direction semantics.

## How a user surfaces & uses CFs in HA

After installing 2.12.0 + 0.20.0 and running a full module scan:

| Where | What |
|---|---|
| Settings → Automations & Scenes → **Scenes** | One row per classified CF, with the integration tag |
| Settings → Devices & Services → Nikobus → bridge device | Scenes section, one row per CF |
| Lovelace tile / button card | Standard activate-on-tap |
| Developer Tools → States, filter `scene.` | Attributes show `bus_address`, `pattern`, `outputs`, `member_count` for triage |

Entity-ID shape: `scene.nikobus_cf_3880ca`, `scene.nikobus_cf_384102`, etc.

## Test plan

- [x] 5 new tests in `tests/test_cf_storage.py` pin the canonical shape + load/save round-trip + malformed-disk handling.
- [x] 5 new tests in `tests/test_cf_ingest.py` pin the conversion contract (CFOutputMember → JSON dict), address normalisation (lowercase → uppercase), preserve-on-empty-broadcasts behavior, and graceful handling when `nikobus_discovery` is `None`.
- [x] Updated `_make_coordinator_stub` in `tests/test_coordinator.py` to provide the new `_ingest_cf_broadcasts` mock so existing `TestReconcilePostDiscovery` tests keep passing without learning about CFs.
- [x] All 212 existing + new tests pass (`pytest tests/`).
- [ ] **Live verification on the Sluiskouter install** after library 0.20.0 lands:
  - Run `Scan all module links`.
  - Confirm `nikobus.cfs` storage contains ~10 entries (`384100`, `384102`, `3880C8`…`3880D3`).
  - Confirm `scene.nikobus_cf_*` entities materialise.
  - Pick one (e.g. `scene.nikobus_cf_3880ca` → Gordijn bureau groot) and activate it from HA; observe physical behavior + report back so we can plan the typed cover/switch follow-up.

## Out of scope for this PR

- `.nkb` upload UX (would give us user-friendly names like `Gordijnen bureau` instead of `Nikobus roller CF 3880CA`). Defer to a follow-up once scenes-only is validated.
- Typed `cover` / `switch` mapping. Defer pending real-hardware activation behavior data from this PR's live test.
- CF body decoding from PC-Logic register bytes (separate decoder problem; orthogonal to this PR).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5)_