### PR TITLE
2.13.2: require nikobus-connect>=0.21.2 (light-scene CF grouping fix)

### DIFF
--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.21.1"
+    "nikobus-connect>=0.21.2"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }


### PR DESCRIPTION
Bumps the pin to `nikobus-connect>=0.21.2`, which fixes light-scene CF grouping: IR-triggered scenes now key on their IR **channel slot** (e.g. `0D1C9E`) instead of the receiver base (`0D1C80`). Each scene surfaces as its own entity with only its members — no receiver-wide merge, no physical-button leakage. See fdebrus/nikobus-connect#101.

Without this, a discovery surfaces one bogus 22-output "CF" per IR receiver instead of the individual scenes.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_