### PR TITLE
2.12.1: run discovery buttons as background tasks (fix stage-2 boot timeout)

### DIFF
--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -8,6 +8,7 @@ from typing import Any
 from homeassistant.components.button import ButtonEntity
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -490,9 +491,26 @@ class NikobusPcLinkInventoryButton(ButtonEntity):
         self._attr_device_info = _hub_device_info()
 
     async def async_press(self) -> None:
-        """Start PC Link inventory discovery."""
+        """Start PC Link inventory discovery.
+
+        Scheduled as a background task — the inventory probe + register
+        scan can take 30-60 s, which is too long to hold a UI button
+        handler open. If the press happens during HA startup, blocking
+        here also stalls bootstrap stage 2 (see GH discussion in 2.12).
+        Progress is surfaced via ``SIGNAL_DISCOVERY_STATE``; failures
+        flow through the same channel as the discovery state's error
+        field, plus the integration log.
+        """
         _LOGGER.info("PC Link inventory discovery triggered via UI button")
-        await self._coordinator.start_pc_link_inventory()
+        if self._coordinator.discovery_running:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="discovery_already_running",
+            )
+        self.hass.async_create_background_task(
+            self._coordinator.start_pc_link_inventory(),
+            name="nikobus_pc_link_inventory_discovery",
+        )
 
 
 class NikobusModuleScanButton(ButtonEntity):
@@ -532,9 +550,23 @@ class NikobusModuleScanButton(ButtonEntity):
         self.async_write_ha_state()
 
     async def async_press(self) -> None:
-        """Scan all output modules for button links."""
+        """Scan all output modules for button links.
+
+        Backgrounded for the same reason as the PC-Link inventory
+        button — a full register scan can take 2+ minutes on big
+        installs, and awaiting it here would block the button handler
+        (and HA bootstrap stage 2 if pressed during startup).
+        """
         _LOGGER.info("Module scan discovery triggered via UI button")
-        await self._coordinator.start_module_scan()
+        if self._coordinator.discovery_running:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="discovery_already_running",
+            )
+        self.hass.async_create_background_task(
+            self._coordinator.start_module_scan(),
+            name="nikobus_module_scan_discovery",
+        )
 
 
 class NikobusButtonEntity(NikobusEntity, ButtonEntity):

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],


### PR DESCRIPTION
## Summary

Both discovery UI buttons (`NikobusPcLinkInventoryButton` and `NikobusModuleScanButton`) used to `await` the coordinator's discovery method directly inside `async_press`. On big installs the register scan can take 2+ minutes, which:

- blocks the UI (button spins for the entire scan), and
- if the press happens **during HA startup**, holds open a task that HA's bootstrap stage 2 supervisor tracks — surfaces as:

  ```
  Setup timed out for stage 2 waiting on {
    ButtonEntity._async_press_action,
    NikobusDiscovery._timeout_after
  } - moving forward
  ```

  (Observed in a real-world install log: button pressed at boot, scan ran 2:02, stage 2 timeout fired at the 5-minute mark.)

## Change

Switch both buttons to `hass.async_create_background_task(...)` so `async_press` returns immediately and the long-running work lives outside the bootstrap task tree.

- Progress is still surfaced via the existing `SIGNAL_DISCOVERY_STATE` dispatcher (UI updates already work this way for `NikobusModuleScanButton`).
- A quick `discovery_running` pre-check preserves the "already running" toast for the common double-click case.
- No coordinator-side changes.

## Test plan

- [ ] Press PC-Link inventory button — UI returns immediately, discovery state messages show progress.
- [ ] Press Module scan button while inventory is running — gets "already running" error.
- [ ] Restart HA with no nikobus integration loaded → button press during boot doesn't stall stage 2.
- [ ] Failed discovery (e.g. PC-Link unplugged) — error appears in the discovery state, not as an exception on the button.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RhmmoSKRaBNPezNeHoSTg5)_