### PR TITLE
Surface light-scene Central Functions as scenes (2.13.0)

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -1481,14 +1481,19 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
     async def async_activate_cf_broadcast(self, bus_address: str) -> None:
         """Send the bus frame that activates a classified CF.
 
-        Each CF broadcast address (``38 41 XX`` or ``38 80 XX``) is
-        what PC-Logic emits when the CF is activated by a wall button
-        or remote. Output modules participating in the CF carry the
-        link records that trigger their channels on this address. From
-        HA we send the same frame format used for wall-button
-        simulations: ``#N{addr}\\r#E1``. The output modules then fire
-        in unison — single-frame atomic activation, no per-channel
-        round-trip.
+        Two CF flavours share this path, both keyed on the bus address
+        that triggers the member outputs:
+
+        * PC-Logic broadcast CFs (``38 41 XX`` / ``38 80 XX``) — what
+          PC-Logic emits when the CF fires.
+        * Light-scene CFs (``pattern == "light_scene"``) — the address
+          is the real wall-button / IR trigger the members link to
+          (e.g. an IR channel like ``0D1C9E``).
+
+        In both cases the output modules carry link records pointing to
+        this address, so we send the same wall-button-simulation frame
+        ``#N{addr}\\r#E1``. The modules fire in unison — single-frame
+        atomic activation, no per-channel round-trip.
         """
         if not bus_address:
             raise HomeAssistantError(

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.12.10",
+  "version": "2.13.0",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.20.6"
+    "nikobus-connect>=0.21.0"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }

--- a/custom_components/nikobus/scene.py
+++ b/custom_components/nikobus/scene.py
@@ -114,6 +114,11 @@ class NikobusCFSceneEntity(NikobusEntity, Scene):
             name = f"Nikobus switch CF {addr} ({member_count} ch)"
         elif pattern == "roller_pair":
             name = f"Nikobus roller CF {addr} ({member_count} ch)"
+        elif pattern == "light_scene":
+            # CF triggered by a real wall button / IR input, detected
+            # from a light-scene/preset member mode (the "MCF" link
+            # fingerprint). ``addr`` is the trigger's bus address.
+            name = f"Nikobus light scene {addr} ({member_count} ch)"
         else:
             name = f"Nikobus CF {addr} ({member_count} ch)"
 

--- a/tests/test_cf_ingest.py
+++ b/tests/test_cf_ingest.py
@@ -83,6 +83,33 @@ class TestIngestCFBroadcasts(unittest.TestCase):
         # Save was actually issued.
         coord.cf_storage.async_save.assert_awaited_once()
 
+    def test_light_scene_cf_lands_in_storage(self):
+        """Light-scene CFs (button/IR-sourced, detected from a
+        light-scene/preset member mode by nikobus-connect 0.21.0)
+        persist through the same path, pattern preserved, with their
+        mixed-mode members (dimmer preset + switch/shutter plain)."""
+        coord = _make_coord_with_cf_storage(
+            {
+                "0D1C9E": _stub_cf_broadcast(
+                    "0D1C9E",
+                    "light_scene",
+                    [
+                        _stub_cf_member("0E6C", 1, "M04 (Light scene on)"),
+                        _stub_cf_member("4707", 12, "M02 (On + Operating time)"),
+                        _stub_cf_member("8394", 1, "M02 (Open)"),
+                    ],
+                )
+            }
+        )
+
+        _run(coord._ingest_cf_broadcasts())
+
+        stored = coord.cf_storage.data["nikobus_cf"]["0D1C9E"]
+        self.assertEqual(stored["pattern"], "light_scene")
+        self.assertEqual(len(stored["outputs"]), 3)
+        members = {(o["module_address"], o["channel"]) for o in stored["outputs"]}
+        self.assertEqual(members, {("0E6C", 1), ("4707", 12), ("8394", 1)})
+
     def test_switch_pair_alles_uit_spray_lands_full(self):
         coord = _make_coord_with_cf_storage(
             {


### PR DESCRIPTION
## Summary

Surfaces the **button/IR-sourced light-scene Central Functions** newly classified by `nikobus-connect` 0.21.0 as Home Assistant scene entities.

Requires `nikobus-connect>=0.21.0`. The library now exposes these CFs on `discovered_cf_broadcasts` with `pattern="light_scene"`, so they flow through the existing `_ingest_cf_broadcasts` → `cf_storage` → scene-entity path **unchanged**.

## Changes

- **`scene.py`**: friendly default name for the `light_scene` pattern (`Nikobus light scene <addr> (N ch)`).
- **`coordinator.py`**: `async_activate_cf_broadcast` docstring now covers the light-scene flavour — same `#N{addr}\r#E1` wall-button-simulation frame; the address is the real button/IR trigger the members link to (e.g. IR channel `0D1C9E`).
- **`manifest.json`**: version `2.13.0`, require `nikobus-connect>=0.21.0`.
- **test**: light-scene CF ingest with mixed-mode members (`tests/test_cf_ingest.py`).

## Behaviour

After a discovery, light-scene CFs appear as scenes (e.g. CF6 "Scene-Dinner" = source `0D1C9E` → dimmer preset + switch + shutter). Activating the scene sends the trigger frame, firing the members in unison.

The human **name** (e.g. "Scene-Dinner") is the only piece not on the bus — it lives in the `.nkb` — so scenes appear with a bus-address default name and you rename them via the standard HA flow.

## Tests

HA CF ingest/storage suites green (incl. the new light-scene case).

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_