### PR TITLE
2.12.9: require nikobus-connect>=0.20.5 (no-PC-Link link resolution)

### DIFF
--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.12.8",
+  "version": "2.12.9",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.20.4"
+    "nikobus-connect>=0.20.5"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }


### PR DESCRIPTION
## Summary

Bumps the `nikobus-connect` dependency floor to **`>=0.20.5`** so the integration pulls the no-PC-Link link-resolution fix.

[nikobus-connect#96](https://github.com/fdebrus/nikobus-connect/pull/96) (0.20.5, merged) resolves button link records against **manual-config (no-PC-Link) button stores**. On those installs the store is keyed by each button's `convert()` form while the register scan decodes raw addresses — so "Scan all module links" decoded every link but matched **none** (`active=0, legacy_undecoded=N`). 0.20.5 bridges the two representations via a last-resort convert() fallback.

## Changes

- `manifest.json`: `nikobus-connect>=0.20.4` → `>=0.20.5`
- version `2.12.8` → `2.12.9`

No code changes.

## Deploy note

Requires `nikobus-connect 0.20.5` published to PyPI for the pin to resolve. After updating, a no-PC-Link user re-runs **Scan all module links**; their buttons then bind to their outputs.

This completes end-to-end support for no-PC-Link installs (inventory from files + 2/4/8-button decoding + link binding).

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_