### PR TITLE
2.14.0: naming + stateful A/B latch switch for PC-Logic / Modular-Interface inputs

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -1261,6 +1261,11 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         if self.cf_storage is not None:
             for cf_addr in self.cf_storage.data.get("nikobus_cf", {}):
                 known.add(f"nikobus_cf_{str(cf_addr).lower()}")
+        # Stateful A/B latch switches for PC-Logic / Modular-Interface
+        # inputs (switch platform, unique_id ``nikobus_input_switch_<addr>``).
+        for in_addr, phys in self.dict_button_data.get("nikobus_button", {}).items():
+            if isinstance(phys, dict) and phys.get("pc_logic_parent_type") in INPUT_MODULE_TYPES:
+                known.add(f"nikobus_input_switch_{str(in_addr).lower()}")
         known.add(f"{DOMAIN}_connection_status")
         known.add(f"{DOMAIN}_discovery_status")
         known.add(f"{DOMAIN}_discovery_progress")

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.13.4",
+  "version": "2.13.5",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.13.3",
+  "version": "2.13.4",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.13.5",
+  "version": "2.14.0",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/custom_components/nikobus/scene.py
+++ b/custom_components/nikobus/scene.py
@@ -118,7 +118,7 @@ class NikobusCFSceneEntity(NikobusEntity, Scene):
             # CF triggered by a real wall button / IR input, detected
             # from a light-scene/preset member mode (the "MCF" link
             # fingerprint). ``addr`` is the trigger's bus address.
-            name = f"Nikobus light scene {addr} ({member_count} ch)"
+            name = f"Nikobus CF scene {addr} ({member_count} ch)"
         else:
             name = f"Nikobus CF {addr} ({member_count} ch)"
 

--- a/custom_components/nikobus/scene.py
+++ b/custom_components/nikobus/scene.py
@@ -118,7 +118,7 @@ class NikobusCFSceneEntity(NikobusEntity, Scene):
             # CF triggered by a real wall button / IR input, detected
             # from a light-scene/preset member mode (the "MCF" link
             # fingerprint). ``addr`` is the trigger's bus address.
-            name = f"Nikobus CF scene {addr} ({member_count} ch)"
+            name = f"Nikobus scene {addr} ({member_count} ch)"
         else:
             name = f"Nikobus CF {addr} ({member_count} ch)"
 

--- a/custom_components/nikobus/switch.py
+++ b/custom_components/nikobus/switch.py
@@ -11,14 +11,65 @@ from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .const import DOMAIN, EVENT_BUTTON_OPERATION
+from .button import _pc_logic_input_naming
+from .const import DOMAIN, EVENT_BUTTON_OPERATION, EVENT_BUTTON_PRESSED
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity
-from .router import build_unique_id, get_routing, register_output_module_devices
+from .router import (
+    INPUT_MODULE_TYPES,
+    build_unique_id,
+    get_routing,
+    register_output_module_devices,
+)
+
+try:  # nikobus-connect provides the input-address math
+    from nikobus_connect.discovery.protocol import (
+        convert_nikobus_address,
+        derive_pc_logic_input_physicals,
+    )
+except Exception:  # pragma: no cover - defensive (older library)
+    convert_nikobus_address = None
+    derive_pc_logic_input_physicals = None
 
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
+
+
+def input_ab_addresses(phys: dict[str, Any]) -> tuple[str, str] | None:
+    """Return ``(addr_1A, addr_1B)`` bus addresses for a synthesized
+    PC-Logic / Modular-Interface input, or ``None``.
+
+    A PC-Logic logical input emits two bus events — its 1A and 1B
+    forms. Validated against two installs (and the library's own
+    derivation note):
+
+      * ``1A = convert_nikobus_address(physical)``
+      * ``1B`` = ``1A`` with the first hex nibble incremented by 4
+
+    The physical address is re-derived from the input's
+    ``pc_logic_parent_address`` + ``pc_logic_slot_index`` provenance so
+    this doesn't depend on the button-store key format.
+    """
+
+    if convert_nikobus_address is None or derive_pc_logic_input_physicals is None:
+        return None
+    parent = phys.get("pc_logic_parent_address")
+    slot = phys.get("pc_logic_slot_index")
+    if not isinstance(parent, str) or not isinstance(slot, int) or slot < 1:
+        return None
+    try:
+        physicals = derive_pc_logic_input_physicals(parent, max(slot, 6))
+    except Exception:  # pragma: no cover - defensive
+        return None
+    if slot > len(physicals):
+        return None
+    addr_1a = convert_nikobus_address(physicals[slot - 1])
+    if not isinstance(addr_1a, str) or len(addr_1a) != 6:
+        return None
+    addr_1a = addr_1a.upper()
+    addr_1b = format((int(addr_1a[0], 16) + 4) % 16, "X") + addr_1a[1:]
+    return addr_1a, addr_1b
 
 
 async def async_setup_entry(
@@ -38,17 +89,46 @@ async def async_setup_entry(
         if spec.kind == "relay_switch":
             entities.append(
                 NikobusRelaySwitchEntity(
-                    coordinator, spec.address, spec.channel, 
+                    coordinator, spec.address, spec.channel,
                     spec.channel_description, spec.module_desc, spec.module_model
                 )
             )
         elif spec.kind == "cover_binary":
             entities.append(
                 NikobusCoverSwitchEntity(
-                    coordinator, spec.address, spec.channel, 
+                    coordinator, spec.address, spec.channel,
                     spec.channel_description, spec.module_desc, spec.module_model
                 )
             )
+
+    # Stateful A/B latch switch per PC-Logic / Modular-Interface input.
+    # The input itself surfaces as a stateless button (button.py); this
+    # adds a persistent on/off mirror: the 1A signal turns it on, 1B
+    # turns it off, and turn_on/off drive the corresponding bus frame.
+    for physical_addr, phys in coordinator.dict_button_data.get(
+        "nikobus_button", {}
+    ).items():
+        if not isinstance(phys, dict):
+            continue
+        if phys.get("pc_logic_parent_type") not in INPUT_MODULE_TYPES:
+            continue
+        naming = _pc_logic_input_naming(phys)
+        ab = input_ab_addresses(phys)
+        if naming is None or ab is None:
+            continue
+        device_name, via_device = naming
+        addr_1a, addr_1b = ab
+        entities.append(
+            NikobusInputLatchSwitch(
+                coordinator,
+                physical_addr=str(physical_addr).upper(),
+                addr_1a=addr_1a,
+                addr_1b=addr_1b,
+                device_name=device_name,
+                via_device=via_device,
+                model=str(phys.get("model") or "Logical Input"),
+            )
+        )
 
     async_add_entities(entities)
 
@@ -203,3 +283,87 @@ class NikobusCoverSwitchEntity(NikobusBaseSwitch):
             self._is_on = None
             self.async_write_ha_state()
             raise err
+
+class NikobusInputLatchSwitch(NikobusEntity, SwitchEntity, RestoreEntity):
+    """Stateful on/off latch for a PC-Logic / Modular-Interface input.
+
+    A PC-Logic logical input is momentary on the bus: it emits a 1A
+    pulse and a 1B pulse rather than holding a level. This entity gives
+    that input a persistent on/off state in HA:
+
+      * the **1A** bus signal latches it **on**, **1B** latches it
+        **off** (observed via the ``nikobus_button_pressed`` event, so
+        physical presses and other controllers are tracked too);
+      * ``turn_on`` / ``turn_off`` drive the corresponding 1A / 1B bus
+        frame (same ``#N<addr>\\r#E1`` path as a wall-button simulation).
+
+    State is restored across restarts. It lives alongside the stateless
+    input button entity, sharing the same input device.
+    """
+
+    def __init__(
+        self,
+        coordinator: NikobusDataCoordinator,
+        *,
+        physical_addr: str,
+        addr_1a: str,
+        addr_1b: str,
+        device_name: str,
+        via_device: tuple[str, str],
+        model: str,
+    ) -> None:
+        super().__init__(
+            coordinator=coordinator,
+            address=physical_addr,
+            name=device_name,
+            model=model,
+            via_device=via_device,
+        )
+        self._addr_1a = addr_1a
+        self._addr_1b = addr_1b
+        self._attr_name = "A/B state"
+        self._attr_unique_id = f"nikobus_input_switch_{physical_addr.lower()}"
+        self._attr_is_on = False
+
+    @property
+    def is_on(self) -> bool:
+        return self._attr_is_on
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        parent = super().extra_state_attributes or {}
+        return {**parent, "address_1a": self._addr_1a, "address_1b": self._addr_1b}
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        last = await self.async_get_last_state()
+        if last is not None and last.state in ("on", "off"):
+            self._attr_is_on = last.state == "on"
+        self.async_on_remove(
+            self.hass.bus.async_listen(EVENT_BUTTON_PRESSED, self._handle_button_event)
+        )
+
+    @callback
+    def _handle_button_event(self, event: Event) -> None:
+        """Latch on the 1A signal, clear on the 1B signal."""
+        addr = str(event.data.get("address") or "").upper()
+        if addr == self._addr_1a:
+            self._attr_is_on = True
+            self.async_write_ha_state()
+        elif addr == self._addr_1b:
+            self._attr_is_on = False
+            self.async_write_ha_state()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        await self.coordinator.async_event_handler(
+            "ha_button_pressed", {"address": self._addr_1a}
+        )
+        self._attr_is_on = True
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self.coordinator.async_event_handler(
+            "ha_button_pressed", {"address": self._addr_1b}
+        )
+        self._attr_is_on = False
+        self.async_write_ha_state()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,7 @@ _mod("homeassistant")
 _mod(
     "homeassistant.core",
     HomeAssistant=type("HomeAssistant", (), {}),
+    Event=type("Event", (), {}),
     callback=_ha_callback,
 )
 class _ConfigEntry:
@@ -211,12 +212,12 @@ _mod(
 )
 _mod(
     "homeassistant.helpers.entity",
-    EntityCategory=type("EntityCategory", (), {"DIAGNOSTIC": "diagnostic"}),
+    EntityCategory=type("EntityCategory", (), {"DIAGNOSTIC": "diagnostic", "CONFIG": "config"}),
 )
 _mod(
     "homeassistant.const",
     PERCENTAGE="%",
-    EntityCategory=type("EntityCategory", (), {"DIAGNOSTIC": "diagnostic"}),
+    EntityCategory=type("EntityCategory", (), {"DIAGNOSTIC": "diagnostic", "CONFIG": "config"}),
 )
 _mod(
     "homeassistant.helpers.entity_platform",
@@ -224,6 +225,21 @@ _mod(
     AddConfigEntryEntitiesCallback=type("AddConfigEntryEntitiesCallback", (), {}),
 )
 _mod("homeassistant.components.binary_sensor", BinarySensorEntity=type("BinarySensorEntity", (), {}), DOMAIN="binary_sensor")
+_mod("homeassistant.components.switch", SwitchEntity=type("SwitchEntity", (), {}), DOMAIN="switch")
+_mod("homeassistant.components.button", ButtonEntity=type("ButtonEntity", (), {}), DOMAIN="button")
+
+
+class _RestoreEntityStub:
+    """Minimal stub for RestoreEntity."""
+
+    async def async_get_last_state(self):  # pragma: no cover - overridden in tests
+        return None
+
+    async def async_added_to_hass(self):  # pragma: no cover
+        return None
+
+
+_mod("homeassistant.helpers.restore_state", RestoreEntity=_RestoreEntityStub)
 
 # ---------------------------------------------------------------------------
 # Third-party stubs

--- a/tests/test_input_latch_switch.py
+++ b/tests/test_input_latch_switch.py
@@ -1,0 +1,81 @@
+"""Tests for the PC-Logic / Modular-Interface input A/B latch switch."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+from custom_components.nikobus.switch import input_ab_addresses
+from custom_components.nikobus.coordinator import NikobusDataCoordinator
+
+
+class TestInputABAddresses(unittest.TestCase):
+    """``input_ab_addresses`` must match the library's derivation
+    (validated against the documented 0x940C install):
+
+        slot 1 -> 1A 21814B / 1B 61814B
+        slot 4 -> 1A 09814B / 1B 49814B
+    """
+
+    def _phys(self, slot, parent="940C", ptype="pc_logic"):
+        return {
+            "pc_logic_parent_address": parent,
+            "pc_logic_slot_index": slot,
+            "pc_logic_parent_type": ptype,
+        }
+
+    def test_slot1(self):
+        self.assertEqual(input_ab_addresses(self._phys(1)), ("21814B", "61814B"))
+
+    def test_slot4(self):
+        self.assertEqual(input_ab_addresses(self._phys(4)), ("09814B", "49814B"))
+
+    def test_1b_is_first_nibble_plus_four(self):
+        a, b = input_ab_addresses(self._phys(1))
+        self.assertEqual(int(b[0], 16), (int(a[0], 16) + 4) % 16)
+        self.assertEqual(a[1:], b[1:])
+
+    def test_interface_module_uses_same_derivation(self):
+        # interface_module inputs derive identically (the library uses
+        # the same helper for both types).
+        self.assertEqual(
+            input_ab_addresses(self._phys(1, ptype="interface_module")),
+            ("21814B", "61814B"),
+        )
+
+    def test_missing_provenance_returns_none(self):
+        self.assertIsNone(input_ab_addresses({}))
+        self.assertIsNone(input_ab_addresses({"pc_logic_parent_address": "940C"}))
+
+
+class TestInputSwitchKnownIds(unittest.TestCase):
+    """The latch switch's unique_id must be in the known set so the
+    orphan cleanup doesn't evict it."""
+
+    def test_input_switch_ids_are_known(self):
+        coord = NikobusDataCoordinator.__new__(NikobusDataCoordinator)
+        coord.dict_module_data = {}
+        coord.dict_scene_data = {}
+        coord.cf_storage = MagicMock()
+        coord.cf_storage.data = {"nikobus_cf": {}}
+        coord.dict_button_data = {
+            "nikobus_button": {
+                "64A061": {
+                    "pc_logic_parent_address": "940C",
+                    "pc_logic_slot_index": 1,
+                    "pc_logic_parent_type": "pc_logic",
+                },
+                # an ordinary wall button must NOT get an input-switch id
+                "1DF1E0": {"type": "Wall Button"},
+            }
+        }
+
+        known = coord.get_known_entity_unique_ids()
+
+        # Must match switch.py: f"nikobus_input_switch_{addr.lower()}"
+        self.assertIn("nikobus_input_switch_64a061", known)
+        self.assertNotIn("nikobus_input_switch_1df1e0", known)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This branch accumulated a few related changes (HA → **2.14.0**):

## 1. Scene default naming
Auto-detected light-scene CFs now default to **`Nikobus scene <addr> (<n> ch)`** (from "light scene" → "CF scene" → final "scene"). Cosmetic; manual renames preserved.

## 2. Stateful A/B latch switch for inputs (the main feature)

A new **controllable switch per PC-Logic (05-201) / Modular Interface (05-206) logical input**.

These inputs are **momentary** on the bus — each emits a **1A pulse** and a **1B pulse** rather than holding a level, so as stateless buttons HA couldn't represent "is this input in its A or B state". The switch fixes that:

- **State latches** on the **1A** signal (→ on) / **1B** signal (→ off), observed via the `nikobus_button_pressed` event (tracks physical presses + other controllers, not just HA). **Restored across restarts.**
- **Controllable:** `turn_on`/`turn_off` drive the 1A / 1B bus frame (same `#N<addr>\r#E1` path as scene activation).
- **Added alongside** the existing stateless input button (shares the input device). Fixed mapping **1A = on, 1B = off**.

**A/B address derivation** (no library change — uses existing helpers): from the input's `pc_logic_parent_address` + `pc_logic_slot_index`, `1A = convert_nikobus_address(physical)`, `1B` = first nibble +4. Verified against the documented `0x940C` install (slot1 `21814B`/`61814B`, slot4 `09814B`/`49814B`).

`nikobus_input_switch_<addr>` unique_ids added to the known-id set so the orphan cleanup keeps them.

## Tests
A/B address math + known-id inclusion; conftest stubs for `components.switch`/`button`, `restore_state`, `core.Event`, `EntityCategory.CONFIG`. **231 passed.**

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj