### PR TITLE
2.13.3: stop orphan-cleanup from evicting CF/light-scene entities

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -1253,6 +1253,14 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         for scene in self.dict_scene_data.get("scene", []):
             if sid := scene.get("id"):
                 known.add(f"{DOMAIN}_scene_{sid}")
+        # CF / light-scene entities classified by the library during
+        # discovery and surfaced by the scene platform as
+        # ``NikobusCFSceneEntity`` (unique_id ``nikobus_cf_<addr>``).
+        # Without these, ``_async_cleanup_orphan_entities`` evicts them
+        # immediately after the scene platform creates them.
+        if self.cf_storage is not None:
+            for cf_addr in self.cf_storage.data.get("nikobus_cf", {}):
+                known.add(f"nikobus_cf_{str(cf_addr).lower()}")
         known.add(f"{DOMAIN}_connection_status")
         known.add(f"{DOMAIN}_discovery_status")
         known.add(f"{DOMAIN}_discovery_progress")

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.13.2",
+  "version": "2.13.3",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/tests/test_known_entity_cf_scenes.py
+++ b/tests/test_known_entity_cf_scenes.py
@@ -1,0 +1,57 @@
+"""Regression test: CF / light-scene entities must be in the known-id set.
+
+``_async_cleanup_orphan_entities`` removes any Nikobus entity whose
+``unique_id`` is not returned by
+``NikobusDataCoordinator.get_known_entity_unique_ids``. The scene
+platform creates one ``NikobusCFSceneEntity`` per persisted CF with
+``unique_id = f"nikobus_cf_{addr.lower()}"``. If those ids are missing
+from the known set, the cleanup evicts the scenes right after they are
+created — the user sees no scene entities even though ``nikobus.cfs``
+is populated (Nikobus-HA, light-scene CF surfacing).
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+from custom_components.nikobus.coordinator import NikobusDataCoordinator
+
+
+def _coord_with_cfs(cf_addrs):
+    coord = NikobusDataCoordinator.__new__(NikobusDataCoordinator)
+    coord.dict_module_data = {}
+    coord.dict_button_data = {}
+    coord.dict_scene_data = {}
+    coord.cf_storage = MagicMock()
+    coord.cf_storage.data = {
+        "nikobus_cf": {addr: {"pattern": "light_scene", "outputs": []} for addr in cf_addrs}
+    }
+    return coord
+
+
+class TestKnownEntityIdsIncludeCFScenes(unittest.TestCase):
+    def test_cf_scene_unique_ids_are_known(self):
+        coord = _coord_with_cfs(["0D1C9E", "0FFEC8"])
+
+        known = coord.get_known_entity_unique_ids()
+
+        # Must match scene.py: f"nikobus_cf_{addr.lower()}"
+        self.assertIn("nikobus_cf_0d1c9e", known)
+        self.assertIn("nikobus_cf_0ffec8", known)
+
+    def test_no_cfs_is_safe(self):
+        coord = _coord_with_cfs([])
+        known = coord.get_known_entity_unique_ids()
+        self.assertFalse(any(k.startswith("nikobus_cf_") for k in known))
+
+    def test_missing_cf_storage_is_safe(self):
+        coord = _coord_with_cfs([])
+        coord.cf_storage = None
+        # Should not raise.
+        known = coord.get_known_entity_unique_ids()
+        self.assertIsInstance(known, set)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

Discovery classified and **persisted** the light scenes correctly (`nikobus.cfs` contains `0D1C9E`, `0D1C9F`, `0FFEC8` with full members), the scene platform created the `NikobusCFSceneEntity` entities — but **no scene entities appeared in HA**.

Root cause: `async_setup_entry` runs `_async_cleanup_orphan_entities` right after forwarding platforms. That cleanup removes any Nikobus entity whose `unique_id` isn't in `get_known_entity_unique_ids()`. The known set lists **software** scenes (`nikobus_scene_*`) but **not** the CF/light-scene entities (`nikobus_cf_<addr>`). So the scenes were created and then **immediately evicted** on every setup.

## Fix

Add the persisted CF addresses from `cf_storage` to the known-id set, matching `scene.py`'s `unique_id = f"nikobus_cf_{addr.lower()}"`.

## Test

`tests/test_known_entity_cf_scenes.py` — asserts `nikobus_cf_<addr>` ids are in the known set, and that empty / missing `cf_storage` is safe. Full suite: **225 passed**.

After this, the three scenes survive setup and show up (Developer Tools → States / the entity list) — ready to rename and activate.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_