### PR TITLE
2.14.1: require nikobus-connect>=0.22.0 (light-scene CF activation fix)

### DIFF
--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.21.2"
+    "nikobus-connect>=0.22.0"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }


### PR DESCRIPTION
## Summary

Bumps the `nikobus-connect` floor to **`>=0.22.0`** (version `2.14.0` → `2.14.1`) so the integration pulls the **light-scene CF activation fix** — [nikobus-connect#102](https://github.com/fdebrus/nikobus-connect/pull/102), merged and released as `v0.22.0`.

## Why

Light-scene scenes activated but **nothing fired**: the CF stored the trigger's *base* address (e.g. IR slot `0D1C9E`), which never appears on the bus, so `#N<addr>\r#E1` matched no module. `0.22.0` keys CFs on the keyed **wire** address (the real `#N` frame, e.g. `DE4E2C`) and splits a multi-key base into one CF per key.

## Changes

- `manifest.json`: `nikobus-connect>=0.21.2` → `>=0.22.0`, version `2.14.0` → `2.14.1`

No HA code change — the scene platform already broadcasts the stored `bus_address`, and the known-id set is derived from `cf_storage`, so the changed CF unique_ids (`base` → wire form) are handled automatically: existing auto CF scene entities are replaced cleanly on the next discovery.

## Deploy note

Requires `nikobus-connect 0.22.0` on PyPI for the pin to resolve — done (released `v0.22.0`). After updating, re-run **Discover modules & buttons → Scan all module links**; light scenes then activate the linked outputs.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_