### PR TITLE
2.12.7: require nikobus-connect>=0.20.3 (2-button link resolution)

### DIFF
--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.12.6",
+  "version": "2.12.7",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.20.2"
+    "nikobus-connect>=0.20.3"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }


### PR DESCRIPTION
## Summary

Bumps the `nikobus-connect` dependency floor to **`>=0.20.3`** so the integration pulls the 2-button link-resolution fix.

[nikobus-connect#94](https://github.com/fdebrus/nikobus-connect/pull/94) (0.20.3, merged) fixed the `0x10` (4\*-082, 2-button) key mapping: its op-points were generated at the wrong bus addresses and its decoded link records never resolved, so 2-button outputs showed empty `linked_modules`. With 0.20.3 the 2-buttons link to their outputs correctly.

## Changes

- `manifest.json`: `nikobus-connect>=0.20.2` → `>=0.20.3`
- version `2.12.6` → `2.12.7`

No code changes.

## Deploy note

Requires `nikobus-connect 0.20.3` published to PyPI for the pin to resolve. After updating, the user re-runs **Discover modules** → **Scan all modules**; the 2-button (4\*-072 / 05-060) units will then show their linked outputs.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_