### PR TITLE
2.12.6: name Modular Interface (05-206) inputs MI-INPUT N, not LM-INPUT N

### DIFF
--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -106,25 +106,41 @@ def _category_for_button_type(type_str: str) -> str:
     return CATEGORY_WALL_BUTTONS
 
 
+def _input_label_prefix(phys: dict[str, Any]) -> str:
+    """Return the input-naming prefix for a synthesized input child.
+
+    PC-Logic (05-201) inputs use ``LM`` (Logic Module — matches Niko's
+    own terminology); Modular Interface (05-206) inputs use ``MI``
+    (Modular Interface). Both share the ``pc_logic_parent_*`` provenance
+    fields, so ``pc_logic_parent_type`` is the discriminator. Anything
+    that isn't explicitly the Modular Interface stays ``LM`` (covers the
+    PC-Logic value and missing/legacy entries — back-compat).
+    """
+    return "MI" if phys.get("pc_logic_parent_type") == "interface_module" else "LM"
+
+
 def _pc_logic_input_naming(
     phys: dict[str, Any],
 ) -> tuple[str, tuple[str, str]] | None:
     """Return ``(device_name, via_device_identifier)`` if ``phys`` is a
-    synthesized PC-Logic logical-input entry; else ``None``.
+    synthesized input-module child (PC-Logic or Modular Interface);
+    else ``None``.
 
-    The library sets ``pc_logic_parent_address`` (the PC-Logic module
-    address) and ``pc_logic_slot_index`` (1..N) on the button-store
-    entry when it synthesizes virtual buttons for PC-Logic inputs. HA
-    parents the device directly under the PC-Logic module device
-    (instead of the wall-buttons category) and renames it
-    ``LM-INPUT N`` to match Niko's own terminology.
+    The library sets ``pc_logic_parent_address`` (the owning module
+    address), ``pc_logic_parent_type`` (``pc_logic`` /
+    ``interface_module``) and ``pc_logic_slot_index`` (1..N) on the
+    button-store entry when it synthesizes virtual buttons for module
+    inputs. HA parents the device directly under the owning module
+    device (instead of the wall-buttons category) and names it
+    ``LM-INPUT N`` for PC-Logic or ``MI-INPUT N`` for the Modular
+    Interface, matching each product's terminology.
     """
 
     parent_addr = phys.get("pc_logic_parent_address")
     slot = phys.get("pc_logic_slot_index")
     if not isinstance(parent_addr, str) or not isinstance(slot, int):
         return None
-    return f"LM-INPUT {slot}", (DOMAIN, parent_addr.upper())
+    return f"{_input_label_prefix(phys)}-INPUT {slot}", (DOMAIN, parent_addr.upper())
 
 
 def _remote_transmitter_naming(
@@ -169,11 +185,12 @@ def register_wall_button_devices(
     ``_category_for_button_type`` so the integration's device list
     nests by class rather than dumping everything under the bridge.
 
-    Synthesized PC-Logic logical inputs (the library's
+    Synthesized input-module children (the library's
     ``_synthesize_pc_logic_inputs`` adds these with ``pc_logic_*``
     provenance fields) are routed differently: the device is parented
-    directly under the PC-Logic module that owns it, and the name
-    follows the Niko ``LM-INPUT N`` convention.
+    directly under the owning module, and the name follows the Niko
+    ``LM-INPUT N`` (PC-Logic) / ``MI-INPUT N`` (Modular Interface)
+    convention.
     """
     device_registry = dr.async_get(hass)
     pc_logic_parents_registered: set[str] = set()
@@ -404,7 +421,8 @@ def _iter_input_module_entities(coordinator: NikobusDataCoordinator):
 
     Both PC-Logic (05-201) and Modular Interface (05-206) inputs are
     surfaced through synthesized button-store entries (one ``LM-INPUT N``
-    device per input, parented under the owning module). Their per-channel
+    / ``MI-INPUT N`` device per input, parented under the owning module).
+    Their per-channel
     placeholder entities are redundant — skip the module-attached
     ``NikobusInputEntity`` creation for both.
     """
@@ -457,23 +475,25 @@ def op_point_display_name(
     every receiver that learned the same code. Wall keys keep the
     library description verbatim; it already carries the channel label.
 
-    PC-Logic logical-input keys (the parent button carries
+    Input-module keys (the parent button carries
     ``pc_logic_parent_address``) render as ``Key A on LM-INPUT N`` /
-    ``Key B on LM-INPUT N``, mirroring the IR ``<key> on <parent>``
+    ``Key B on LM-INPUT N`` for PC-Logic, or ``... on MI-INPUT N`` for
+    the Modular Interface, mirroring the IR ``<key> on <parent>``
     pattern so the device list disambiguates each slot's keys.
     """
     if key_label.startswith("IR:"):
         ir_code = key_label[len("IR:"):]
         return f"IR {ir_code} on {physical_address}"
     if isinstance(parent_phys, dict) and parent_phys.get("pc_logic_parent_address"):
-        # ``1A`` → "Key A on LM-INPUT N", ``1B`` → "Key B on LM-INPUT N".
+        # ``1A`` → "Key A on {LM,MI}-INPUT N", ``1B`` → "Key B on …".
         slot = parent_phys.get("pc_logic_slot_index")
         if (
             len(key_label) == 2
             and key_label[1].isalpha()
             and isinstance(slot, int)
         ):
-            return f"Key {key_label[1].upper()} on LM-INPUT {slot}"
+            prefix = _input_label_prefix(parent_phys)
+            return f"Key {key_label[1].upper()} on {prefix}-INPUT {slot}"
     return op_point.get("description") or f"Push button {key_label}"
 
 

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.12.5",
+  "version": "2.12.6",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/tests/test_input_module_naming.py
+++ b/tests/test_input_module_naming.py
@@ -1,0 +1,147 @@
+"""Regression tests for synthesized input-module naming.
+
+PC-Logic (05-201) and Modular Interface (05-206) inputs share the same
+``pc_logic_parent_*`` provenance fields. The bug fixed here: both were
+labelled ``LM-INPUT N`` because the naming code only checked
+``pc_logic_parent_address`` and ignored ``pc_logic_parent_type``. The
+"LM" (Logic Module) prefix is PC-Logic-specific; the Modular Interface
+must use "MI".
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+COMP = Path(__file__).parent.parent / "custom_components" / "nikobus"
+
+
+def _ensure_stubs() -> None:
+    if "homeassistant.components.button" not in sys.modules:
+        m = types.ModuleType("homeassistant.components.button")
+        m.__spec__ = importlib.machinery.ModuleSpec(
+            "homeassistant.components.button", None
+        )
+        m.ButtonEntity = type("ButtonEntity", (), {})
+        sys.modules["homeassistant.components.button"] = m
+
+    for mod_name in ("homeassistant.const", "homeassistant.helpers.entity"):
+        mod = sys.modules.get(mod_name)
+        if mod is not None and hasattr(mod, "EntityCategory"):
+            if not hasattr(mod.EntityCategory, "CONFIG"):
+                mod.EntityCategory.CONFIG = "config"
+
+
+def _load_button_module():
+    _ensure_stubs()
+    if "custom_components.nikobus.entity" not in sys.modules:
+        spec = importlib.util.spec_from_file_location(
+            "custom_components.nikobus.entity", COMP / "entity.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        mod.__package__ = "custom_components.nikobus"
+        sys.modules["custom_components.nikobus.entity"] = mod
+        spec.loader.exec_module(mod)
+
+    if "custom_components.nikobus.button" not in sys.modules:
+        spec = importlib.util.spec_from_file_location(
+            "custom_components.nikobus.button", COMP / "button.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        mod.__package__ = "custom_components.nikobus"
+        sys.modules["custom_components.nikobus.button"] = mod
+        spec.loader.exec_module(mod)
+    return sys.modules["custom_components.nikobus.button"]
+
+
+# --- _input_label_prefix --------------------------------------------------
+
+def test_prefix_pc_logic_is_lm() -> None:
+    button = _load_button_module()
+    assert button._input_label_prefix({"pc_logic_parent_type": "pc_logic"}) == "LM"
+
+
+def test_prefix_interface_module_is_mi() -> None:
+    button = _load_button_module()
+    assert (
+        button._input_label_prefix({"pc_logic_parent_type": "interface_module"})
+        == "MI"
+    )
+
+
+def test_prefix_missing_type_defaults_to_lm() -> None:
+    # Back-compat: legacy entries without the discriminator stay LM.
+    button = _load_button_module()
+    assert button._input_label_prefix({}) == "LM"
+
+
+# --- _pc_logic_input_naming (device name) ---------------------------------
+
+def test_device_name_pc_logic() -> None:
+    button = _load_button_module()
+    name, via = button._pc_logic_input_naming(
+        {
+            "pc_logic_parent_address": "940c",
+            "pc_logic_parent_type": "pc_logic",
+            "pc_logic_slot_index": 3,
+        }
+    )
+    assert name == "LM-INPUT 3"
+    assert via == (button.DOMAIN, "940C")
+
+
+def test_device_name_interface_module() -> None:
+    button = _load_button_module()
+    name, via = button._pc_logic_input_naming(
+        {
+            "pc_logic_parent_address": "1234",
+            "pc_logic_parent_type": "interface_module",
+            "pc_logic_slot_index": 5,
+        }
+    )
+    assert name == "MI-INPUT 5"
+    assert via == (button.DOMAIN, "1234")
+
+
+def test_device_name_non_input_returns_none() -> None:
+    button = _load_button_module()
+    assert button._pc_logic_input_naming({"type": "Bus push button"}) is None
+
+
+# --- op_point_display_name (per-key name) ---------------------------------
+
+def test_key_name_pc_logic() -> None:
+    button = _load_button_module()
+    parent = {
+        "pc_logic_parent_address": "940C",
+        "pc_logic_parent_type": "pc_logic",
+        "pc_logic_slot_index": 1,
+    }
+    assert (
+        button.op_point_display_name("64A061", "1A", {}, parent_phys=parent)
+        == "Key A on LM-INPUT 1"
+    )
+    assert (
+        button.op_point_display_name("64A061", "1B", {}, parent_phys=parent)
+        == "Key B on LM-INPUT 1"
+    )
+
+
+def test_key_name_interface_module() -> None:
+    button = _load_button_module()
+    parent = {
+        "pc_logic_parent_address": "1234",
+        "pc_logic_parent_type": "interface_module",
+        "pc_logic_slot_index": 2,
+    }
+    assert (
+        button.op_point_display_name("0E1234", "1A", {}, parent_phys=parent)
+        == "Key A on MI-INPUT 2"
+    )
+    assert (
+        button.op_point_display_name("0E1234", "1B", {}, parent_phys=parent)
+        == "Key B on MI-INPUT 2"
+    )


### PR DESCRIPTION
## The bug

PC-Logic (05-201) and Modular Interface (05-206) synthesized inputs both carry the same `pc_logic_parent_*` provenance fields (the library reuses the field names for both). The two HA-side naming functions — `_pc_logic_input_naming` (device name) and `op_point_display_name` (per-key name) — gated only on `pc_logic_parent_address`, which **both** types carry, and ignored the `pc_logic_parent_type` discriminator.

Result: Modular Interface inputs were mislabelled with the PC-Logic-specific **"LM"** (Logic Module) prefix — e.g. `LM-INPUT 1` / `Key A on LM-INPUT 1` — even though "LM" is meaningless for a 05-206.

- ✅ PC-Logic (05-201): `LM-INPUT N` — correct.
- ❌ Modular Interface (05-206): wrongly showed `LM-INPUT N` too.

## The fix

Branch both naming functions on `pc_logic_parent_type` (already stamped on each entry by the library and carried through the button-store merge) via a small `_input_label_prefix` helper:

| Module | `module_type` | Prefix | Device | Key |
|---|---|---|---|---|
| PC-Logic (05-201) | `pc_logic` | `LM` | `LM-INPUT N` | `Key A on LM-INPUT N` |
| Modular Interface (05-206) | `interface_module` | `MI` | `MI-INPUT N` | `Key A on MI-INPUT N` |

`MI` mirrors Niko's product name ("Modular interface") the same way `LM` mirrors "Logic Module", keeps the two visually parallel (`xx-INPUT N`), and avoids a `DM`/Dimmer-Module collision. Anything not explicitly the Modular Interface stays `LM` (covers the PC-Logic value and legacy entries without the discriminator — back-compat).

## Scope / impact

Pure **display-name** change, HA-side only — no addressing or routing impact. Existing 05-206 installs will see the default device/key labels flip from `LM-INPUT N` to `MI-INPUT N` on next reload; any user `name_by_user` renames are preserved.

## Tests

- Adds `tests/test_input_module_naming.py`: pins `_input_label_prefix` (LM / MI / legacy-default), the device name, and the per-key name for both module types.
- Full suite green: **221 passed**.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_