### PR TITLE
2.12.10: require nikobus-connect>=0.20.6 (PC-Logic CF address-table recognition)

### DIFF
--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.12.9",
+  "version": "2.12.10",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.20.5"
+    "nikobus-connect>=0.20.6"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }


### PR DESCRIPTION
## Summary

Bumps the `nikobus-connect` dependency floor to **`>=0.20.6`**.

[nikobus-connect#97](https://github.com/fdebrus/nikobus-connect/pull/97) (0.20.6, merged) recognises the PC-Logic CF (Central Function) trigger-address-table region during a register scan and logs it as a `CF address-table chunk` instead of `noise chunk`.

## Changes

- `manifest.json`: `nikobus-connect>=0.20.5` → `>=0.20.6`
- version `2.12.9` → `2.12.10`

No code changes.

## Scope

**Diagnostic-only.** 0.20.6 does not create any new entities — it stops mislabelling the PC-Logic CF-address enumeration as noise and records that region for what it is. It emits no links and no scenes. Naming actual CF scenes still requires the `.nkb`/Groups ground truth paired with this enumeration (a future, separate step).

## Deploy note

Requires `nikobus-connect 0.20.6` published to PyPI for the pin to resolve.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_