### PR TITLE
2.12.8: require nikobus-connect>=0.20.4 (8-button 1X-half links)

### DIFF
--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.12.7",
+  "version": "2.12.8",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.20.3"
+    "nikobus-connect>=0.20.4"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }


### PR DESCRIPTION
## Summary

Bumps the `nikobus-connect` dependency floor to **`>=0.20.4`** so the integration pulls the 8-button link fix.

[nikobus-connect#95](https://github.com/fdebrus/nikobus-connect/pull/95) (0.20.4, merged) links the **`1X` half** (`1A/1B/1C/1D`) of 8-control-point buttons. Their link records are stored under the button's `N+1` sibling address (encoded at raw key indices 0-3 on this hardware), which previously had nowhere to attach — so every 8-button linked only its `2X` half (`2A/2B/2C/2D`). With 0.20.4 all 8 op-points link.

## Changes

- `manifest.json`: `nikobus-connect>=0.20.3` → `>=0.20.4`
- version `2.12.7` → `2.12.8`

No code changes.

## Deploy note

Requires `nikobus-connect 0.20.4` published to PyPI for the pin to resolve. After updating, the user re-runs **Scan all module links**; all eight op-points on every 8-button then show their linked outputs.

This completes the button-link work across all three control-point counts:
- 2-button (4\*-072 / 0x10) → 0.20.3
- 4-button (4\*-074 / 0x11) → 0.20.2
- 8-button (4\*-078 / 0x12, 1X half) → 0.20.4

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_