### PR TITLE
2.13.1: require nikobus-connect>=0.21.1 (light-scene classifier fix)

### DIFF
--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.21.0"
+    "nikobus-connect>=0.21.1"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }


### PR DESCRIPTION
Bumps the pin to `nikobus-connect>=0.21.1`, which fixes the light-scene CF classifier so it runs even when the discovery's unmatched set is empty — the case for installs whose only CFs are button/IR-triggered light scenes (like CF6 "Scene-Dinner"). See fdebrus/nikobus-connect#100.

Without this bump the merged 2.13.0 surfaces no light scenes on such installs.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_