### PR TITLE
2.12.2: don't let leftover manual config files clobber PC-Link inventory on boot

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -58,7 +58,11 @@ from .const import (
 )
 from .nkbactuator import NikobusActuator
 from .nkbconfig import NikobusConfig
-from .nkbmanual import async_apply_manual_config
+from .nkbmanual import (
+    async_apply_friendly_name_overlay,
+    async_apply_manual_config,
+    module_store_has_pclink_inventory,
+)
 from .nkbstorage import (
     NikobusButtonStorage,
     NikobusCFStorage,
@@ -264,14 +268,36 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             # The files are fully declarative — what's in them gets
             # written to the live stores on every coordinator setup.
             # ``linked_modules`` is NOT imported from the button file;
-            # step 2 (per-module register scan) populates that. Applied
-            # unconditionally if the files exist — presence of the
-            # files is the signal.
-            changed = await async_apply_manual_config(
-                self.hass,
-                self.module_storage,
-                self.dict_button_data,
-            )
+            # step 2 (per-module register scan) populates that.
+            #
+            # 2.12.2: gate on provenance so a PC-Link install with
+            # leftover legacy config files on disk does NOT get its
+            # bus-discovered inventory wiped and rebuilt from those stale
+            # files on every restart. The wholesale declarative
+            # replacement is reserved for installs that have never
+            # completed a PC-Link inventory; PC-Link installs take the
+            # non-destructive friendly-name overlay instead (same as the
+            # discovery flow's step 3). See ``start_pc_link_inventory``.
+            if module_store_has_pclink_inventory(self.module_storage):
+                _LOGGER.debug(
+                    "Boot: PC-Link inventory present in module store; "
+                    "applying manual files as friendly-name overlay only "
+                    "(no wholesale replacement)."
+                )
+                changed = await async_apply_friendly_name_overlay(
+                    self.hass,
+                    self.module_storage,
+                    self.dict_button_data,
+                )
+            else:
+                # No-PC-Link install (or first boot): the files ARE the
+                # inventory source. Applied if they exist — presence of
+                # the files is the signal.
+                changed = await async_apply_manual_config(
+                    self.hass,
+                    self.module_storage,
+                    self.dict_button_data,
+                )
             if changed:
                 await self.module_storage.async_save()
                 await self.button_storage.async_save()

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/custom_components/nikobus/nkbmanual.py
+++ b/custom_components/nikobus/nkbmanual.py
@@ -76,6 +76,43 @@ def _tag_manual_source(entry: dict[str, Any]) -> None:
     entry["discovered_info"] = discovered_info
 
 
+def module_store_has_pclink_inventory(
+    module_store: NikobusModuleStorage,
+) -> bool:
+    """True if the live module store holds PC-Link-discovered inventory.
+
+    A PC-Link inventory writes ``discovered_info`` carrying bus-sourced
+    fields (``device_type`` / ``channels_count``) and crucially does NOT
+    tag entries with ``source == "manual_config"`` (that tag is only
+    applied by ``_apply_module_config`` on this manual-import path).
+
+    We use this to keep the boot-time manual import from clobbering a
+    real PC-Link inventory: an install that has ever completed a PC-Link
+    discovery has at least one module whose ``discovered_info.source`` is
+    something other than ``"manual_config"``. Such installs must take the
+    non-destructive friendly-name overlay path instead of the wholesale
+    declarative replacement, which is reserved for no-PC-Link installs.
+
+    Returns ``False`` for an empty store (nothing discovered yet) and for
+    a store whose every entry is manual-config-sourced.
+    """
+    modules = module_store.data.get("nikobus_module")
+    if not isinstance(modules, dict) or not modules:
+        return False
+    for entry in modules.values():
+        if not isinstance(entry, dict):
+            continue
+        discovered_info = entry.get("discovered_info")
+        source = (
+            discovered_info.get("source")
+            if isinstance(discovered_info, dict)
+            else None
+        )
+        if source != "manual_config":
+            return True
+    return False
+
+
 # ---------------------------------------------------------------------------
 # v1 (legacy nested) → flat-by-address conversion
 # ---------------------------------------------------------------------------

--- a/tests/test_manual_config.py
+++ b/tests/test_manual_config.py
@@ -1405,5 +1405,83 @@ class TestConsolidationEndToEnd(unittest.TestCase):
         )
 
 
+class TestModuleStoreHasPclinkInventory(unittest.TestCase):
+    """Guard signal that keeps the boot-time manual import from clobbering
+    a real PC-Link inventory (the ``…53252`` 8-key-button regression).
+
+    A PC-Link install with leftover legacy config files used to have its
+    bus-discovered store wiped and rebuilt from those stale files on every
+    restart — re-tagging everything ``manual_config`` / ``Manual button``
+    and mis-splitting odd-base-nibble 8-key buttons into two 4-key ones.
+    The boot path now overlays names instead of replacing when this
+    returns True.
+    """
+
+    def test_empty_store_is_not_pclink(self):
+        store = _InMemoryModuleStore({"nikobus_module": {}})
+        self.assertFalse(nkbmanual.module_store_has_pclink_inventory(store))
+
+    def test_missing_key_is_not_pclink(self):
+        store = _InMemoryModuleStore({})
+        self.assertFalse(nkbmanual.module_store_has_pclink_inventory(store))
+
+    def test_all_manual_config_is_not_pclink(self):
+        # Mirrors the user's nikobus.modules file: every entry tagged
+        # source=manual_config. Must NOT look like a PC-Link install,
+        # else a genuine no-PC-Link user would never get their files
+        # applied.
+        store = _InMemoryModuleStore({
+            "nikobus_module": {
+                "3851": {
+                    "module_type": "switch_module",
+                    "model": "05-000-02",
+                    "discovered_info": {"source": "manual_config"},
+                },
+                "5372": {
+                    "module_type": "roller_module",
+                    "model": "05-001-02",
+                    "discovered_info": {"source": "manual_config"},
+                },
+            }
+        })
+        self.assertFalse(nkbmanual.module_store_has_pclink_inventory(store))
+
+    def test_pclink_discovered_entry_is_pclink(self):
+        # PC-Link inventory writes discovered_info with bus-sourced
+        # fields and NO manual_config source tag.
+        store = _InMemoryModuleStore({
+            "nikobus_module": {
+                "3851": {
+                    "module_type": "switch_module",
+                    "model": "05-000-02",
+                    "discovered_info": {
+                        "device_type": "01",
+                        "channels_count": 12,
+                    },
+                },
+            }
+        })
+        self.assertTrue(nkbmanual.module_store_has_pclink_inventory(store))
+
+    def test_mixed_store_with_one_discovered_is_pclink(self):
+        # If even one entry is bus-discovered, protect the store.
+        store = _InMemoryModuleStore({
+            "nikobus_module": {
+                "3851": {"discovered_info": {"source": "manual_config"}},
+                "3861": {"discovered_info": {"device_type": "01"}},
+            }
+        })
+        self.assertTrue(nkbmanual.module_store_has_pclink_inventory(store))
+
+    def test_entry_without_discovered_info_is_pclink(self):
+        # An entry that carries no provenance at all is not a
+        # manual_config entry, so it counts as pre-existing discovered
+        # inventory worth protecting.
+        store = _InMemoryModuleStore({
+            "nikobus_module": {"3851": {"module_type": "switch_module"}}
+        })
+        self.assertTrue(nkbmanual.module_store_has_pclink_inventory(store))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

A PC-Link install with leftover `nikobus_module_config.json` / `nikobus_button_config.json` on disk (from a previous version) had its **bus-discovered inventory wiped and rebuilt from those stale files on every coordinator startup**.

The boot path in `connect()` called `async_apply_manual_config` unconditionally on file *presence*. That function is destructive — it replaces the button/module stores wholesale, re-tagging everything `source: "manual_config"` / `"type": "Manual button"`.

Secondary effect: the 2.11.8 legacy 1A-only consolidation then ran over the re-imported buttons and **mis-split 8-key buttons with an odd physical base nibble** (e.g. a reporting user's `…53252` "Gelijkvloers bureau" 4*-078) into two 4-key buttons.

### Symptoms seen in user data
- Every button entry typed `"Manual button"`.
- Every module/button tagged `discovered_info.source = "manual_config"`, despite the install having a 05-200 PC-Link.
- 8-control-point buttons appearing as two separate 4-key buttons.

## Fix

Gate the boot-time import on store **provenance**:

- New `module_store_has_pclink_inventory()` in `nkbmanual.py` — a PC-Link inventory writes `discovered_info` with bus-sourced fields (`device_type` / `channels_count`) and *without* `source == "manual_config"`. If the live store holds any such entry, a real inventory was completed.
- `connect()` now branches: PC-Link installs apply the manual files as a **non-destructive friendly-name overlay** (names / roller times only, no wipe) — exactly what the discovery flow's step 3 already does. The wholesale declarative replacement is reserved for no-PC-Link installs (empty store, or all-`manual_config`-tagged).

The discovery path (`start_pc_link_inventory`) was already correct (probe PC-Link → overlay) and is unchanged.

## Recovery note for affected users

This stops the corruption going forward but does **not** auto-repair an already-corrupted store (which is all-`manual_config`-tagged, so the guard correctly treats it as "no PC-Link inventory yet"). Affected users should re-run PC-Link discovery once to repopulate real inventory; the guard then protects it on every subsequent boot. Deleting the leftover `nikobus_*_config.json` files also works.

## Not included

The underlying 8-key consolidation guard bug (`nkbmanual.py`, the odd-base-nibble split) is left as-is — it only affects the no-PC-Link path and needs a separate tie-breaker decision.

## Tests

- Adds `TestModuleStoreHasPclinkInventory` (6 cases: empty, missing key, all-manual, bus-discovered, mixed, untagged).
- Full suite green: **218 passed** (40 in `test_manual_config.py`, 96 in `test_coordinator.py`).

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_