### PR TITLE
2.15.0: send simulated button presses as a repeated burst (reliability)

### DIFF
--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -24,8 +24,10 @@ from homeassistant.helpers.selector import (
 from .const import (
     CONF_CONNECTION_STRING,
     CONF_HAS_FEEDBACK_MODULE,
+    CONF_PRESS_REPEAT,
     CONF_PRIOR_GEN3,
     CONF_REFRESH_INTERVAL,
+    DEFAULT_PRESS_REPEAT,
     DOMAIN,
 )
 from .coordinator import NikobusConfigEntry
@@ -189,6 +191,10 @@ def _hardware_schema(defaults: dict[str, Any]) -> vol.Schema:
             CONF_PRIOR_GEN3,
             default=defaults.get(CONF_PRIOR_GEN3, False),
         ): bool,
+        vol.Optional(
+            CONF_PRESS_REPEAT,
+            default=defaults.get(CONF_PRESS_REPEAT, DEFAULT_PRESS_REPEAT),
+        ): vol.All(cv.positive_int, vol.Range(min=1, max=10)),
     })
 
 

--- a/custom_components/nikobus/const.py
+++ b/custom_components/nikobus/const.py
@@ -135,6 +135,7 @@ CONF_CONNECTION_STRING: Final[str] = "connection_string"
 CONF_REFRESH_INTERVAL: Final[str] = "refresh_interval"
 CONF_HAS_FEEDBACK_MODULE: Final[str] = "has_feedbackmodule"
 CONF_PRIOR_GEN3: Final[str] = "prior_gen3"
+CONF_PRESS_REPEAT: Final[str] = "press_repeat"
 
 # Filenames used by the manual-config import — the step-1 inventory
 # source for installs without a PC-Link. Both are read on every
@@ -164,6 +165,17 @@ HANDSHAKE_TIMEOUT: Final[int] = 60  # Timeout for handshake in seconds
 # =============================================================================
 REFRESH_DELAY: Final[float] = 0.5  # Delay before retrieving status after button press
 DIMMER_DELAY: Final[int] = 1  # Delay before retrieving dimmer status
+
+# Simulated-button-press repetition. A real Nikobus button emits its
+# telegram repeatedly for as long as it's held, and modules only act on
+# a command seen at least twice (the bus protocol's noise/collision
+# guard). A single #N frame is therefore unreliable under bus
+# contention, so HA-originated presses (button, scene, CF, latch switch)
+# are sent as a short, spaced burst. ``DEFAULT_PRESS_REPEAT`` mirrors
+# the reference firmware's "2 to register, 3 to be sure"; the per-repeat
+# gap keeps the burst short enough to read as a tap, not a hold.
+DEFAULT_PRESS_REPEAT: Final[int] = 3
+PRESS_REPEAT_DELAY: Final[float] = 0.05  # seconds between repeated #N frames
 SHORT_PRESS: Final[float] = 1.0  # Short press duration in seconds
 BUTTON_TIMER_THRESHOLDS: Final[tuple[int, int, int]] = (1, 2, 3)
 

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -27,8 +27,11 @@ from nikobus_connect.exceptions import NikobusConnectionError, NikobusDataError,
 from .const import (
     CONF_CONNECTION_STRING,
     CONF_HAS_FEEDBACK_MODULE,
+    CONF_PRESS_REPEAT,
     CONF_PRIOR_GEN3,
     CONF_REFRESH_INTERVAL,
+    DEFAULT_PRESS_REPEAT,
+    PRESS_REPEAT_DELAY,
     DEVICE_ADDRESS_INVENTORY,
     DEVICE_INVENTORY_ANSWER,
     DISCOVERY_PHASE_ERROR,
@@ -111,6 +114,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self._refresh_interval = _opts.get(CONF_REFRESH_INTERVAL, config_entry.data.get(CONF_REFRESH_INTERVAL, 120))
         self._has_feedback_module = _opts.get(CONF_HAS_FEEDBACK_MODULE, config_entry.data.get(CONF_HAS_FEEDBACK_MODULE, False))
         self._prior_gen3 = _opts.get(CONF_PRIOR_GEN3, config_entry.data.get(CONF_PRIOR_GEN3, False))
+        self._press_repeat = _opts.get(CONF_PRESS_REPEAT, config_entry.data.get(CONF_PRESS_REPEAT, DEFAULT_PRESS_REPEAT))
 
         super().__init__(
             hass,
@@ -1031,10 +1035,38 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
     # Event / dispatcher
     # ------------------------------------------------------------------
 
+    async def async_send_button_press(self, address: str) -> None:
+        """Put a simulated button press on the bus as a short, spaced burst.
+
+        A real Nikobus button emits its telegram repeatedly for as long
+        as it's held, and modules only act on a command seen at least
+        twice (the bus protocol's noise/collision guard). A single ``#N``
+        frame is therefore unreliable under bus contention — the symptom
+        being presses that "sometimes" do nothing. We mirror the
+        reference firmware ("2 to register, 3 to be sure") by repeating
+        the frame ``CONF_PRESS_REPEAT`` times (default 3) with a small
+        inter-frame gap, kept short enough to read as a tap, not a hold.
+
+        Shared by every HA-originated press: input buttons, the input
+        A/B latch switch, software-scene feedback LEDs, and CF /
+        light-scene activation.
+        """
+        if not address:
+            return
+        try:
+            repeats = max(1, int(self._press_repeat))
+        except (TypeError, ValueError):
+            repeats = DEFAULT_PRESS_REPEAT
+        command = f"#N{address}\r#E1"
+        for i in range(repeats):
+            await self.nikobus_command.queue_command(command)
+            if i < repeats - 1:
+                await asyncio.sleep(PRESS_REPEAT_DELAY)
+
     async def async_event_handler(self, event: str, data: dict[str, Any]) -> None:
         """Dispatch events and trigger targeted entity updates."""
         if event == "ha_button_pressed":
-            await self.nikobus_command.queue_command(f"#N{data.get('address')}\r#E1")
+            await self.async_send_button_press(str(data.get("address") or ""))
 
         if address := data.get("impacted_module_address"):
             async_dispatcher_send(self.hass, f"{DOMAIN}_update_{address}")
@@ -1520,7 +1552,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             )
         addr = bus_address.upper()
         _LOGGER.info("Activating Nikobus CF broadcast: %s", addr)
-        await self.nikobus_command.queue_command(f"#N{addr}\r#E1")
+        await self.async_send_button_press(addr)
 
     async def _reconcile_post_discovery(
         self,

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.14.1",
+  "version": "2.15.0",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/custom_components/nikobus/scene.py
+++ b/custom_components/nikobus/scene.py
@@ -341,9 +341,10 @@ class NikobusSceneEntity(NikobusEntity, Scene):
         """Send feedback LED trigger commands."""
         for addr in self._feedback_leds:
             _LOGGER.debug("Triggering feedback LED/Button: %s", addr)
-            # Standard Nikobus command for button trigger
-            cmd = f"#N{addr}\r#E1"
-            await self.coordinator.nikobus_command.queue_command(cmd)
+            # Standard Nikobus button trigger — sent as a repeated burst
+            # (see coordinator.async_send_button_press) so it isn't
+            # dropped under bus contention.
+            await self.coordinator.async_send_button_press(addr)
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -1,305 +1,309 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
-        },
-        "error": {
-            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-            "unknown": "[%key:common::config_flow::error::unknown%]"
-        },
-        "step": {
-            "hardware": {
-                "data": {
-                    "has_feedbackmodule": "Feedback Module (05-207) installed and connected via PC-Link",
-                    "prior_gen3": "PC-Link is older than Gen 3"
-                },
-                "data_description": {
-                    "has_feedbackmodule": "When enabled, the Feedback Module pushes state changes automatically — no polling needed.",
-                    "prior_gen3": "Enables compatibility tweaks for first and second-generation PC-Link hardware."
-                },
-                "description": "Tell us about your Nikobus hardware so the integration can use the optimal update strategy.",
-                "title": "Hardware Configuration"
-            },
-            "polling": {
-                "data": {
-                    "refresh_interval": "Polling interval (seconds)"
-                },
-                "data_description": {
-                    "refresh_interval": "How often to read module states from the bus (60–3600 s). Lower values mean faster updates but more bus traffic."
-                },
-                "description": "Without a Feedback Module, Home Assistant polls the Nikobus bus periodically. Choose how often.",
-                "title": "Polling Interval"
-            },
-            "reconfigure": {
-                "data": {
-                    "connection_string": "Connection (serial port or IP:port)",
-                    "has_feedbackmodule": "Feedback Module (05-207) installed and connected via PC-Link",
-                    "prior_gen3": "PC-Link is older than Gen 3",
-                    "refresh_interval": "Polling interval (seconds)"
-                },
-                "data_description": {
-                    "connection_string": "Serial device path or TCP address of the PC-Link bridge",
-                    "has_feedbackmodule": "When enabled, the Feedback Module pushes state changes automatically — no polling needed.",
-                    "prior_gen3": "Enables compatibility tweaks for first and second-generation PC-Link hardware.",
-                    "refresh_interval": "How often to read module states from the bus (60–3600 s). Lower values mean faster updates but more bus traffic."
-                },
-                "description": "Update the connection string or hardware settings. The connection will be re-tested.",
-                "title": "Reconfigure Nikobus"
-            },
-            "user": {
-                "data": {
-                    "connection_string": "Connection (serial port or IP:port)"
-                },
-                "data_description": {
-                    "connection_string": "Serial device path or TCP address of the PC-Link bridge"
-                },
-                "description": "Enter the address of your Nikobus PC-Link module.\n\n- **Serial port**: `/dev/ttyUSB0` or `COM3`\n- **Network bridge**: `192.168.1.50:9999`",
-                "title": "Connect to Nikobus"
-            }
-        }
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     },
-    "entity": {
-        "button": {
-            "discover_modules_buttons": {
-                "name": "Discover modules & buttons"
-            },
-            "scan_all_module_links": {
-                "name": "Scan all module links"
-            }
-        },
-        "sensor": {
-            "connection": {
-                "name": "Connection",
-                "state": {
-                    "connected": "Connected",
-                    "reconnecting": "Reconnecting",
-                    "disconnected": "Disconnected"
-                }
-            },
-            "discovery_progress": {
-                "name": "Discovery progress"
-            },
-            "discovery_status": {
-                "name": "Discovery status",
-                "state": {
-                    "idle": "Idle",
-                    "pc_link": "PC Link inventory",
-                    "module_scan": "Scanning modules",
-                    "finished": "Finished",
-                    "error": "Error"
-                }
-            }
-        }
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
-    "issues": {
-        "no_buttons_configured": {
-            "title": "No Nikobus buttons configured",
-            "fix_flow": {
-                "step": {
-                    "confirm": {
-                        "title": "Discover Nikobus modules and buttons",
-                        "description": "Home Assistant has not detected any Nikobus buttons. Run a PC-Link inventory discovery now to populate the configuration."
-                    }
-                }
-            }
+    "step": {
+      "hardware": {
+        "data": {
+          "has_feedbackmodule": "Feedback Module (05-207) installed and connected via PC-Link",
+          "prior_gen3": "PC-Link is older than Gen 3",
+          "press_repeat": "Simulated press repeats"
         },
-        "legacy_undecoded_buttons": {
-            "title": "{count} Nikobus button(s) flagged as legacy",
-            "fix_flow": {
-                "step": {
-                    "init": {
-                        "title": "Review legacy Nikobus buttons",
-                        "description": "These {count} button(s) are flagged as legacy after a full Stage-2 scan. The Reason column explains why each one was flagged:\n\n  - **no decoded links** — no output module references this button. Either a wall button used only for Home Assistant automations (KEEP), or residue from a previous owner (PURGE).\n  - **residue / stale links** — the button's links live only in PC-Link / PC-Logic registry memory with no current output module recording them, or every linked module was evicted. Typically residue programming from a previous owner that DIN-button re-pairing didn't clear (PURGE).\n\nTo recover any purged button, re-run **Discover modules & buttons** and then **Scan all module links** — the library re-adds anything currently in the project.\n\n{candidates}\n\nLeave the list empty and submit to keep everything.",
-                        "data": {
-                            "addresses": "Buttons to remove"
-                        }
-                    }
-                },
-                "abort": {
-                    "not_loaded": "The Nikobus integration is not loaded; reload the entry and retry.",
-                    "no_candidates": "No legacy buttons remain — nothing to do."
-                }
-            }
-        }
-    },
-    "exceptions": {
-        "communication_error": {
-            "message": "Communication with Nikobus failed: {error}"
+        "data_description": {
+          "has_feedbackmodule": "When enabled, the Feedback Module pushes state changes automatically — no polling needed.",
+          "prior_gen3": "Enables compatibility tweaks for first and second-generation PC-Link hardware.",
+          "press_repeat": "How many times each HA-triggered press (button, scene, CF, latch switch) is sent on the bus. A real button repeats its telegram, so a single send can be missed under bus contention. Default 3."
         },
-        "forensic_requires_module_address": {
-            "message": "Forensic register scan requires a module_address. Specify one (e.g. 940C) — the register range cannot be applied across all modules."
+        "description": "Tell us about your Nikobus hardware so the integration can use the optimal update strategy.",
+        "title": "Hardware Configuration"
+      },
+      "polling": {
+        "data": {
+          "refresh_interval": "Polling interval (seconds)"
         },
-        "forensic_range_incomplete": {
-            "message": "Forensic mode requires both register_start and register_end. Provide both or omit both."
+        "data_description": {
+          "refresh_interval": "How often to read module states from the bus (60–3600 s). Lower values mean faster updates but more bus traffic."
         },
-        "discovery_already_running": {
-            "message": "A Nikobus discovery is already running."
+        "description": "Without a Feedback Module, Home Assistant polls the Nikobus bus periodically. Choose how often.",
+        "title": "Polling Interval"
+      },
+      "reconfigure": {
+        "data": {
+          "connection_string": "Connection (serial port or IP:port)",
+          "has_feedbackmodule": "Feedback Module (05-207) installed and connected via PC-Link",
+          "prior_gen3": "PC-Link is older than Gen 3",
+          "refresh_interval": "Polling interval (seconds)"
         },
-        "discovery_not_initialized": {
-            "message": "Nikobus discovery is not initialized."
+        "data_description": {
+          "connection_string": "Serial device path or TCP address of the PC-Link bridge",
+          "has_feedbackmodule": "When enabled, the Feedback Module pushes state changes automatically — no polling needed.",
+          "prior_gen3": "Enables compatibility tweaks for first and second-generation PC-Link hardware.",
+          "refresh_interval": "How often to read module states from the bus (60–3600 s). Lower values mean faster updates but more bus traffic."
         },
-        "initialization_error": {
-            "message": "Failed to initialize Nikobus components: {error}"
+        "description": "Update the connection string or hardware settings. The connection will be re-tested.",
+        "title": "Reconfigure Nikobus"
+      },
+      "user": {
+        "data": {
+          "connection_string": "Connection (serial port or IP:port)"
         },
-        "no_loaded_entry": {
-            "message": "No loaded Nikobus integration found. Set one up before calling this action."
+        "data_description": {
+          "connection_string": "Serial device path or TCP address of the PC-Link bridge"
         },
-        "no_modules_known": {
-            "message": "No Nikobus modules are configured yet. Run a PC-Link inventory discovery first, then retry the module scan."
-        },
-        "no_inventory_source": {
-            "message": "No PC-Link detected on the bus and no manual config files found. Either install a PC-Link or create nikobus_module_config.json (and optionally nikobus_button_config.json) in your Home Assistant config directory, then retry."
-        },
-        "cf_no_address": {
-            "message": "Cannot activate a Nikobus CF without a bus address."
-        },
-        "not_connected": {
-            "message": "Nikobus bus is not connected — cannot send a command. Check the connection and retry."
-        }
-    },
-    "options": {
-        "abort": {
-            "not_loaded": "The Nikobus integration is not loaded. Please reload the integration and try again.",
-            "module_not_found": "The selected module was not found in storage.",
-            "channel_not_found": "The selected channel was not found."
-        },
-        "error": {
-            "invalid_hex_address": "LED address must be exactly 6 hexadecimal characters (or empty)."
-        },
-        "step": {
-            "hardware": {
-                "data": {
-                    "has_feedbackmodule": "Feedback Module (05-207) installed and connected via PC-Link",
-                    "prior_gen3": "PC-Link is older than Gen 3"
-                },
-                "data_description": {
-                    "has_feedbackmodule": "When enabled, the Feedback Module pushes state changes automatically — no polling needed.",
-                    "prior_gen3": "Enables compatibility tweaks for first and second-generation PC-Link hardware."
-                },
-                "description": "Update your hardware settings. The integration will reload automatically.",
-                "title": "Hardware Configuration"
-            },
-            "init": {
-                "description": "What would you like to do?",
-                "menu_options": {
-                    "configure_modules": "Customize a module (description, entity type, LED triggers, travel time)",
-                    "hardware": "Change hardware settings"
-                },
-                "title": "Nikobus"
-            },
-            "polling": {
-                "data": {
-                    "refresh_interval": "Polling interval (seconds)"
-                },
-                "data_description": {
-                    "refresh_interval": "How often to read module states from the bus (60–3600 s)."
-                },
-                "description": "How often should Home Assistant poll the Nikobus bus for state changes?",
-                "title": "Polling Interval"
-            },
-            "configure_modules": {
-                "title": "Customize a Nikobus module",
-                "description": "Pick a module to edit. Discovery-owned fields (model, address, channel count) stay read-only; only user-facing fields (descriptions, entity types, LED triggers, travel times) can be changed here.",
-                "data": {
-                    "module": "Module"
-                }
-            },
-            "edit_module": {
-                "title": "Module {address} ({module_type})",
-                "description": "Model: {model}. Edit the module description, override the module type if discovery misclassified it, or pick a channel to customize. Note: re-running *Discover modules & buttons* may overwrite a manual type override until the library learns to respect it.",
-                "data": {
-                    "description": "Module description",
-                    "module_type": "Module type",
-                    "channel": "Channel"
-                }
-            },
-            "edit_channel": {
-                "title": "Module {address} — channel {channel}",
-                "description": "Configure how this channel appears in Home Assistant. Pick **Disabled (hide channel)** in the Entity type dropdown to skip creating an entity for this channel.",
-                "data": {
-                    "entity_type": "Entity type",
-                    "description": "Channel description",
-                    "led_on": "LED-on trigger (6-hex bus address, optional)",
-                    "led_off": "LED-off trigger (6-hex bus address, optional)",
-                    "operation_time_up": "Travel time up (seconds)",
-                    "operation_time_down": "Travel time down (seconds)"
-                }
-            }
-        }
-    },
-    "services": {
-        "query_module_inventory": {
-            "description": "Triggers a Nikobus module inventory scan. Without parameters, scans every output module. With a module_address, scans just that module using the per-module-type tuned ranges. With register_start + register_end (and optionally sub_byte), runs a forensic-mode scan of exactly the requested range — useful for reverse-engineering storage layouts on PC-Logic, interface modules, or unfamiliar regions of any module.",
-            "fields": {
-                "module_address": {
-                    "description": "Optional Nikobus module address (e.g. 940C, F586). Without it, scans every known output module.",
-                    "name": "Module address"
-                },
-                "register_start": {
-                    "description": "Forensic mode — lower bound of the register range to scan, as a hex byte (e.g. 0x70 or 70). Requires register_end and a specific module_address. When provided, the scan walks only this range and skips the production extra-pass logic.",
-                    "name": "Register start"
-                },
-                "register_end": {
-                    "description": "Forensic mode — upper bound of the register range to scan, as a hex byte (e.g. 0x83 or 83). Must be ≥ register_start.",
-                    "name": "Register end"
-                },
-                "sub_byte": {
-                    "description": "Memory bank selector for forensic mode (default 04 — output link table). Other observed banks: 00 (module header / identity), 01 (BP-cell records).",
-                    "name": "Sub-byte"
-                }
-            },
-            "name": "Query module inventory"
-        },
-        "detect_stale_inventory": {
-            "description": "Probes every known output module (switch, dimmer, roller) on the bus and reports which ones don't respond. Returns a manifest with checked / present / absent module lists plus orphaned button addresses. Does not modify configuration; pair with purge_stale_inventory after reviewing the results.",
-            "fields": {
-                "timeout": {
-                    "description": "Per-module probe timeout. Worst-case scan time is roughly N modules × timeout.",
-                    "name": "Probe timeout (seconds)"
-                }
-            },
-            "name": "Detect stale inventory"
-        },
-        "purge_stale_inventory": {
-            "description": "Removes the given addresses from the persisted module and button stores, then reloads the integration so entities for the purged addresses are dropped. Run detect_stale_inventory first to obtain the list of safe-to-remove addresses.",
-            "fields": {
-                "addresses": {
-                    "description": "List of module / button addresses to remove (matched case-insensitively against both stores).",
-                    "name": "Addresses"
-                }
-            },
-            "name": "Purge stale inventory"
-        }
-    },
-    "selector": {
-        "module_type": {
-            "options": {
-                "switch_module": "Switch module",
-                "dimmer_module": "Dimmer module",
-                "roller_module": "Roller / shutter module",
-                "other_module": "Other (PC Logic / Feedback / unclassified)"
-            }
-        },
-        "entity_type_switch_module": {
-            "options": {
-                "default": "Default (switch)",
-                "light": "Light",
-                "disabled": "Disabled (hide channel)"
-            }
-        },
-        "entity_type_dimmer_module": {
-            "options": {
-                "default": "Default (light)",
-                "disabled": "Disabled (hide channel)"
-            }
-        },
-        "entity_type_roller_module": {
-            "options": {
-                "default": "Default (cover)",
-                "switch": "Switch",
-                "light": "Light",
-                "disabled": "Disabled (hide channel)"
-            }
-        }
+        "description": "Enter the address of your Nikobus PC-Link module.\n\n- **Serial port**: `/dev/ttyUSB0` or `COM3`\n- **Network bridge**: `192.168.1.50:9999`",
+        "title": "Connect to Nikobus"
+      }
     }
+  },
+  "entity": {
+    "button": {
+      "discover_modules_buttons": {
+        "name": "Discover modules & buttons"
+      },
+      "scan_all_module_links": {
+        "name": "Scan all module links"
+      }
+    },
+    "sensor": {
+      "connection": {
+        "name": "Connection",
+        "state": {
+          "connected": "Connected",
+          "reconnecting": "Reconnecting",
+          "disconnected": "Disconnected"
+        }
+      },
+      "discovery_progress": {
+        "name": "Discovery progress"
+      },
+      "discovery_status": {
+        "name": "Discovery status",
+        "state": {
+          "idle": "Idle",
+          "pc_link": "PC Link inventory",
+          "module_scan": "Scanning modules",
+          "finished": "Finished",
+          "error": "Error"
+        }
+      }
+    }
+  },
+  "issues": {
+    "no_buttons_configured": {
+      "title": "No Nikobus buttons configured",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Discover Nikobus modules and buttons",
+            "description": "Home Assistant has not detected any Nikobus buttons. Run a PC-Link inventory discovery now to populate the configuration."
+          }
+        }
+      }
+    },
+    "legacy_undecoded_buttons": {
+      "title": "{count} Nikobus button(s) flagged as legacy",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Review legacy Nikobus buttons",
+            "description": "These {count} button(s) are flagged as legacy after a full Stage-2 scan. The Reason column explains why each one was flagged:\n\n  - **no decoded links** — no output module references this button. Either a wall button used only for Home Assistant automations (KEEP), or residue from a previous owner (PURGE).\n  - **residue / stale links** — the button's links live only in PC-Link / PC-Logic registry memory with no current output module recording them, or every linked module was evicted. Typically residue programming from a previous owner that DIN-button re-pairing didn't clear (PURGE).\n\nTo recover any purged button, re-run **Discover modules & buttons** and then **Scan all module links** — the library re-adds anything currently in the project.\n\n{candidates}\n\nLeave the list empty and submit to keep everything.",
+            "data": {
+              "addresses": "Buttons to remove"
+            }
+          }
+        },
+        "abort": {
+          "not_loaded": "The Nikobus integration is not loaded; reload the entry and retry.",
+          "no_candidates": "No legacy buttons remain — nothing to do."
+        }
+      }
+    }
+  },
+  "exceptions": {
+    "communication_error": {
+      "message": "Communication with Nikobus failed: {error}"
+    },
+    "forensic_requires_module_address": {
+      "message": "Forensic register scan requires a module_address. Specify one (e.g. 940C) — the register range cannot be applied across all modules."
+    },
+    "forensic_range_incomplete": {
+      "message": "Forensic mode requires both register_start and register_end. Provide both or omit both."
+    },
+    "discovery_already_running": {
+      "message": "A Nikobus discovery is already running."
+    },
+    "discovery_not_initialized": {
+      "message": "Nikobus discovery is not initialized."
+    },
+    "initialization_error": {
+      "message": "Failed to initialize Nikobus components: {error}"
+    },
+    "no_loaded_entry": {
+      "message": "No loaded Nikobus integration found. Set one up before calling this action."
+    },
+    "no_modules_known": {
+      "message": "No Nikobus modules are configured yet. Run a PC-Link inventory discovery first, then retry the module scan."
+    },
+    "no_inventory_source": {
+      "message": "No PC-Link detected on the bus and no manual config files found. Either install a PC-Link or create nikobus_module_config.json (and optionally nikobus_button_config.json) in your Home Assistant config directory, then retry."
+    },
+    "cf_no_address": {
+      "message": "Cannot activate a Nikobus CF without a bus address."
+    },
+    "not_connected": {
+      "message": "Nikobus bus is not connected — cannot send a command. Check the connection and retry."
+    }
+  },
+  "options": {
+    "abort": {
+      "not_loaded": "The Nikobus integration is not loaded. Please reload the integration and try again.",
+      "module_not_found": "The selected module was not found in storage.",
+      "channel_not_found": "The selected channel was not found."
+    },
+    "error": {
+      "invalid_hex_address": "LED address must be exactly 6 hexadecimal characters (or empty)."
+    },
+    "step": {
+      "hardware": {
+        "data": {
+          "has_feedbackmodule": "Feedback Module (05-207) installed and connected via PC-Link",
+          "prior_gen3": "PC-Link is older than Gen 3",
+          "press_repeat": "Simulated press repeats"
+        },
+        "data_description": {
+          "has_feedbackmodule": "When enabled, the Feedback Module pushes state changes automatically — no polling needed.",
+          "prior_gen3": "Enables compatibility tweaks for first and second-generation PC-Link hardware.",
+          "press_repeat": "How many times each HA-triggered press (button, scene, CF, latch switch) is sent on the bus. A real button repeats its telegram, so a single send can be missed under bus contention. Default 3."
+        },
+        "description": "Update your hardware settings. The integration will reload automatically.",
+        "title": "Hardware Configuration"
+      },
+      "init": {
+        "description": "What would you like to do?",
+        "menu_options": {
+          "configure_modules": "Customize a module (description, entity type, LED triggers, travel time)",
+          "hardware": "Change hardware settings"
+        },
+        "title": "Nikobus"
+      },
+      "polling": {
+        "data": {
+          "refresh_interval": "Polling interval (seconds)"
+        },
+        "data_description": {
+          "refresh_interval": "How often to read module states from the bus (60–3600 s)."
+        },
+        "description": "How often should Home Assistant poll the Nikobus bus for state changes?",
+        "title": "Polling Interval"
+      },
+      "configure_modules": {
+        "title": "Customize a Nikobus module",
+        "description": "Pick a module to edit. Discovery-owned fields (model, address, channel count) stay read-only; only user-facing fields (descriptions, entity types, LED triggers, travel times) can be changed here.",
+        "data": {
+          "module": "Module"
+        }
+      },
+      "edit_module": {
+        "title": "Module {address} ({module_type})",
+        "description": "Model: {model}. Edit the module description, override the module type if discovery misclassified it, or pick a channel to customize. Note: re-running *Discover modules & buttons* may overwrite a manual type override until the library learns to respect it.",
+        "data": {
+          "description": "Module description",
+          "module_type": "Module type",
+          "channel": "Channel"
+        }
+      },
+      "edit_channel": {
+        "title": "Module {address} — channel {channel}",
+        "description": "Configure how this channel appears in Home Assistant. Pick **Disabled (hide channel)** in the Entity type dropdown to skip creating an entity for this channel.",
+        "data": {
+          "entity_type": "Entity type",
+          "description": "Channel description",
+          "led_on": "LED-on trigger (6-hex bus address, optional)",
+          "led_off": "LED-off trigger (6-hex bus address, optional)",
+          "operation_time_up": "Travel time up (seconds)",
+          "operation_time_down": "Travel time down (seconds)"
+        }
+      }
+    }
+  },
+  "services": {
+    "query_module_inventory": {
+      "description": "Triggers a Nikobus module inventory scan. Without parameters, scans every output module. With a module_address, scans just that module using the per-module-type tuned ranges. With register_start + register_end (and optionally sub_byte), runs a forensic-mode scan of exactly the requested range — useful for reverse-engineering storage layouts on PC-Logic, interface modules, or unfamiliar regions of any module.",
+      "fields": {
+        "module_address": {
+          "description": "Optional Nikobus module address (e.g. 940C, F586). Without it, scans every known output module.",
+          "name": "Module address"
+        },
+        "register_start": {
+          "description": "Forensic mode — lower bound of the register range to scan, as a hex byte (e.g. 0x70 or 70). Requires register_end and a specific module_address. When provided, the scan walks only this range and skips the production extra-pass logic.",
+          "name": "Register start"
+        },
+        "register_end": {
+          "description": "Forensic mode — upper bound of the register range to scan, as a hex byte (e.g. 0x83 or 83). Must be ≥ register_start.",
+          "name": "Register end"
+        },
+        "sub_byte": {
+          "description": "Memory bank selector for forensic mode (default 04 — output link table). Other observed banks: 00 (module header / identity), 01 (BP-cell records).",
+          "name": "Sub-byte"
+        }
+      },
+      "name": "Query module inventory"
+    },
+    "detect_stale_inventory": {
+      "description": "Probes every known output module (switch, dimmer, roller) on the bus and reports which ones don't respond. Returns a manifest with checked / present / absent module lists plus orphaned button addresses. Does not modify configuration; pair with purge_stale_inventory after reviewing the results.",
+      "fields": {
+        "timeout": {
+          "description": "Per-module probe timeout. Worst-case scan time is roughly N modules × timeout.",
+          "name": "Probe timeout (seconds)"
+        }
+      },
+      "name": "Detect stale inventory"
+    },
+    "purge_stale_inventory": {
+      "description": "Removes the given addresses from the persisted module and button stores, then reloads the integration so entities for the purged addresses are dropped. Run detect_stale_inventory first to obtain the list of safe-to-remove addresses.",
+      "fields": {
+        "addresses": {
+          "description": "List of module / button addresses to remove (matched case-insensitively against both stores).",
+          "name": "Addresses"
+        }
+      },
+      "name": "Purge stale inventory"
+    }
+  },
+  "selector": {
+    "module_type": {
+      "options": {
+        "switch_module": "Switch module",
+        "dimmer_module": "Dimmer module",
+        "roller_module": "Roller / shutter module",
+        "other_module": "Other (PC Logic / Feedback / unclassified)"
+      }
+    },
+    "entity_type_switch_module": {
+      "options": {
+        "default": "Default (switch)",
+        "light": "Light",
+        "disabled": "Disabled (hide channel)"
+      }
+    },
+    "entity_type_dimmer_module": {
+      "options": {
+        "default": "Default (light)",
+        "disabled": "Disabled (hide channel)"
+      }
+    },
+    "entity_type_roller_module": {
+      "options": {
+        "default": "Default (cover)",
+        "switch": "Switch",
+        "light": "Light",
+        "disabled": "Disabled (hide channel)"
+      }
+    }
+  }
 }

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -1,238 +1,242 @@
 {
-    "config": {
-        "step": {
-            "user": {
-                "title": "Connexion à Nikobus",
-                "description": "Entrez l'adresse de votre module PC-Link Nikobus.\n\n- **Port série** : `/dev/ttyUSB0` ou `COM3`\n- **Pont réseau** : `192.168.1.50:9999`",
-                "data": {
-                    "connection_string": "Connexion (port série ou IP:port)"
-                },
-                "data_description": {
-                    "connection_string": "Chemin du port série ou adresse TCP du pont PC-Link"
-                }
-            },
-            "hardware": {
-                "title": "Configuration matérielle",
-                "description": "Indiquez votre matériel Nikobus afin que l'intégration utilise la stratégie de mise à jour optimale.",
-                "data": {
-                    "has_feedbackmodule": "Module Feedback (05-207) installé et connecté via PC-Link",
-                    "prior_gen3": "PC-Link antérieur à la Gen 3"
-                },
-                "data_description": {
-                    "has_feedbackmodule": "Lorsqu'activé, le module Feedback envoie automatiquement les changements d'état — pas de scrutation nécessaire.",
-                    "prior_gen3": "Active les adaptations de compatibilité pour les PC-Link de première et deuxième génération."
-                }
-            },
-            "polling": {
-                "title": "Intervalle de scrutation",
-                "description": "Sans module Feedback, Home Assistant interroge périodiquement le bus Nikobus. Choisissez la fréquence.",
-                "data": {
-                    "refresh_interval": "Intervalle de scrutation (secondes)"
-                },
-                "data_description": {
-                    "refresh_interval": "Fréquence de lecture des états des modules sur le bus (60–3600 s)."
-                }
-            },
-            "reconfigure": {
-                "title": "Reconfigurer Nikobus",
-                "description": "Mettez à jour la connexion ou les paramètres matériels. La connexion sera retestée.",
-                "data": {
-                    "connection_string": "Connexion (port série ou IP:port)",
-                    "has_feedbackmodule": "Module Feedback (05-207) installé et connecté via PC-Link",
-                    "prior_gen3": "PC-Link antérieur à la Gen 3",
-                    "refresh_interval": "Intervalle de scrutation (secondes)"
-                }
-            }
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connexion à Nikobus",
+        "description": "Entrez l'adresse de votre module PC-Link Nikobus.\n\n- **Port série** : `/dev/ttyUSB0` ou `COM3`\n- **Pont réseau** : `192.168.1.50:9999`",
+        "data": {
+          "connection_string": "Connexion (port série ou IP:port)"
         },
-        "error": {
-            "cannot_connect": "Impossible de se connecter au PC-Link Nikobus — vérifiez l'adresse et qu'aucun autre client n'est connecté",
-            "unknown": "Erreur inattendue — consultez les journaux Home Assistant pour plus de détails"
-        },
-        "abort": {
-            "already_configured": "Cette connexion Nikobus est déjà configurée."
+        "data_description": {
+          "connection_string": "Chemin du port série ou adresse TCP du pont PC-Link"
         }
+      },
+      "hardware": {
+        "title": "Configuration matérielle",
+        "description": "Indiquez votre matériel Nikobus afin que l'intégration utilise la stratégie de mise à jour optimale.",
+        "data": {
+          "has_feedbackmodule": "Module Feedback (05-207) installé et connecté via PC-Link",
+          "prior_gen3": "PC-Link antérieur à la Gen 3",
+          "press_repeat": "Répétitions de l'appui simulé"
+        },
+        "data_description": {
+          "has_feedbackmodule": "Lorsqu'activé, le module Feedback envoie automatiquement les changements d'état — pas de scrutation nécessaire.",
+          "prior_gen3": "Active les adaptations de compatibilité pour les PC-Link de première et deuxième génération.",
+          "press_repeat": "Nombre de fois où chaque appui déclenché par HA (bouton, scène, CF, interrupteur) est envoyé sur le bus. Un vrai bouton répète son télégramme ; un seul envoi peut être manqué en cas de trafic. Défaut 3."
+        }
+      },
+      "polling": {
+        "title": "Intervalle de scrutation",
+        "description": "Sans module Feedback, Home Assistant interroge périodiquement le bus Nikobus. Choisissez la fréquence.",
+        "data": {
+          "refresh_interval": "Intervalle de scrutation (secondes)"
+        },
+        "data_description": {
+          "refresh_interval": "Fréquence de lecture des états des modules sur le bus (60–3600 s)."
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigurer Nikobus",
+        "description": "Mettez à jour la connexion ou les paramètres matériels. La connexion sera retestée.",
+        "data": {
+          "connection_string": "Connexion (port série ou IP:port)",
+          "has_feedbackmodule": "Module Feedback (05-207) installé et connecté via PC-Link",
+          "prior_gen3": "PC-Link antérieur à la Gen 3",
+          "refresh_interval": "Intervalle de scrutation (secondes)"
+        }
+      }
     },
-    "options": {
-        "step": {
-            "init": {
-                "title": "Nikobus",
-                "description": "Que souhaitez-vous faire ?",
-                "menu_options": {
-                    "hardware": "Modifier la configuration matérielle",
-                    "configure_modules": "Personnaliser un module (description, type d'entité, déclencheurs LED, temps de course)"
-                }
-            },
-            "hardware": {
-                "title": "Configuration matérielle",
-                "description": "Mettez à jour les paramètres matériels. L'intégration rechargera automatiquement.",
-                "data": {
-                    "has_feedbackmodule": "Module Feedback (05-207) installé et connecté via PC-Link",
-                    "prior_gen3": "PC-Link antérieur à la Gen 3"
-                },
-                "data_description": {
-                    "has_feedbackmodule": "Lorsqu'activé, le module Feedback envoie automatiquement les changements d'état.",
-                    "prior_gen3": "Active les adaptations de compatibilité pour les PC-Link de première et deuxième génération."
-                }
-            },
-            "polling": {
-                "title": "Intervalle de scrutation",
-                "description": "À quelle fréquence Home Assistant doit-il interroger le bus Nikobus ?",
-                "data": {
-                    "refresh_interval": "Intervalle de scrutation (secondes)"
-                },
-                "data_description": {
-                    "refresh_interval": "Fréquence de lecture des états des modules (60–3600 s)."
-                }
-            },
-            "configure_modules": {
-                "title": "Personnaliser un module Nikobus",
-                "description": "Choisissez un module à modifier. Les champs issus de la découverte (modèle, adresse, nombre de canaux) restent en lecture seule ; seuls les champs utilisateur (descriptions, types d'entité, déclencheurs LED, temps de course) peuvent être modifiés ici.",
-                "data": {
-                    "module": "Module"
-                }
-            },
-            "edit_module": {
-                "title": "Module {address} ({module_type})",
-                "description": "Modèle : {model}. Modifiez la description du module, corrigez le type si la découverte s'est trompée, ou choisissez un canal à personnaliser. Note : relancer *Découvrir les modules et boutons* peut écraser un type forcé manuellement, jusqu'à ce que la bibliothèque apprenne à le respecter.",
-                "data": {
-                    "description": "Description du module",
-                    "module_type": "Type de module",
-                    "channel": "Canal"
-                }
-            },
-            "edit_channel": {
-                "title": "Module {address} — canal {channel}",
-                "description": "Configurez l'apparence de ce canal dans Home Assistant. Sélectionnez **Désactivé (masquer le canal)** dans la liste Type d'entité pour ne pas créer d'entité pour ce canal.",
-                "data": {
-                    "entity_type": "Type d'entité",
-                    "description": "Description du canal",
-                    "led_on": "Déclencheur LED allumée (adresse bus 6-hex, optionnel)",
-                    "led_off": "Déclencheur LED éteinte (adresse bus 6-hex, optionnel)",
-                    "operation_time_up": "Temps de course à l'ouverture (secondes)",
-                    "operation_time_down": "Temps de course à la fermeture (secondes)"
-                }
-            }
-        },
-        "abort": {
-            "not_loaded": "L'intégration Nikobus n'est pas chargée. Veuillez la recharger puis réessayer."
-        }
+    "error": {
+      "cannot_connect": "Impossible de se connecter au PC-Link Nikobus — vérifiez l'adresse et qu'aucun autre client n'est connecté",
+      "unknown": "Erreur inattendue — consultez les journaux Home Assistant pour plus de détails"
     },
-    "entity": {
-        "sensor": {
-            "connection": {
-                "name": "Connexion",
-                "state": {
-                    "connected": "Connecté",
-                    "reconnecting": "Reconnexion en cours",
-                    "disconnected": "Déconnecté"
-                }
-            },
-            "discovery_status": {
-                "name": "Statut de la découverte",
-                "state": {
-                    "idle": "Inactif",
-                    "pc_link": "Inventaire PC Link",
-                    "module_scan": "Analyse des modules",
-                    "finished": "Terminé",
-                    "error": "Erreur"
-                }
-            },
-            "discovery_progress": {
-                "name": "Progression de la découverte"
-            }
-        },
-        "button": {
-            "discover_modules_buttons": {
-                "name": "Découvrir modules et boutons"
-            },
-            "scan_all_module_links": {
-                "name": "Scanner les liens des modules"
-            }
-        }
-    },
-    "issues": {
-        "no_buttons_configured": {
-            "title": "Aucun bouton Nikobus configuré",
-            "fix_flow": {
-                "step": {
-                    "confirm": {
-                        "title": "Découvrir les modules et boutons Nikobus",
-                        "description": "Home Assistant n'a détecté aucun bouton Nikobus. Lancez maintenant un inventaire PC-Link pour compléter la configuration."
-                    }
-                }
-            }
-        },
-        "legacy_undecoded_buttons": {
-            "title": "{count} bouton(s) Nikobus signalé(s) comme hérité(s)",
-            "fix_flow": {
-                "step": {
-                    "init": {
-                        "title": "Examiner les boutons Nikobus hérités",
-                        "description": "Ces {count} bouton(s) sont signalés comme hérités après un scan complet de phase 2. La colonne Raison explique pourquoi :\n\n  - **no decoded links** — aucun module de sortie ne référence ce bouton. Soit un bouton mural utilisé uniquement pour des automatisations Home Assistant (à conserver), soit un résidu d'un précédent propriétaire (à purger).\n  - **residue / stale links** — les liens du bouton existent uniquement dans la mémoire de registre PC-Link / PC-Logic sans qu'aucun module de sortie actuel ne les enregistre, ou tous les modules liés ont été évincés. Typiquement une programmation résiduelle d'un précédent propriétaire que l'appairage DIN-button n'a pas effacée (à purger).\n\nPour récupérer un bouton purgé, relancez **Découvrir les modules et boutons** puis **Scanner les liens de tous les modules** — la bibliothèque réinsère tout ce qui figure encore dans le projet.\n\n{candidates}\n\nLaissez la liste vide et soumettez pour tout conserver.",
-                        "data": {
-                            "addresses": "Boutons à supprimer"
-                        }
-                    }
-                },
-                "abort": {
-                    "not_loaded": "L'intégration Nikobus n'est pas chargée ; rechargez l'entrée puis réessayez.",
-                    "no_candidates": "Aucun bouton hérité ne reste — rien à faire."
-                }
-            }
-        }
-    },
-    "exceptions": {
-        "communication_error": {
-            "message": "Communication avec Nikobus échouée : {error}"
-        },
-        "discovery_already_running": {
-            "message": "Une découverte Nikobus est déjà en cours."
-        },
-        "discovery_not_initialized": {
-            "message": "La découverte Nikobus n'est pas initialisée."
-        },
-        "initialization_error": {
-            "message": "Échec de l'initialisation des composants Nikobus : {error}"
-        },
-        "no_loaded_entry": {
-            "message": "Aucune intégration Nikobus chargée. Configurez-en une avant d'appeler cette action."
-        },
-        "no_modules_known": {
-            "message": "Aucun module Nikobus n'est encore configuré. Lancez d'abord un inventaire PC-Link, puis relancez le scan des modules."
-        },
-        "no_inventory_source": {
-            "message": "Aucun PC-Link détecté sur le bus et aucun fichier de configuration manuelle trouvé. Installez un PC-Link ou créez nikobus_module_config.json (et éventuellement nikobus_button_config.json) dans votre répertoire de configuration Home Assistant, puis réessayez."
-        }
-    },
-    "selector": {
-        "module_type": {
-            "options": {
-                "switch_module": "Module d'interrupteurs",
-                "dimmer_module": "Module variateur",
-                "roller_module": "Module volet / store",
-                "other_module": "Autre (PC Logic / Feedback / non classé)"
-            }
-        },
-        "entity_type_switch_module": {
-            "options": {
-                "default": "Par défaut (interrupteur)",
-                "light": "Lumière",
-                "disabled": "Désactivé (masquer le canal)"
-            }
-        },
-        "entity_type_dimmer_module": {
-            "options": {
-                "default": "Par défaut (lumière)",
-                "disabled": "Désactivé (masquer le canal)"
-            }
-        },
-        "entity_type_roller_module": {
-            "options": {
-                "default": "Par défaut (volet)",
-                "switch": "Interrupteur",
-                "light": "Lumière",
-                "disabled": "Désactivé (masquer le canal)"
-            }
-        }
+    "abort": {
+      "already_configured": "Cette connexion Nikobus est déjà configurée."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Nikobus",
+        "description": "Que souhaitez-vous faire ?",
+        "menu_options": {
+          "hardware": "Modifier la configuration matérielle",
+          "configure_modules": "Personnaliser un module (description, type d'entité, déclencheurs LED, temps de course)"
+        }
+      },
+      "hardware": {
+        "title": "Configuration matérielle",
+        "description": "Mettez à jour les paramètres matériels. L'intégration rechargera automatiquement.",
+        "data": {
+          "has_feedbackmodule": "Module Feedback (05-207) installé et connecté via PC-Link",
+          "prior_gen3": "PC-Link antérieur à la Gen 3",
+          "press_repeat": "Répétitions de l'appui simulé"
+        },
+        "data_description": {
+          "has_feedbackmodule": "Lorsqu'activé, le module Feedback envoie automatiquement les changements d'état.",
+          "prior_gen3": "Active les adaptations de compatibilité pour les PC-Link de première et deuxième génération.",
+          "press_repeat": "Nombre de fois où chaque appui déclenché par HA (bouton, scène, CF, interrupteur) est envoyé sur le bus. Un vrai bouton répète son télégramme ; un seul envoi peut être manqué en cas de trafic. Défaut 3."
+        }
+      },
+      "polling": {
+        "title": "Intervalle de scrutation",
+        "description": "À quelle fréquence Home Assistant doit-il interroger le bus Nikobus ?",
+        "data": {
+          "refresh_interval": "Intervalle de scrutation (secondes)"
+        },
+        "data_description": {
+          "refresh_interval": "Fréquence de lecture des états des modules (60–3600 s)."
+        }
+      },
+      "configure_modules": {
+        "title": "Personnaliser un module Nikobus",
+        "description": "Choisissez un module à modifier. Les champs issus de la découverte (modèle, adresse, nombre de canaux) restent en lecture seule ; seuls les champs utilisateur (descriptions, types d'entité, déclencheurs LED, temps de course) peuvent être modifiés ici.",
+        "data": {
+          "module": "Module"
+        }
+      },
+      "edit_module": {
+        "title": "Module {address} ({module_type})",
+        "description": "Modèle : {model}. Modifiez la description du module, corrigez le type si la découverte s'est trompée, ou choisissez un canal à personnaliser. Note : relancer *Découvrir les modules et boutons* peut écraser un type forcé manuellement, jusqu'à ce que la bibliothèque apprenne à le respecter.",
+        "data": {
+          "description": "Description du module",
+          "module_type": "Type de module",
+          "channel": "Canal"
+        }
+      },
+      "edit_channel": {
+        "title": "Module {address} — canal {channel}",
+        "description": "Configurez l'apparence de ce canal dans Home Assistant. Sélectionnez **Désactivé (masquer le canal)** dans la liste Type d'entité pour ne pas créer d'entité pour ce canal.",
+        "data": {
+          "entity_type": "Type d'entité",
+          "description": "Description du canal",
+          "led_on": "Déclencheur LED allumée (adresse bus 6-hex, optionnel)",
+          "led_off": "Déclencheur LED éteinte (adresse bus 6-hex, optionnel)",
+          "operation_time_up": "Temps de course à l'ouverture (secondes)",
+          "operation_time_down": "Temps de course à la fermeture (secondes)"
+        }
+      }
+    },
+    "abort": {
+      "not_loaded": "L'intégration Nikobus n'est pas chargée. Veuillez la recharger puis réessayer."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "connection": {
+        "name": "Connexion",
+        "state": {
+          "connected": "Connecté",
+          "reconnecting": "Reconnexion en cours",
+          "disconnected": "Déconnecté"
+        }
+      },
+      "discovery_status": {
+        "name": "Statut de la découverte",
+        "state": {
+          "idle": "Inactif",
+          "pc_link": "Inventaire PC Link",
+          "module_scan": "Analyse des modules",
+          "finished": "Terminé",
+          "error": "Erreur"
+        }
+      },
+      "discovery_progress": {
+        "name": "Progression de la découverte"
+      }
+    },
+    "button": {
+      "discover_modules_buttons": {
+        "name": "Découvrir modules et boutons"
+      },
+      "scan_all_module_links": {
+        "name": "Scanner les liens des modules"
+      }
+    }
+  },
+  "issues": {
+    "no_buttons_configured": {
+      "title": "Aucun bouton Nikobus configuré",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Découvrir les modules et boutons Nikobus",
+            "description": "Home Assistant n'a détecté aucun bouton Nikobus. Lancez maintenant un inventaire PC-Link pour compléter la configuration."
+          }
+        }
+      }
+    },
+    "legacy_undecoded_buttons": {
+      "title": "{count} bouton(s) Nikobus signalé(s) comme hérité(s)",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Examiner les boutons Nikobus hérités",
+            "description": "Ces {count} bouton(s) sont signalés comme hérités après un scan complet de phase 2. La colonne Raison explique pourquoi :\n\n  - **no decoded links** — aucun module de sortie ne référence ce bouton. Soit un bouton mural utilisé uniquement pour des automatisations Home Assistant (à conserver), soit un résidu d'un précédent propriétaire (à purger).\n  - **residue / stale links** — les liens du bouton existent uniquement dans la mémoire de registre PC-Link / PC-Logic sans qu'aucun module de sortie actuel ne les enregistre, ou tous les modules liés ont été évincés. Typiquement une programmation résiduelle d'un précédent propriétaire que l'appairage DIN-button n'a pas effacée (à purger).\n\nPour récupérer un bouton purgé, relancez **Découvrir les modules et boutons** puis **Scanner les liens de tous les modules** — la bibliothèque réinsère tout ce qui figure encore dans le projet.\n\n{candidates}\n\nLaissez la liste vide et soumettez pour tout conserver.",
+            "data": {
+              "addresses": "Boutons à supprimer"
+            }
+          }
+        },
+        "abort": {
+          "not_loaded": "L'intégration Nikobus n'est pas chargée ; rechargez l'entrée puis réessayez.",
+          "no_candidates": "Aucun bouton hérité ne reste — rien à faire."
+        }
+      }
+    }
+  },
+  "exceptions": {
+    "communication_error": {
+      "message": "Communication avec Nikobus échouée : {error}"
+    },
+    "discovery_already_running": {
+      "message": "Une découverte Nikobus est déjà en cours."
+    },
+    "discovery_not_initialized": {
+      "message": "La découverte Nikobus n'est pas initialisée."
+    },
+    "initialization_error": {
+      "message": "Échec de l'initialisation des composants Nikobus : {error}"
+    },
+    "no_loaded_entry": {
+      "message": "Aucune intégration Nikobus chargée. Configurez-en une avant d'appeler cette action."
+    },
+    "no_modules_known": {
+      "message": "Aucun module Nikobus n'est encore configuré. Lancez d'abord un inventaire PC-Link, puis relancez le scan des modules."
+    },
+    "no_inventory_source": {
+      "message": "Aucun PC-Link détecté sur le bus et aucun fichier de configuration manuelle trouvé. Installez un PC-Link ou créez nikobus_module_config.json (et éventuellement nikobus_button_config.json) dans votre répertoire de configuration Home Assistant, puis réessayez."
+    }
+  },
+  "selector": {
+    "module_type": {
+      "options": {
+        "switch_module": "Module d'interrupteurs",
+        "dimmer_module": "Module variateur",
+        "roller_module": "Module volet / store",
+        "other_module": "Autre (PC Logic / Feedback / non classé)"
+      }
+    },
+    "entity_type_switch_module": {
+      "options": {
+        "default": "Par défaut (interrupteur)",
+        "light": "Lumière",
+        "disabled": "Désactivé (masquer le canal)"
+      }
+    },
+    "entity_type_dimmer_module": {
+      "options": {
+        "default": "Par défaut (lumière)",
+        "disabled": "Désactivé (masquer le canal)"
+      }
+    },
+    "entity_type_roller_module": {
+      "options": {
+        "default": "Par défaut (volet)",
+        "switch": "Interrupteur",
+        "light": "Lumière",
+        "disabled": "Désactivé (masquer le canal)"
+      }
+    }
+  }
 }

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -1,238 +1,242 @@
 {
-    "config": {
-        "step": {
-            "user": {
-                "title": "Verbinding met Nikobus",
-                "description": "Voer het adres van uw Nikobus PC-Link module in.\n\n- **Seriële poort**: `/dev/ttyUSB0` of `COM3`\n- **Netwerkbrug**: `192.168.1.50:9999`",
-                "data": {
-                    "connection_string": "Verbinding (seriële poort of IP:poort)"
-                },
-                "data_description": {
-                    "connection_string": "Serieel apparaatpad of TCP-adres van de PC-Link brug"
-                }
-            },
-            "hardware": {
-                "title": "Hardwareconfiguratie",
-                "description": "Vertel ons over uw Nikobus-hardware zodat de integratie de optimale updatestrategie kan gebruiken.",
-                "data": {
-                    "has_feedbackmodule": "Feedbackmodule (05-207) geïnstalleerd en verbonden via PC-Link",
-                    "prior_gen3": "PC-Link is ouder dan Gen 3"
-                },
-                "data_description": {
-                    "has_feedbackmodule": "Indien ingeschakeld stuurt de Feedbackmodule automatisch statuswijzigingen — geen polling nodig.",
-                    "prior_gen3": "Schakelt compatibiliteitsaanpassingen in voor eerste en tweede generatie PC-Link hardware."
-                }
-            },
-            "polling": {
-                "title": "Polling-interval",
-                "description": "Zonder Feedbackmodule peilt Home Assistant periodiek de Nikobus-bus. Kies hoe vaak.",
-                "data": {
-                    "refresh_interval": "Polling-interval (seconden)"
-                },
-                "data_description": {
-                    "refresh_interval": "Hoe vaak modulestatussen van de bus worden gelezen (60–3600 s)."
-                }
-            },
-            "reconfigure": {
-                "title": "Nikobus herconfigureren",
-                "description": "Werk de verbinding of hardware-instellingen bij. De verbinding wordt opnieuw getest.",
-                "data": {
-                    "connection_string": "Verbinding (seriële poort of IP:poort)",
-                    "has_feedbackmodule": "Feedbackmodule (05-207) geïnstalleerd en verbonden via PC-Link",
-                    "prior_gen3": "PC-Link is ouder dan Gen 3",
-                    "refresh_interval": "Polling-interval (seconden)"
-                }
-            }
+  "config": {
+    "step": {
+      "user": {
+        "title": "Verbinding met Nikobus",
+        "description": "Voer het adres van uw Nikobus PC-Link module in.\n\n- **Seriële poort**: `/dev/ttyUSB0` of `COM3`\n- **Netwerkbrug**: `192.168.1.50:9999`",
+        "data": {
+          "connection_string": "Verbinding (seriële poort of IP:poort)"
         },
-        "error": {
-            "cannot_connect": "Kan geen verbinding maken met de Nikobus PC-Link — controleer het adres en of geen andere client verbonden is",
-            "unknown": "Onverwachte fout — raadpleeg de Home Assistant-logboeken voor details"
-        },
-        "abort": {
-            "already_configured": "Deze Nikobus-verbinding is al geconfigureerd."
+        "data_description": {
+          "connection_string": "Serieel apparaatpad of TCP-adres van de PC-Link brug"
         }
+      },
+      "hardware": {
+        "title": "Hardwareconfiguratie",
+        "description": "Vertel ons over uw Nikobus-hardware zodat de integratie de optimale updatestrategie kan gebruiken.",
+        "data": {
+          "has_feedbackmodule": "Feedbackmodule (05-207) geïnstalleerd en verbonden via PC-Link",
+          "prior_gen3": "PC-Link is ouder dan Gen 3",
+          "press_repeat": "Herhalingen gesimuleerde druk"
+        },
+        "data_description": {
+          "has_feedbackmodule": "Indien ingeschakeld stuurt de Feedbackmodule automatisch statuswijzigingen — geen polling nodig.",
+          "prior_gen3": "Schakelt compatibiliteitsaanpassingen in voor eerste en tweede generatie PC-Link hardware.",
+          "press_repeat": "Hoe vaak elke door HA geactiveerde druk (knop, sfeer, CF, schakelaar) op de bus wordt verzonden. Een echte knop herhaalt zijn telegram, dus één verzending kan gemist worden bij een drukke bus. Standaard 3."
+        }
+      },
+      "polling": {
+        "title": "Polling-interval",
+        "description": "Zonder Feedbackmodule peilt Home Assistant periodiek de Nikobus-bus. Kies hoe vaak.",
+        "data": {
+          "refresh_interval": "Polling-interval (seconden)"
+        },
+        "data_description": {
+          "refresh_interval": "Hoe vaak modulestatussen van de bus worden gelezen (60–3600 s)."
+        }
+      },
+      "reconfigure": {
+        "title": "Nikobus herconfigureren",
+        "description": "Werk de verbinding of hardware-instellingen bij. De verbinding wordt opnieuw getest.",
+        "data": {
+          "connection_string": "Verbinding (seriële poort of IP:poort)",
+          "has_feedbackmodule": "Feedbackmodule (05-207) geïnstalleerd en verbonden via PC-Link",
+          "prior_gen3": "PC-Link is ouder dan Gen 3",
+          "refresh_interval": "Polling-interval (seconden)"
+        }
+      }
     },
-    "options": {
-        "step": {
-            "init": {
-                "title": "Nikobus",
-                "description": "Wat wilt u doen?",
-                "menu_options": {
-                    "hardware": "Hardware-instellingen wijzigen",
-                    "configure_modules": "Module aanpassen (beschrijving, entiteitstype, LED-triggers, looptijd)"
-                }
-            },
-            "hardware": {
-                "title": "Hardwareconfiguratie",
-                "description": "Werk uw hardware-instellingen bij. De integratie herlaadt automatisch.",
-                "data": {
-                    "has_feedbackmodule": "Feedbackmodule (05-207) geïnstalleerd en verbonden via PC-Link",
-                    "prior_gen3": "PC-Link is ouder dan Gen 3"
-                },
-                "data_description": {
-                    "has_feedbackmodule": "Indien ingeschakeld stuurt de Feedbackmodule automatisch statuswijzigingen.",
-                    "prior_gen3": "Schakelt compatibiliteitsaanpassingen in voor eerste en tweede generatie PC-Link hardware."
-                }
-            },
-            "polling": {
-                "title": "Polling-interval",
-                "description": "Hoe vaak moet Home Assistant de Nikobus-bus pollen?",
-                "data": {
-                    "refresh_interval": "Polling-interval (seconden)"
-                },
-                "data_description": {
-                    "refresh_interval": "Hoe vaak modulestatussen worden gelezen (60–3600 s)."
-                }
-            },
-            "configure_modules": {
-                "title": "Een Nikobus-module aanpassen",
-                "description": "Kies een module om te bewerken. Velden uit de ontdekking (model, adres, aantal kanalen) blijven alleen-lezen; alleen gebruikersvelden (beschrijvingen, entiteitstypes, LED-triggers, looptijden) kunnen hier worden gewijzigd.",
-                "data": {
-                    "module": "Module"
-                }
-            },
-            "edit_module": {
-                "title": "Module {address} ({module_type})",
-                "description": "Model: {model}. Bewerk de beschrijving, corrigeer het moduletype als de ontdekking het verkeerd heeft geclassificeerd, of kies een kanaal om aan te passen. Let op: opnieuw *Modules en knoppen ontdekken* uitvoeren kan een handmatig overschreven type weer wegschrijven totdat de bibliotheek dit respecteert.",
-                "data": {
-                    "description": "Modulebeschrijving",
-                    "module_type": "Moduletype",
-                    "channel": "Kanaal"
-                }
-            },
-            "edit_channel": {
-                "title": "Module {address} — kanaal {channel}",
-                "description": "Stel in hoe dit kanaal in Home Assistant verschijnt. Kies **Uitgeschakeld (kanaal verbergen)** in de entiteitstype-keuzelijst om geen entiteit voor dit kanaal aan te maken.",
-                "data": {
-                    "entity_type": "Entiteitstype",
-                    "description": "Kanaalbeschrijving",
-                    "led_on": "LED-aan trigger (6-hex busadres, optioneel)",
-                    "led_off": "LED-uit trigger (6-hex busadres, optioneel)",
-                    "operation_time_up": "Looptijd omhoog (seconden)",
-                    "operation_time_down": "Looptijd omlaag (seconden)"
-                }
-            }
-        },
-        "abort": {
-            "not_loaded": "De Nikobus-integratie is niet geladen. Herlaad de integratie en probeer het opnieuw."
-        }
+    "error": {
+      "cannot_connect": "Kan geen verbinding maken met de Nikobus PC-Link — controleer het adres en of geen andere client verbonden is",
+      "unknown": "Onverwachte fout — raadpleeg de Home Assistant-logboeken voor details"
     },
-    "entity": {
-        "sensor": {
-            "connection": {
-                "name": "Verbinding",
-                "state": {
-                    "connected": "Verbonden",
-                    "reconnecting": "Opnieuw verbinden",
-                    "disconnected": "Verbinding verbroken"
-                }
-            },
-            "discovery_status": {
-                "name": "Ontdekkingsstatus",
-                "state": {
-                    "idle": "Inactief",
-                    "pc_link": "PC Link-inventaris",
-                    "module_scan": "Modules scannen",
-                    "finished": "Voltooid",
-                    "error": "Fout"
-                }
-            },
-            "discovery_progress": {
-                "name": "Ontdekkingsvoortgang"
-            }
-        },
-        "button": {
-            "discover_modules_buttons": {
-                "name": "Modules en knoppen ontdekken"
-            },
-            "scan_all_module_links": {
-                "name": "Alle modulekoppelingen scannen"
-            }
-        }
-    },
-    "issues": {
-        "no_buttons_configured": {
-            "title": "Geen Nikobus-knoppen geconfigureerd",
-            "fix_flow": {
-                "step": {
-                    "confirm": {
-                        "title": "Nikobus-modules en -knoppen ontdekken",
-                        "description": "Home Assistant heeft geen Nikobus-knoppen gedetecteerd. Voer nu een PC-Link-inventaris uit om de configuratie aan te vullen."
-                    }
-                }
-            }
-        },
-        "legacy_undecoded_buttons": {
-            "title": "{count} Nikobus-knop(pen) gemarkeerd als verouderd",
-            "fix_flow": {
-                "step": {
-                    "init": {
-                        "title": "Verouderde Nikobus-knoppen beoordelen",
-                        "description": "Deze {count} knop(pen) zijn als verouderd gemarkeerd na een volledige fase-2-scan. De kolom Reden legt uit waarom:\n\n  - **no decoded links** — geen output-module verwijst naar deze knop. Ofwel een wandknop die alleen wordt gebruikt voor Home Assistant-automatiseringen (behouden), ofwel resten van een vorige eigenaar (opschonen).\n  - **residue / stale links** — de koppelingen van de knop bestaan alleen in het PC-Link-/PC-Logic-registergeheugen zonder dat een huidige output-module ze opslaat, of elke gekoppelde module is verwijderd. Doorgaans residuele programmering van een vorige eigenaar die door DIN-button-koppeling niet is gewist (opschonen).\n\nOm een gewiste knop te herstellen, voer **Modules en knoppen ontdekken** opnieuw uit en daarna **Modulelinks scannen** — de bibliotheek voegt alles wat nog in het project staat opnieuw toe.\n\n{candidates}\n\nLaat de lijst leeg en bevestig om alles te behouden.",
-                        "data": {
-                            "addresses": "Te verwijderen knoppen"
-                        }
-                    }
-                },
-                "abort": {
-                    "not_loaded": "De Nikobus-integratie is niet geladen; herlaad het item en probeer opnieuw.",
-                    "no_candidates": "Geen verouderde knoppen meer — niets te doen."
-                }
-            }
-        }
-    },
-    "exceptions": {
-        "communication_error": {
-            "message": "Communicatie met Nikobus mislukt: {error}"
-        },
-        "discovery_already_running": {
-            "message": "Er is al een Nikobus-ontdekking bezig."
-        },
-        "discovery_not_initialized": {
-            "message": "Nikobus-ontdekking is niet geïnitialiseerd."
-        },
-        "initialization_error": {
-            "message": "Initialisatie van Nikobus-componenten mislukt: {error}"
-        },
-        "no_loaded_entry": {
-            "message": "Geen geladen Nikobus-integratie gevonden. Stel er één in voordat u deze actie aanroept."
-        },
-        "no_modules_known": {
-            "message": "Er zijn nog geen Nikobus-modules geconfigureerd. Voer eerst een PC-Link-inventaris uit en probeer dan opnieuw modules te scannen."
-        },
-        "no_inventory_source": {
-            "message": "Geen PC-Link gedetecteerd op de bus en geen handmatige configuratiebestanden gevonden. Installeer een PC-Link of maak nikobus_module_config.json (en eventueel nikobus_button_config.json) aan in uw Home Assistant-configuratiemap en probeer het opnieuw."
-        }
-    },
-    "selector": {
-        "module_type": {
-            "options": {
-                "switch_module": "Schakelmodule",
-                "dimmer_module": "Dimmermodule",
-                "roller_module": "Rolluik / zonweringsmodule",
-                "other_module": "Overig (PC Logic / Feedback / niet geclassificeerd)"
-            }
-        },
-        "entity_type_switch_module": {
-            "options": {
-                "default": "Standaard (schakelaar)",
-                "light": "Lamp",
-                "disabled": "Uitgeschakeld (kanaal verbergen)"
-            }
-        },
-        "entity_type_dimmer_module": {
-            "options": {
-                "default": "Standaard (lamp)",
-                "disabled": "Uitgeschakeld (kanaal verbergen)"
-            }
-        },
-        "entity_type_roller_module": {
-            "options": {
-                "default": "Standaard (rolluik)",
-                "switch": "Schakelaar",
-                "light": "Lamp",
-                "disabled": "Uitgeschakeld (kanaal verbergen)"
-            }
-        }
+    "abort": {
+      "already_configured": "Deze Nikobus-verbinding is al geconfigureerd."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Nikobus",
+        "description": "Wat wilt u doen?",
+        "menu_options": {
+          "hardware": "Hardware-instellingen wijzigen",
+          "configure_modules": "Module aanpassen (beschrijving, entiteitstype, LED-triggers, looptijd)"
+        }
+      },
+      "hardware": {
+        "title": "Hardwareconfiguratie",
+        "description": "Werk uw hardware-instellingen bij. De integratie herlaadt automatisch.",
+        "data": {
+          "has_feedbackmodule": "Feedbackmodule (05-207) geïnstalleerd en verbonden via PC-Link",
+          "prior_gen3": "PC-Link is ouder dan Gen 3",
+          "press_repeat": "Herhalingen gesimuleerde druk"
+        },
+        "data_description": {
+          "has_feedbackmodule": "Indien ingeschakeld stuurt de Feedbackmodule automatisch statuswijzigingen.",
+          "prior_gen3": "Schakelt compatibiliteitsaanpassingen in voor eerste en tweede generatie PC-Link hardware.",
+          "press_repeat": "Hoe vaak elke door HA geactiveerde druk (knop, sfeer, CF, schakelaar) op de bus wordt verzonden. Een echte knop herhaalt zijn telegram, dus één verzending kan gemist worden bij een drukke bus. Standaard 3."
+        }
+      },
+      "polling": {
+        "title": "Polling-interval",
+        "description": "Hoe vaak moet Home Assistant de Nikobus-bus pollen?",
+        "data": {
+          "refresh_interval": "Polling-interval (seconden)"
+        },
+        "data_description": {
+          "refresh_interval": "Hoe vaak modulestatussen worden gelezen (60–3600 s)."
+        }
+      },
+      "configure_modules": {
+        "title": "Een Nikobus-module aanpassen",
+        "description": "Kies een module om te bewerken. Velden uit de ontdekking (model, adres, aantal kanalen) blijven alleen-lezen; alleen gebruikersvelden (beschrijvingen, entiteitstypes, LED-triggers, looptijden) kunnen hier worden gewijzigd.",
+        "data": {
+          "module": "Module"
+        }
+      },
+      "edit_module": {
+        "title": "Module {address} ({module_type})",
+        "description": "Model: {model}. Bewerk de beschrijving, corrigeer het moduletype als de ontdekking het verkeerd heeft geclassificeerd, of kies een kanaal om aan te passen. Let op: opnieuw *Modules en knoppen ontdekken* uitvoeren kan een handmatig overschreven type weer wegschrijven totdat de bibliotheek dit respecteert.",
+        "data": {
+          "description": "Modulebeschrijving",
+          "module_type": "Moduletype",
+          "channel": "Kanaal"
+        }
+      },
+      "edit_channel": {
+        "title": "Module {address} — kanaal {channel}",
+        "description": "Stel in hoe dit kanaal in Home Assistant verschijnt. Kies **Uitgeschakeld (kanaal verbergen)** in de entiteitstype-keuzelijst om geen entiteit voor dit kanaal aan te maken.",
+        "data": {
+          "entity_type": "Entiteitstype",
+          "description": "Kanaalbeschrijving",
+          "led_on": "LED-aan trigger (6-hex busadres, optioneel)",
+          "led_off": "LED-uit trigger (6-hex busadres, optioneel)",
+          "operation_time_up": "Looptijd omhoog (seconden)",
+          "operation_time_down": "Looptijd omlaag (seconden)"
+        }
+      }
+    },
+    "abort": {
+      "not_loaded": "De Nikobus-integratie is niet geladen. Herlaad de integratie en probeer het opnieuw."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "connection": {
+        "name": "Verbinding",
+        "state": {
+          "connected": "Verbonden",
+          "reconnecting": "Opnieuw verbinden",
+          "disconnected": "Verbinding verbroken"
+        }
+      },
+      "discovery_status": {
+        "name": "Ontdekkingsstatus",
+        "state": {
+          "idle": "Inactief",
+          "pc_link": "PC Link-inventaris",
+          "module_scan": "Modules scannen",
+          "finished": "Voltooid",
+          "error": "Fout"
+        }
+      },
+      "discovery_progress": {
+        "name": "Ontdekkingsvoortgang"
+      }
+    },
+    "button": {
+      "discover_modules_buttons": {
+        "name": "Modules en knoppen ontdekken"
+      },
+      "scan_all_module_links": {
+        "name": "Alle modulekoppelingen scannen"
+      }
+    }
+  },
+  "issues": {
+    "no_buttons_configured": {
+      "title": "Geen Nikobus-knoppen geconfigureerd",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Nikobus-modules en -knoppen ontdekken",
+            "description": "Home Assistant heeft geen Nikobus-knoppen gedetecteerd. Voer nu een PC-Link-inventaris uit om de configuratie aan te vullen."
+          }
+        }
+      }
+    },
+    "legacy_undecoded_buttons": {
+      "title": "{count} Nikobus-knop(pen) gemarkeerd als verouderd",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Verouderde Nikobus-knoppen beoordelen",
+            "description": "Deze {count} knop(pen) zijn als verouderd gemarkeerd na een volledige fase-2-scan. De kolom Reden legt uit waarom:\n\n  - **no decoded links** — geen output-module verwijst naar deze knop. Ofwel een wandknop die alleen wordt gebruikt voor Home Assistant-automatiseringen (behouden), ofwel resten van een vorige eigenaar (opschonen).\n  - **residue / stale links** — de koppelingen van de knop bestaan alleen in het PC-Link-/PC-Logic-registergeheugen zonder dat een huidige output-module ze opslaat, of elke gekoppelde module is verwijderd. Doorgaans residuele programmering van een vorige eigenaar die door DIN-button-koppeling niet is gewist (opschonen).\n\nOm een gewiste knop te herstellen, voer **Modules en knoppen ontdekken** opnieuw uit en daarna **Modulelinks scannen** — de bibliotheek voegt alles wat nog in het project staat opnieuw toe.\n\n{candidates}\n\nLaat de lijst leeg en bevestig om alles te behouden.",
+            "data": {
+              "addresses": "Te verwijderen knoppen"
+            }
+          }
+        },
+        "abort": {
+          "not_loaded": "De Nikobus-integratie is niet geladen; herlaad het item en probeer opnieuw.",
+          "no_candidates": "Geen verouderde knoppen meer — niets te doen."
+        }
+      }
+    }
+  },
+  "exceptions": {
+    "communication_error": {
+      "message": "Communicatie met Nikobus mislukt: {error}"
+    },
+    "discovery_already_running": {
+      "message": "Er is al een Nikobus-ontdekking bezig."
+    },
+    "discovery_not_initialized": {
+      "message": "Nikobus-ontdekking is niet geïnitialiseerd."
+    },
+    "initialization_error": {
+      "message": "Initialisatie van Nikobus-componenten mislukt: {error}"
+    },
+    "no_loaded_entry": {
+      "message": "Geen geladen Nikobus-integratie gevonden. Stel er één in voordat u deze actie aanroept."
+    },
+    "no_modules_known": {
+      "message": "Er zijn nog geen Nikobus-modules geconfigureerd. Voer eerst een PC-Link-inventaris uit en probeer dan opnieuw modules te scannen."
+    },
+    "no_inventory_source": {
+      "message": "Geen PC-Link gedetecteerd op de bus en geen handmatige configuratiebestanden gevonden. Installeer een PC-Link of maak nikobus_module_config.json (en eventueel nikobus_button_config.json) aan in uw Home Assistant-configuratiemap en probeer het opnieuw."
+    }
+  },
+  "selector": {
+    "module_type": {
+      "options": {
+        "switch_module": "Schakelmodule",
+        "dimmer_module": "Dimmermodule",
+        "roller_module": "Rolluik / zonweringsmodule",
+        "other_module": "Overig (PC Logic / Feedback / niet geclassificeerd)"
+      }
+    },
+    "entity_type_switch_module": {
+      "options": {
+        "default": "Standaard (schakelaar)",
+        "light": "Lamp",
+        "disabled": "Uitgeschakeld (kanaal verbergen)"
+      }
+    },
+    "entity_type_dimmer_module": {
+      "options": {
+        "default": "Standaard (lamp)",
+        "disabled": "Uitgeschakeld (kanaal verbergen)"
+      }
+    },
+    "entity_type_roller_module": {
+      "options": {
+        "default": "Standaard (rolluik)",
+        "switch": "Schakelaar",
+        "light": "Lamp",
+        "disabled": "Uitgeschakeld (kanaal verbergen)"
+      }
+    }
+  }
 }

--- a/tests/test_button_press_repeat.py
+++ b/tests/test_button_press_repeat.py
@@ -1,0 +1,74 @@
+"""Tests for repeated simulated-button-press emission.
+
+A single ``#N`` frame is unreliable on the Nikobus bus (modules only act
+on a command seen at least twice), so HA-originated presses are emitted
+as a short, spaced burst via ``coordinator.async_send_button_press``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from custom_components.nikobus.coordinator import NikobusDataCoordinator
+from custom_components.nikobus.const import DEFAULT_PRESS_REPEAT
+
+
+def _coord(press_repeat=DEFAULT_PRESS_REPEAT):
+    c = NikobusDataCoordinator.__new__(NikobusDataCoordinator)
+    c._press_repeat = press_repeat
+    c.nikobus_command = AsyncMock()
+    return c
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+class TestButtonPressRepeat(unittest.TestCase):
+    def test_default_sends_three_times(self):
+        c = _coord()
+        with patch("custom_components.nikobus.coordinator.asyncio.sleep",
+                   new=AsyncMock()):
+            _run(c.async_send_button_press("9E4E2C"))
+        sent = [args.args[0] for args in c.nikobus_command.queue_command.call_args_list]
+        self.assertEqual(sent, ["#N9E4E2C\r#E1"] * 3)
+
+    def test_configurable_repeat_count(self):
+        c = _coord(press_repeat=2)
+        with patch("custom_components.nikobus.coordinator.asyncio.sleep",
+                   new=AsyncMock()):
+            _run(c.async_send_button_press("DE4E2C"))
+        self.assertEqual(c.nikobus_command.queue_command.await_count, 2)
+
+    def test_spacing_between_repeats(self):
+        """N frames => N-1 inter-frame gaps (no trailing sleep)."""
+        c = _coord(press_repeat=3)
+        sleep = AsyncMock()
+        with patch("custom_components.nikobus.coordinator.asyncio.sleep", new=sleep):
+            _run(c.async_send_button_press("ABCDEF"))
+        self.assertEqual(sleep.await_count, 2)
+
+    def test_count_floor_is_one(self):
+        c = _coord(press_repeat=0)  # misconfig / disabled -> still send once
+        with patch("custom_components.nikobus.coordinator.asyncio.sleep",
+                   new=AsyncMock()):
+            _run(c.async_send_button_press("112233"))
+        self.assertEqual(c.nikobus_command.queue_command.await_count, 1)
+
+    def test_empty_address_sends_nothing(self):
+        c = _coord()
+        _run(c.async_send_button_press(""))
+        c.nikobus_command.queue_command.assert_not_called()
+
+    def test_event_handler_routes_through_burst(self):
+        c = _coord()
+        c.hass = None
+        with patch.object(c, "async_send_button_press", new=AsyncMock()) as burst:
+            _run(c.async_event_handler("ha_button_pressed", {"address": "9E4E2C"}))
+        burst.assert_awaited_once_with("9E4E2C")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Simulated button presses from HA "sometimes" did nothing. Root cause: a **single `#N` frame is unreliable on the Nikobus bus**. A real button emits its telegram repeatedly while held, and modules only act on a command seen **at least twice** (the protocol's noise/collision guard — see the reference firmware's `Nikobus_send_byte(3, 3, …)` / *"telegram moet ten minste 2 maal op de bus komen, 3 om zeker te zijn"*). HA was sending exactly **one** frame per press, so under bus contention the module never saw the required repetition and the press was dropped.

## Fix

New `coordinator.async_send_button_press(address)` emits `#N<addr>\r#E1` as a **short, spaced burst** — `CONF_PRESS_REPEAT` times (default **3**), ~50 ms apart. This mirrors the reference firmware's "2 to register, 3 to be sure" and the ~160 ms a real tap occupies on the bus (`pressed → released duration_s≈0.16` in real logs), kept short enough to read as a tap, not a hold.

Every HA-originated press now routes through it:
- `async_event_handler("ha_button_pressed")` — input buttons **and** the input A/B latch switch
- `async_activate_cf_broadcast` — CF / light scenes
- software-scene feedback-LED triggers

State-GET commands keep their own separate retry budget and are untouched.

## Configurable

`CONF_PRESS_REPEAT` (Options → hardware step, range 1–10, default 3); en/nl/fr strings added. `0`/invalid floors to a single send; missing falls back to the default.

## Tests

`tests/test_button_press_repeat.py` — burst count, spacing (N → N−1 gaps), floor-at-1, empty-address no-op, and event-handler routing. **Full suite: 237 passed.**

## Tuning note

3× is a safe default. If misses persist on a very busy bus, raise the option; if hold-mode buttons start acting "held", lower it. A debug log comparing a physical press vs an HA press of the same address will confirm the real telegram count.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_