### PR TITLE
2.12.5: require nikobus-connect>=0.20.2 (47-082/47-084 button device types)

### DIFF
--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.12.4",
+  "version": "2.12.5",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.20.0"
+    "nikobus-connect>=0.20.2"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }


### PR DESCRIPTION
## Summary

Bumps the `nikobus-connect` dependency floor to **`>=0.20.2`** so the integration pulls the library version that catalogues the `47-08x` bus push-button series.

[nikobus-connect#93](https://github.com/fdebrus/nikobus-connect/pull/93) (0.20.2, merged) added device types:
- `0x10` → `4*-082`, 2 control points
- `0x11` → `4*-084`, 4 control points

These were previously dropped as `Category="Unknown"` by `merge_discovered_buttons`, so buttons of those types never surfaced in HA. With 0.20.2 + this pin, a fresh "Discover modules" on PC-Link surfaces them.

## Why a pin bump is needed

The integration installs `nikobus-connect` from PyPI via `manifest.json` requirements; without raising the floor, HA could resolve an older library that still drops these device types.

## Changes

- `manifest.json`: `nikobus-connect>=0.20.0` → `>=0.20.2`
- version `2.12.4` → `2.12.5`

No code changes.

## Deploy note

Requires `nikobus-connect 0.20.2` to be published to PyPI for the pin to resolve.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_