### PR TITLE
3.0.0: remove legacy friendly-name import overlay + codebase cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+## 3.0.0
+
+Major release — **please read the breaking changes before upgrading.**
+
+### ⚠️ Breaking changes
+
+- **Legacy friendly-name import removed.** The `nikobus_module_config.json` /
+  `nikobus_button_config.json` files are no longer imported to set entity
+  names. Entity names now live in Home Assistant's registry and are preserved
+  across reloads and re-discovery — set them in HA. The files remain **only**
+  as the inventory fallback for installs without a PC-Link; the integration
+  logs a warning when it finds them so you know they're otherwise unused. If
+  you only kept them for names and you have a PC-Link/bridge, you can delete
+  them.
+- **Light-scene CF entity ids change.** Light-scene Central Functions are now
+  keyed on the address the bus actually emits (the keyed "wire" form, e.g.
+  `0D1C9E` → `DE4E2C`). This **fixes activation that previously did nothing**
+  and splits a multi-key trigger into one scene per key. Consequently, on the
+  **first discovery after upgrade** a light-scene's `unique_id`/entity id
+  changes: the old `scene.nikobus_cf_…` entity is replaced by one or more new
+  ones. **Re-point any automation or dashboard that referenced the old
+  entity.** CF *switch/roller* scenes are unaffected.
+- Requires **`nikobus-connect >= 0.22.0`**.
+
+### Added
+
+- **Input A/B latch switch** for PC-Logic (05-201) and Modular Interface
+  (05-206) inputs — a persistent on/off mirror alongside the existing
+  momentary buttons. The **A** signal latches it on, **B** latches it off, and
+  `turn_on` / `turn_off` drive the matching bus frame. Tracks physical presses
+  and other controllers, and survives restarts. (Assumes the input emits both
+  its A and B telegrams — the normal case.)
+- **Reliable simulated presses.** HA-originated presses (buttons, scenes,
+  CF/light-scene activation, the latch switch) are sent as a short repeated
+  burst instead of a single frame — matching how a real button behaves on the
+  bus and fixing presses that "sometimes" did nothing under bus contention.
+  Repeat count is configurable (Options → hardware settings; default 3).
+- Light-scene Central Functions are surfaced as scene entities.
+- Unrecognised button presses are logged at **INFO** ("run discovery to
+  populate it") instead of DEBUG, so a newly-seen button is easy to notice.
+
+### Fixed
+
+- Light-scene CF activation now actually fires its linked outputs.
+- Modular Interface (05-206) inputs are labelled `MI-INPUT N`, not
+  `LM-INPUT N`.
+
+### Internal
+
+- Substantial dead-code removal, de-duplication (shared hub-device,
+  routing-cache, input-naming/identity and operation-point helpers), and a
+  full correctness review across the integration — no behaviour change.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ Changes persist in `.storage/nikobus.modules` and survive re-discovery.
 
 ### Installs without a PC-Link
 
-If no PC-Link answers the discovery probe, the integration falls back to importing inventory from optional `nikobus_module_config.json` / `nikobus_button_config.json` files in `/config` (Feedback-module-only installs). These files are **only** consulted by the *Discover modules* action as a fallback — they are never imported automatically at startup, and never overwrite a PC-Link-discovered inventory. If you keep them, their descriptions are also overlaid onto discovered devices as friendly names.
+If no PC-Link answers the discovery probe, the integration falls back to importing inventory from optional `nikobus_module_config.json` / `nikobus_button_config.json` files in `/config` (Feedback-module-only installs). These files are **only** consulted by the *Discover modules* action as a fallback — they are never imported automatically at startup, and never overwrite a PC-Link-discovered inventory.
+
+> **3.0.0:** these files are now an **inventory source only**. The previous behaviour that imported their descriptions as friendly names on every startup has been removed — entity names live in Home Assistant (see [Renaming](#renaming)). If you only kept the files for their names and you have a PC-Link, you can delete them; the integration logs a warning when it finds them.
 
 ---
 
@@ -163,6 +165,9 @@ Each input has two keys — **A** and **B** — because the firmware emits one t
 
 - Use the **A / B buttons** to simulate the input going on/off *from* HA.
 - Use the **A / B sensors** to monitor the input's real state on the bus.
+- Use the **A/B latch switch** (added in 3.0.0) for a persistent on/off mirror: the **A** signal latches it on, **B** latches it off, and `turn_on` / `turn_off` drive the matching bus frame. It tracks physical presses and other controllers, and survives restarts.
+
+> The latch switch assumes the input emits **both** its A and B telegrams (one per direction) — the normal case. An input wired to emit only one of the two can be turned on/off from HA but its mirrored state won't follow physical presses in both directions.
 
 Input addresses are computed by firmware from the module's own address (not stored in inventory) and synthesised automatically — no configuration needed.
 
@@ -330,6 +335,8 @@ outputs:
 
 > CF scenes get generic names (`Nikobus switch CF …`). The friendly names from your Nikobus "Groups" are not imported — rename the scene entities in HA if you want.
 
+> **Upgrading to 3.0.0:** light-scene CFs are now keyed on the address the bus actually emits (the wire form), which both fixes activation and splits a multi-key trigger into one scene per key. As a result a light-scene's `unique_id` (and entity id) **changes on the first discovery after upgrade** — the old `scene.nikobus_cf_…` entity is replaced by one or more new ones. Re-point any automation or dashboard that referenced the old entity. CF *switch/roller* scenes are unaffected.
+
 ### User-authored scenes (`nikobus_scene_config.json`)
 
 For HA-side per-channel groupings that **don't** exist as a CF on the bus. Loaded from `/config` at startup; a missing/empty file is fine. Dimmers/shutters use 0–255, switches `"on"`/`"off"`, shutters `"open"`/`"close"`.
@@ -394,7 +401,7 @@ The store rebuilds cleanly with proper device types and no duplicates. Names you
 
 ### Custom channel/button names didn't carry over
 
-Friendly names you set in Home Assistant live in HA's entity/device registry (keyed by `unique_id`), not in the integration's store — so a clean re-discovery preserves them as long as the bus addresses are unchanged. Descriptions authored only in a legacy `nikobus_button_config.json` are overlaid where the discovered op-point addresses match.
+Friendly names you set in Home Assistant live in HA's entity/device registry (keyed by `unique_id`), not in the integration's store — so a clean re-discovery preserves them as long as the bus addresses are unchanged. (Removed in **3.0.0**: names are no longer imported from a legacy `nikobus_button_config.json`; set them in HA and they persist.)
 
 ### State is slow to update
 
@@ -436,7 +443,7 @@ The code is split into two packages.
 
 - `coordinator.py` — wires the library together; owns polling, discovery lifecycle, and state signals.
 - `nkbstorage.py` — the three HA Stores (`nikobus.modules`, `nikobus.buttons`, `nikobus.cfs`).
-- `nkbmanual.py` — optional fallback import of `nikobus_*_config.json` for no-PC-Link installs, plus the friendly-name overlay.
+- `nkbmanual.py` — optional fallback import of `nikobus_*_config.json` for no-PC-Link installs (inventory source only).
 - `nkbactuator.py` — turns incoming button frames into HA events with debounce + duration tracking.
 - `nkbconfig.py` — scene-file loader/writer.
 - `nkbtravelcalculator.py` — virtual cover-position tracking.

--- a/custom_components/nikobus/__init__.py
+++ b/custom_components/nikobus/__init__.py
@@ -1,13 +1,10 @@
 """The Nikobus integration."""
 from __future__ import annotations
 
-import json
 import logging
-import os
 from typing import Any, Final
 
 import voluptuous as vol
-from aiofiles import open as aio_open
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse, SupportsResponse
@@ -26,6 +23,7 @@ from homeassistant.components import (
 
 from .const import DOMAIN, HUB_IDENTIFIER
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
+from .entity import hub_device_info
 from .exceptions import NikobusConnectionError, NikobusDataError, NikobusError
 
 _LOGGER = logging.getLogger(__name__)
@@ -359,16 +357,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NikobusConfigEntry) -> b
     # 6. Clean up stale entities
     await _async_cleanup_orphan_entities(hass, entry, coordinator)
 
-    # 7. Legacy per-button-description → device.name_by_user migration
-    #    was a one-shot that renamed ``nikobus_button_config.json`` to
-    #    ``.migrated`` after applying. As of 2.11.4 we leave manual
-    #    config files in place under their canonical names (they're
-    #    now the step-1 inventory source for no-PC-Link installs), so
-    #    the rename-on-success behaviour is no longer compatible.
-    #    Users wanting custom device names set them via the HA device
-    #    registry UI directly.
-
-    # 8. Surface repair issues for actionable misconfigurations.
+    # 7. Surface repair issues for actionable misconfigurations.
     coordinator.refresh_repair_issues()
 
     _LOGGER.info("Nikobus integration setup complete")
@@ -395,11 +384,7 @@ def _register_hub_device(hass: HomeAssistant, entry: NikobusConfigEntry) -> None
     """Register the Nikobus bridge (hub) as a device."""
     device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
-        config_entry_id=entry.entry_id,
-        identifiers={(DOMAIN, HUB_IDENTIFIER)},
-        manufacturer="Niko",
-        name="Nikobus Bridge",
-        model="PC-Link Bridge",
+        config_entry_id=entry.entry_id, **hub_device_info()
     )
     _register_category_devices(hass, entry)
 

--- a/custom_components/nikobus/binary_sensor.py
+++ b/custom_components/nikobus/binary_sensor.py
@@ -93,7 +93,6 @@ class NikobusButtonBinarySensor(NikobusEntity, BinarySensorEntity):
             model=model,
             via_device=(DOMAIN, physical_address),
         )
-        self._address = bus_addr
         self._attr_unique_id = f"{DOMAIN}_button_{bus_addr}"
 
         self._attr_is_on = False

--- a/custom_components/nikobus/binary_sensor.py
+++ b/custom_components/nikobus/binary_sensor.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.event import async_call_later
 from .button import op_point_display_name, register_wall_button_devices
 from .const import DOMAIN, EVENT_BUTTON_PRESSED
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
+from .router import iter_operation_points
 from .entity import NikobusEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,25 +36,12 @@ async def async_setup_entry(
     buttons = (coordinator.dict_button_data or {}).get("nikobus_button", {})
     register_wall_button_devices(hass, entry, buttons, coordinator.dict_module_data)
 
-    entities: list[NikobusButtonBinarySensor] = []
-    for physical_addr, phys in buttons.items():
-        if not isinstance(phys, dict):
-            continue
-        for key_label, op_point in (phys.get("operation_points") or {}).items():
-            if not isinstance(op_point, dict):
-                continue
-            bus_addr = op_point.get("bus_address")
-            if not bus_addr:
-                continue
-            entities.append(
-                NikobusButtonBinarySensor(
-                    coordinator,
-                    physical_addr,
-                    key_label,
-                    op_point,
-                    parent_phys=phys,
-                )
-            )
+    entities: list[NikobusButtonBinarySensor] = [
+        NikobusButtonBinarySensor(
+            coordinator, physical_addr, key_label, op_point, parent_phys=phys
+        )
+        for physical_addr, key_label, op_point, phys in iter_operation_points(buttons)
+    ]
     async_add_entities(entities)
 
 

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -25,7 +25,12 @@ from .const import (
 )
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity
-from .router import INPUT_MODULE_TYPES, OPAQUE_MODULE_TYPES
+from .router import (
+    INPUT_MODULE_TYPES,
+    OPAQUE_MODULE_TYPES,
+    input_label_prefix,
+    pc_logic_input_naming,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -106,43 +111,6 @@ def _category_for_button_type(type_str: str) -> str:
     return CATEGORY_WALL_BUTTONS
 
 
-def _input_label_prefix(phys: dict[str, Any]) -> str:
-    """Return the input-naming prefix for a synthesized input child.
-
-    PC-Logic (05-201) inputs use ``LM`` (Logic Module — matches Niko's
-    own terminology); Modular Interface (05-206) inputs use ``MI``
-    (Modular Interface). Both share the ``pc_logic_parent_*`` provenance
-    fields, so ``pc_logic_parent_type`` is the discriminator. Anything
-    that isn't explicitly the Modular Interface stays ``LM`` (covers the
-    PC-Logic value and missing/legacy entries — back-compat).
-    """
-    return "MI" if phys.get("pc_logic_parent_type") == "interface_module" else "LM"
-
-
-def _pc_logic_input_naming(
-    phys: dict[str, Any],
-) -> tuple[str, tuple[str, str]] | None:
-    """Return ``(device_name, via_device_identifier)`` if ``phys`` is a
-    synthesized input-module child (PC-Logic or Modular Interface);
-    else ``None``.
-
-    The library sets ``pc_logic_parent_address`` (the owning module
-    address), ``pc_logic_parent_type`` (``pc_logic`` /
-    ``interface_module``) and ``pc_logic_slot_index`` (1..N) on the
-    button-store entry when it synthesizes virtual buttons for module
-    inputs. HA parents the device directly under the owning module
-    device (instead of the wall-buttons category) and names it
-    ``LM-INPUT N`` for PC-Logic or ``MI-INPUT N`` for the Modular
-    Interface, matching each product's terminology.
-    """
-
-    parent_addr = phys.get("pc_logic_parent_address")
-    slot = phys.get("pc_logic_slot_index")
-    if not isinstance(parent_addr, str) or not isinstance(slot, int):
-        return None
-    return f"{_input_label_prefix(phys)}-INPUT {slot}", (DOMAIN, parent_addr.upper())
-
-
 def _remote_transmitter_naming(
     phys: dict[str, Any],
 ) -> tuple[str, tuple[str, str]] | None:
@@ -199,7 +167,7 @@ def register_wall_button_devices(
         if not isinstance(phys, dict):
             continue
 
-        pc_logic_naming = _pc_logic_input_naming(phys)
+        pc_logic_naming = pc_logic_input_naming(phys)
         if pc_logic_naming is not None:
             name, via_device = pc_logic_naming
             parent_addr = via_device[1]
@@ -492,7 +460,7 @@ def op_point_display_name(
             and key_label[1].isalpha()
             and isinstance(slot, int)
         ):
-            prefix = _input_label_prefix(parent_phys)
+            prefix = input_label_prefix(parent_phys)
             return f"Key {key_label[1].upper()} on {prefix}-INPUT {slot}"
     return op_point.get("description") or f"Push button {key_label}"
 

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -28,6 +28,7 @@ from .router import (
     INPUT_MODULE_TYPES,
     OPAQUE_MODULE_TYPES,
     input_label_prefix,
+    iter_operation_points,
     pc_logic_input_naming,
 )
 
@@ -71,21 +72,10 @@ def _iter_button_entities(
     buttons: dict[str, Any],
 ):
     """Yield one NikobusButtonEntity per discovered operation point."""
-    for physical_addr, phys in buttons.items():
-        if not isinstance(phys, dict):
-            continue
-        op_points = phys.get("operation_points") or {}
-        if not isinstance(op_points, dict):
-            continue
-        for key_label, op_point in op_points.items():
-            if not isinstance(op_point, dict):
-                continue
-            bus_addr = op_point.get("bus_address")
-            if not bus_addr:
-                continue
-            yield NikobusButtonEntity(
-                coordinator, physical_addr, key_label, op_point, parent_phys=phys
-            )
+    for physical_addr, key_label, op_point, phys in iter_operation_points(buttons):
+        yield NikobusButtonEntity(
+            coordinator, physical_addr, key_label, op_point, parent_phys=phys
+        )
 
 
 def _category_for_button_type(type_str: str) -> str:

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -20,11 +20,10 @@ from .const import (
     CATEGORY_SYSTEM_MODULES,
     CATEGORY_WALL_BUTTONS,
     DOMAIN,
-    HUB_IDENTIFIER,
     SIGNAL_DISCOVERY_STATE,
 )
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
-from .entity import NikobusEntity
+from .entity import NikobusEntity, hub_device_info
 from .router import (
     INPUT_MODULE_TYPES,
     OPAQUE_MODULE_TYPES,
@@ -304,15 +303,6 @@ def _ensure_pc_logic_parent_device(
     )
 
 
-def _hub_device_info() -> dr.DeviceInfo:
-    return dr.DeviceInfo(
-        identifiers={(DOMAIN, HUB_IDENTIFIER)},
-        name="Nikobus Bridge",
-        manufacturer=BRAND,
-        model="PC-Link Bridge",
-    )
-
-
 def _iter_module_records(
     dict_module_data: dict[str, Any], module_types: frozenset[str]
 ):
@@ -476,7 +466,7 @@ class NikobusPcLinkInventoryButton(ButtonEntity):
     def __init__(self, coordinator: NikobusDataCoordinator) -> None:
         self._coordinator = coordinator
         self._attr_unique_id = f"{DOMAIN}_pc_link_inventory_button"
-        self._attr_device_info = _hub_device_info()
+        self._attr_device_info = hub_device_info()
 
     async def async_press(self) -> None:
         """Start PC Link inventory discovery.
@@ -518,7 +508,7 @@ class NikobusModuleScanButton(ButtonEntity):
     def __init__(self, coordinator: NikobusDataCoordinator) -> None:
         self._coordinator = coordinator
         self._attr_unique_id = f"{DOMAIN}_module_scan_button"
-        self._attr_device_info = _hub_device_info()
+        self._attr_device_info = hub_device_info()
 
     @property
     def available(self) -> bool:

--- a/custom_components/nikobus/const.py
+++ b/custom_components/nikobus/const.py
@@ -145,22 +145,6 @@ MANUAL_MODULE_CONFIG_FILENAME: Final[str] = "nikobus_module_config.json"
 MANUAL_BUTTON_CONFIG_FILENAME: Final[str] = "nikobus_button_config.json"
 
 # =============================================================================
-# Serial Connection
-# =============================================================================
-COMMANDS_HANDSHAKE: Final[list[str]] = [
-    "++++",
-    "ATH0",
-    "ATZ",
-    "$10110000B8CF9D",
-    "#L0",
-    "#E0",
-    "#L0",
-    "#E1",
-]
-EXPECTED_HANDSHAKE_RESPONSE: Final[str] = "$0511"
-HANDSHAKE_TIMEOUT: Final[int] = 60  # Timeout for handshake in seconds
-
-# =============================================================================
 # Buttons
 # =============================================================================
 REFRESH_DELAY: Final[float] = 0.5  # Delay before retrieving status after button press
@@ -215,7 +199,6 @@ MAX_EXTENDED_RELEASE_MS: Final[int] = 5000
 # =============================================================================
 # Covers
 # =============================================================================
-DEFAULT_COVER_ASSUMED_STATE: Final[bool] = False
 DEFAULT_COVER_MOVEMENT_BUFFER: Final[float] = 3.0
 DEFAULT_COVER_DEBOUNCE_DELAY: Final[float] = 0.3
 DEFAULT_COVER_OPERATION_TIME: Final[float] = 30.0
@@ -223,11 +206,6 @@ DEFAULT_COVER_OPERATION_TIME: Final[float] = 30.0
 # =============================================================================
 # Listener
 # =============================================================================
-BUTTON_COMMAND_PREFIX: Final[str] = "#N"
-FEEDBACK_REFRESH_COMMAND: Final[tuple[str, str]] = ("$1012", "$1017")
-FEEDBACK_MODULE_ANSWER: Final[str] = "$1C"
-MANUAL_REFRESH_COMMAND: Final[tuple[str, str]] = ("$0512", "$0517")
-COMMAND_PROCESSED: Final[tuple[str, str]] = ("$0515", "$0516")
 DEVICE_ADDRESS_INVENTORY: Final[str] = "$18"
 DEVICE_INVENTORY_ANSWER: Final[tuple[str, str]] = ("$2E", "$1E")
 

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -155,12 +155,22 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self._module_states: dict[str, bytearray] = {}
 
         self.discovery_running = False
-        # Written by nikobus-connect (it holds this coordinator as
-        # ``self._coordinator``): set to PC_LINK in start_inventory_discovery
-        # and MODULE in the register-scan path, reset to None between phases.
-        # Read by ``_inventory_callback`` / ``_discovery_frame_callback`` to
-        # route $18 / $2E / $1E frames. Looks unassigned to a grep of this
-        # file — the writer is in the library. Do NOT remove.
+        # The following are written by nikobus-connect, which holds this
+        # coordinator as ``self._coordinator`` and assigns these attributes
+        # cross-object during discovery. They look unassigned to a grep of
+        # THIS file — the writer is in the library — so do NOT remove them:
+        # the library both writes and READS them (e.g. ``if not
+        # self._coordinator.discovery_module``), and a missing seed here
+        # would raise AttributeError if the library reads before its first
+        # write.
+        #   * ``discovery_module`` / ``discovery_module_address`` — current
+        #     per-module register-scan target; read in the library's frame
+        #     routing.
+        #   * ``inventory_query_type`` — PC_LINK / MODULE phase marker, read
+        #     by ``_inventory_callback`` / ``_discovery_frame_callback`` to
+        #     route $18 / $2E / $1E frames.
+        self.discovery_module = None
+        self.discovery_module_address: str | None = None
         self.inventory_query_type: InventoryQueryType | None = None
         self._reload_task = None
         # Was the most recent ``start_module_scan`` a scan-all (every
@@ -1035,7 +1045,9 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         A/B latch switch, software-scene feedback LEDs, and CF /
         light-scene activation.
         """
-        if not address:
+        if not address or self.nikobus_command is None:
+            # No command handler before connect / during teardown —
+            # nothing to send rather than an AttributeError.
             return
         try:
             repeats = max(1, int(self._press_repeat))

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -1236,7 +1236,8 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             build_routing,
             build_unique_id,
             input_latch_switch_unique_id,
-            is_input_module_child,
+            iter_input_module_children,
+            iter_operation_points,
             INPUT_MODULE_TYPES,
         )
         known: set[str] = set()
@@ -1244,20 +1245,17 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         for specs in routing.values():
             for spec in specs:
                 known.add(build_unique_id(spec.domain, spec.kind, spec.address, spec.channel))
-        for in_addr, phys in self.dict_button_data.get("nikobus_button", {}).items():
-            if not isinstance(phys, dict):
-                continue
-            for op_point in (phys.get("operation_points") or {}).values():
-                if not isinstance(op_point, dict):
-                    continue
-                if bus_addr := op_point.get("bus_address"):
-                    known.add(f"{DOMAIN}_button_{bus_addr}")
-                    known.add(f"{DOMAIN}_push_button_{bus_addr}")
-            # Stateful A/B latch switch for PC-Logic / Modular-Interface
-            # inputs (switch platform). Shared helpers keep this in lock
-            # step with the switch platform's own id/predicate.
-            if is_input_module_child(phys):
-                known.add(input_latch_switch_unique_id(in_addr))
+        buttons = self.dict_button_data.get("nikobus_button", {})
+        # Button + push-button ids, via the shared op-point enumerator
+        # (same guard ladder the button/binary-sensor platforms use).
+        for _addr, _key, op_point, _phys in iter_operation_points(buttons):
+            bus_addr = op_point["bus_address"]
+            known.add(f"{DOMAIN}_button_{bus_addr}")
+            known.add(f"{DOMAIN}_push_button_{bus_addr}")
+        # Stateful A/B latch switch ids for PC-Logic / Modular-Interface
+        # inputs — same enumerator the switch platform creates from.
+        for in_addr, _phys in iter_input_module_children(buttons):
+            known.add(input_latch_switch_unique_id(in_addr))
         # Input-class modules (PC-Logic, Modular Interface) skip ``build_routing``
         # because they don't drive output relays — emit their input-channel
         # button unique IDs directly so orphan-cleanup doesn't remove them.

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -1242,7 +1242,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         for specs in routing.values():
             for spec in specs:
                 known.add(build_unique_id(spec.domain, spec.kind, spec.address, spec.channel))
-        for phys in self.dict_button_data.get("nikobus_button", {}).values():
+        for in_addr, phys in self.dict_button_data.get("nikobus_button", {}).items():
             if not isinstance(phys, dict):
                 continue
             for op_point in (phys.get("operation_points") or {}).values():
@@ -1251,6 +1251,10 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 if bus_addr := op_point.get("bus_address"):
                     known.add(f"{DOMAIN}_button_{bus_addr}")
                     known.add(f"{DOMAIN}_push_button_{bus_addr}")
+            # Stateful A/B latch switch for PC-Logic / Modular-Interface
+            # inputs (switch platform, ``nikobus_input_switch_<addr>``).
+            if phys.get("pc_logic_parent_type") in INPUT_MODULE_TYPES:
+                known.add(f"nikobus_input_switch_{str(in_addr).lower()}")
         # Input-class modules (PC-Logic, Modular Interface) skip ``build_routing``
         # because they don't drive output relays — emit their input-channel
         # button unique IDs directly so orphan-cleanup doesn't remove them.
@@ -1293,11 +1297,6 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         if self.cf_storage is not None:
             for cf_addr in self.cf_storage.data.get("nikobus_cf", {}):
                 known.add(f"nikobus_cf_{str(cf_addr).lower()}")
-        # Stateful A/B latch switches for PC-Logic / Modular-Interface
-        # inputs (switch platform, unique_id ``nikobus_input_switch_<addr>``).
-        for in_addr, phys in self.dict_button_data.get("nikobus_button", {}).items():
-            if isinstance(phys, dict) and phys.get("pc_logic_parent_type") in INPUT_MODULE_TYPES:
-                known.add(f"nikobus_input_switch_{str(in_addr).lower()}")
         known.add(f"{DOMAIN}_connection_status")
         known.add(f"{DOMAIN}_discovery_status")
         known.add(f"{DOMAIN}_discovery_progress")

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -155,6 +155,12 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self._module_states: dict[str, bytearray] = {}
 
         self.discovery_running = False
+        # Written by nikobus-connect (it holds this coordinator as
+        # ``self._coordinator``): set to PC_LINK in start_inventory_discovery
+        # and MODULE in the register-scan path, reset to None between phases.
+        # Read by ``_inventory_callback`` / ``_discovery_frame_callback`` to
+        # route $18 / $2E / $1E frames. Looks unassigned to a grep of this
+        # file — the writer is in the library. Do NOT remove.
         self.inventory_query_type: InventoryQueryType | None = None
         self._reload_task = None
         # Was the most recent ``start_module_scan`` a scan-all (every

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -1236,7 +1236,13 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
 
     def get_known_entity_unique_ids(self) -> set[str]:
         """Return the set of valid unique_ids for all Nikobus entities."""
-        from .router import build_routing, build_unique_id, INPUT_MODULE_TYPES
+        from .router import (
+            build_routing,
+            build_unique_id,
+            input_latch_switch_unique_id,
+            is_input_module_child,
+            INPUT_MODULE_TYPES,
+        )
         known: set[str] = set()
         routing = build_routing(self.dict_module_data)
         for specs in routing.values():
@@ -1252,9 +1258,10 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                     known.add(f"{DOMAIN}_button_{bus_addr}")
                     known.add(f"{DOMAIN}_push_button_{bus_addr}")
             # Stateful A/B latch switch for PC-Logic / Modular-Interface
-            # inputs (switch platform, ``nikobus_input_switch_<addr>``).
-            if phys.get("pc_logic_parent_type") in INPUT_MODULE_TYPES:
-                known.add(f"nikobus_input_switch_{str(in_addr).lower()}")
+            # inputs (switch platform). Shared helpers keep this in lock
+            # step with the switch platform's own id/predicate.
+            if is_input_module_child(phys):
+                known.add(input_latch_switch_unique_id(in_addr))
         # Input-class modules (PC-Logic, Modular Interface) skip ``build_routing``
         # because they don't drive output relays — emit their input-channel
         # button unique IDs directly so orphan-cleanup doesn't remove them.

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -61,7 +61,7 @@ from .const import (
 )
 from .nkbactuator import NikobusActuator
 from .nkbconfig import NikobusConfig
-from .nkbmanual import async_apply_friendly_name_overlay
+from .nkbmanual import legacy_config_files_present
 from .nkbstorage import (
     NikobusButtonStorage,
     NikobusCFStorage,
@@ -266,34 +266,16 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             self.dict_button_data = await self.button_storage.async_load()
             await self.cf_storage.async_load()
 
-            # Boot NEVER imports inventory from the legacy manual-config
-            # files. Building inventory from files is reserved for the
-            # explicit "Discover modules" action, which tries PC-Link
-            # first and only falls back to the files on probe failure
-            # (see ``start_pc_link_inventory`` →
-            # ``_apply_manual_inventory_as_fallback``).
-            #
-            # Importing at boot was wrong on two counts: it silently
-            # clobbered a PC-Link install's bus-discovered inventory from
-            # stale leftover files (2.12.2 guarded that), and — worse —
-            # it seeded a *fresh* PC-Link install from files before the
-            # user ever ran discovery (the provenance guard couldn't tell
-            # "fresh PC-Link install" from "no-PC-Link install"). The
-            # fix is to not import at boot at all.
-            #
-            # The names-only friendly-name overlay still runs: it never
-            # adds or removes modules/buttons, it only enriches entries
-            # that already exist in the stores, so file-authored names
-            # stay in sync each boot without re-running discovery.
-            changed = await async_apply_friendly_name_overlay(
-                self.hass,
-                self.module_storage,
-                self.dict_button_data,
-            )
-            if changed:
-                await self.module_storage.async_save()
-                await self.button_storage.async_save()
-                self._rebuild_dict_module_data()
+            # 3.0.0: the legacy friendly-name overlay (importing entity
+            # names from nikobus_module_config.json / nikobus_button_config.json
+            # on every boot) has been removed — entity names are managed in
+            # Home Assistant and preserved across reloads. The files are still
+            # consulted only as the inventory fallback for installs without a
+            # PC-Link (start_pc_link_inventory → _apply_manual_inventory_as_fallback).
+            # Warn if they're still present so users know the name-import no
+            # longer happens.
+            await self._warn_if_legacy_config_files_present()
+
             self.dict_scene_data = await self.nikobus_config.load_json_data(
                 "nikobus_scene_config.json", "scene"
             )
@@ -1342,6 +1324,24 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self.dict_module_data.clear()
         self.dict_module_data.update(grouped)
 
+    async def _warn_if_legacy_config_files_present(self) -> None:
+        """Warn if the deprecated manual-config files are still on disk.
+
+        As of 3.0.0 these files are no longer imported for entity names;
+        they're only consulted as the no-PC-Link inventory fallback.
+        """
+        present = await legacy_config_files_present(self.hass)
+        if present:
+            _LOGGER.warning(
+                "Legacy Nikobus config file(s) found: %s. As of 3.0.0 these "
+                "are no longer imported for entity names — names are managed "
+                "in Home Assistant and preserved across reloads. They are "
+                "only consulted as the inventory fallback for installs "
+                "without a PC-Link; if you use a PC-Link/bridge you can "
+                "delete them.",
+                ", ".join(present),
+            )
+
     def _invalidate_routing_cache(self) -> None:
         """Drop the cached router spec so the next access rebuilds it
         (e.g. after modules are discovered, purged, or edited)."""
@@ -2056,19 +2056,6 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                     translation_domain=DOMAIN,
                     translation_key="no_inventory_source",
                 )
-
-        # 3. Overlay friendly names from manual files (whether or not
-        #    we used them as inventory source). No-op if files absent.
-        try:
-            overlaid = await async_apply_friendly_name_overlay(
-                self.hass, self.module_storage, self.dict_button_data
-            )
-            if overlaid:
-                await self.module_storage.async_save()
-                await self.button_storage.async_save()
-                self._rebuild_dict_module_data()
-        except Exception:  # noqa: BLE001
-            _LOGGER.exception("Friendly-name overlay failed; continuing")
 
     async def _try_pclink_inventory(self) -> bool:
         """Kick off the ``#A`` broadcast and decide if PC-Link is present.

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -155,8 +155,6 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self._module_states: dict[str, bytearray] = {}
 
         self.discovery_running = False
-        self.discovery_module = None
-        self.discovery_module_address: str | None = None
         self.inventory_query_type: InventoryQueryType | None = None
         self._reload_task = None
         # Was the most recent ``start_module_scan`` a scan-all (every
@@ -1016,9 +1014,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             await self.module_storage.async_save()
             await self.button_storage.async_save()
             self._rebuild_dict_module_data()
-            domain_data = self.hass.data.get(DOMAIN, {})
-            entry_data = domain_data.get(self.config_entry.entry_id, {})
-            entry_data.pop("routing", None)
+            self._invalidate_routing_cache()
             # Reload so platforms drop entities for the purged addresses.
             # Schedule rather than await — matches ``_async_options_updated``.
             self.hass.async_create_task(
@@ -1340,14 +1336,19 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self.dict_module_data.clear()
         self.dict_module_data.update(grouped)
 
+    def _invalidate_routing_cache(self) -> None:
+        """Drop the cached router spec so the next access rebuilds it
+        (e.g. after modules are discovered, purged, or edited)."""
+        domain_data = self.hass.data.get(DOMAIN, {})
+        entry_data = domain_data.get(self.config_entry.entry_id, {})
+        entry_data.pop("routing", None)
+
     async def _async_on_module_save(self) -> None:
         """Persist the Store after discovery/user edits, then refresh derived views."""
         await self.module_storage.async_save()
         self._rebuild_dict_module_data()
         # Clear the cached router spec so newly-discovered modules show up.
-        domain_data = self.hass.data.get(DOMAIN, {})
-        entry_data = domain_data.get(self.config_entry.entry_id, {})
-        entry_data.pop("routing", None)
+        self._invalidate_routing_cache()
 
     @staticmethod
     def _collect_button_linked_modules(phys: dict[str, Any]) -> set[str]:
@@ -1752,9 +1753,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         await self.module_storage.async_save()
         await self.button_storage.async_save()
         self._rebuild_dict_module_data()
-        domain_data = self.hass.data.get(DOMAIN, {})
-        entry_data = domain_data.get(self.config_entry.entry_id, {})
-        entry_data.pop("routing", None)
+        self._invalidate_routing_cache()
         self.invalidate_controlled_by_index()
 
         _LOGGER.info(
@@ -2055,7 +2054,6 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         # 3. Overlay friendly names from manual files (whether or not
         #    we used them as inventory source). No-op if files absent.
         try:
-            from .nkbmanual import async_apply_friendly_name_overlay
             overlaid = await async_apply_friendly_name_overlay(
                 self.hass, self.module_storage, self.dict_button_data
             )

--- a/custom_components/nikobus/cover.py
+++ b/custom_components/nikobus/cover.py
@@ -22,7 +22,6 @@ from .const import (
     DEFAULT_COVER_DEBOUNCE_DELAY,
     DEFAULT_COVER_MOVEMENT_BUFFER,
     DEFAULT_COVER_OPERATION_TIME,
-    DOMAIN,
     EVENT_BUTTON_PRESSED,
 )
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator

--- a/custom_components/nikobus/entity.py
+++ b/custom_components/nikobus/entity.py
@@ -9,10 +9,27 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import BRAND, DOMAIN
+from .const import BRAND, DOMAIN, HUB_IDENTIFIER
 from .coordinator import NikobusDataCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def hub_device_info() -> dr.DeviceInfo:
+    """DeviceInfo for the Nikobus bridge (hub).
+
+    Single source of truth for the bridge device — the ``via_device``
+    parent of the category devices and the device the bridge-level
+    entities (connection/discovery status, action buttons) attach to.
+    Shared by the button and sensor platforms and the hub registration
+    in ``__init__`` so they can't drift.
+    """
+    return dr.DeviceInfo(
+        identifiers={(DOMAIN, HUB_IDENTIFIER)},
+        name="Nikobus Bridge",
+        manufacturer=BRAND,
+        model="PC-Link Bridge",
+    )
 
 
 class NikobusEntity(CoordinatorEntity[NikobusDataCoordinator]):

--- a/custom_components/nikobus/light.py
+++ b/custom_components/nikobus/light.py
@@ -11,7 +11,7 @@ from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .const import DOMAIN, EVENT_BUTTON_OPERATION
+from .const import EVENT_BUTTON_OPERATION
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity
 from .router import build_unique_id, get_routing, register_output_module_devices

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "2.15.0",
+  "version": "3.0.0",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/custom_components/nikobus/nkbactuator.py
+++ b/custom_components/nikobus/nkbactuator.py
@@ -247,7 +247,7 @@ class NikobusActuator:
         """Identify impacted modules and trigger targeted refreshes."""
         hit = find_operation_point(self._dict_button_data, address)
         if hit is None:
-            _LOGGER.debug("Press from unknown button %s — run discovery to populate it", address)
+            _LOGGER.info("Press from unknown button %s — run discovery to populate it", address)
             return
         _physical_addr, _key_label, op_point = hit
         await self.process_button_modules(op_point, address, press_context)

--- a/custom_components/nikobus/nkbconfig.py
+++ b/custom_components/nikobus/nkbconfig.py
@@ -1,7 +1,7 @@
-"""Nikobus Configuration Handler - Load / Write configuration files for Nikobus.
+"""Nikobus Configuration Handler - Load configuration files for Nikobus.
 
 As of nikobus-connect 0.4.0 the module store lives in the HA Store
-(``.storage/nikobus.modules``). This handler only manages the scene config
+(``.storage/nikobus.modules``). This handler only loads the scene config
 file today; the module/button paths are intentionally absent.
 """
 
@@ -10,7 +10,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import os
 from typing import Any
 
 from aiofiles import open as aio_open
@@ -20,7 +19,6 @@ from .exceptions import NikobusDataError
 
 _LOGGER = logging.getLogger(__name__)
 _LOAD_TRANSFORMS: dict[str, str] = {}
-_WRITE_TRANSFORMS: dict[str, str] = {}
 
 
 class NikobusConfig:
@@ -55,38 +53,6 @@ class NikobusConfig:
             _LOGGER.error("Failed to load %s data: %s", data_type, err, exc_info=True)
             raise NikobusDataError(f"Failed to load {data_type} data: {err}") from err
 
-    async def load_optional_json_data(self, file_name: str, data_type: str) -> dict[str, Any]:
-        """Load JSON data from a file, returning an empty dict if it does not exist."""
-        file_path = self._hass.config.path(file_name)
-        _LOGGER.debug("Loading optional %s data from %s", data_type, file_path)
-
-        try:
-            async with aio_open(file_path, mode="r") as file:
-                data = json.loads(await file.read())
-            return self._transform_loaded_data(data, data_type)
-        except FileNotFoundError:
-            _LOGGER.debug("Optional %s file not found: %s", data_type, file_path)
-            return {}
-        except json.JSONDecodeError as err:
-            _LOGGER.error(
-                "Failed to decode JSON in optional %s file: %s",
-                data_type,
-                err,
-                exc_info=True,
-            )
-            raise NikobusDataError(
-                f"Failed to decode JSON in optional {data_type} file: {err}"
-            ) from err
-        except asyncio.CancelledError:
-            raise
-        except Exception as err:
-            _LOGGER.error(
-                "Failed to load optional %s data: %s", data_type, err, exc_info=True
-            )
-            raise NikobusDataError(
-                f"Failed to load optional {data_type} data: {err}"
-            ) from err
-
     def _transform_loaded_data(self, data: dict[str, Any], data_type: str) -> dict[str, Any]:
         """Transform the loaded JSON data based on the data type."""
         transform_name = _LOAD_TRANSFORMS.get(data_type)
@@ -115,74 +81,3 @@ class NikobusConfig:
             _LOGGER.info("Created empty %s config: %s", data_type, file_path)
         except OSError as err:
             _LOGGER.warning("Could not create empty %s config: %s", data_type, err)
-
-    async def write_json_data(
-        self, file_name: str, data_type: str, data: dict[str, Any]
-    ) -> None:
-        """Write data to a JSON file, transforming it into a list format if necessary."""
-        file_path = self._hass.config.path(file_name)
-
-        tmp_path = file_path + ".tmp"
-        try:
-            transformed_data = self._transform_data_for_writing(data_type, data)
-            json_data = json.dumps(transformed_data, indent=4)
-            async with aio_open(tmp_path, "w") as file:
-                await file.write(json_data)
-            os.replace(tmp_path, file_path)
-
-        except IOError as err:
-            _LOGGER.error(
-                "Failed to write %s data to file %s: %s",
-                data_type.capitalize(),
-                file_name,
-                err,
-                exc_info=True,
-            )
-            self._cleanup_tmp(tmp_path)
-            raise NikobusDataError(
-                f"Failed to write {data_type.capitalize()} data to file {file_name}: {err}"
-            ) from err
-
-        except TypeError as err:
-            _LOGGER.error(
-                "Failed to serialize %s data to JSON: %s",
-                data_type,
-                err,
-                exc_info=True,
-            )
-            self._cleanup_tmp(tmp_path)
-            raise NikobusDataError(
-                f"Failed to serialize {data_type} data to JSON: {err}"
-            ) from err
-
-        except asyncio.CancelledError:
-            raise
-        except Exception as err:
-            _LOGGER.error(
-                "Unexpected error writing %s data to file %s: %s",
-                data_type,
-                file_name,
-                err,
-                exc_info=True,
-            )
-            self._cleanup_tmp(tmp_path)
-            raise NikobusDataError(
-                f"Unexpected error writing {data_type} data to file {file_name}: {err}"
-            ) from err
-
-    @staticmethod
-    def _cleanup_tmp(tmp_path: str) -> None:
-        """Remove a leftover .tmp file, ignoring errors."""
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
-
-    def _transform_data_for_writing(
-        self, data_type: str, data: dict[str, Any]
-    ) -> dict[str, Any]:
-        """Transform the data for writing based on the data type."""
-        transform_name = _WRITE_TRANSFORMS.get(data_type)
-        if not transform_name:
-            return data
-        return getattr(self, transform_name)(data)

--- a/custom_components/nikobus/nkbmanual.py
+++ b/custom_components/nikobus/nkbmanual.py
@@ -227,34 +227,6 @@ async def _apply_module_config(
     return len(flat), path
 
 
-# ---------------------------------------------------------------------------
-# Friendly-name overlay (2.11.5+)
-# ---------------------------------------------------------------------------
-#
-# Distinct from ``_apply_module_config`` / ``_apply_button_config`` above,
-# which fully REPLACE the stores from the manual files (used when there's
-# no PC-Link to provide inventory). The overlay enriches existing entries
-# in-place: same address present in both the live store AND the file →
-# copy user-editable fields (descriptions, entity_type, roller times,
-# LED triggers) from file onto the store entry. Modules in the file that
-# aren't in the store are silently ignored — PC-Link's inventory is the
-# authority for what exists.
-#
-# Use case: PC-Link installs whose users want their custom labels (from
-# an old YAML/JSON setup or from a sibling install) to survive the bus
-# discovery's generic "Switch Module" / "Output 1" defaults.
-
-_MODULE_OVERLAY_FIELDS = ("description",)
-_CHANNEL_OVERLAY_FIELDS = (
-    "description",
-    "entity_type",
-    "operation_time_up",
-    "operation_time_down",
-    "led_on",
-    "led_off",
-)
-
-
 def _extract_physical_info(
     entry: dict[str, Any],
 ) -> tuple[str, str, int, str, str] | None:

--- a/custom_components/nikobus/nkbmanual.py
+++ b/custom_components/nikobus/nkbmanual.py
@@ -43,6 +43,20 @@ from .nkbstorage import NikobusModuleStorage
 _LOGGER = logging.getLogger(__name__)
 
 
+async def legacy_config_files_present(hass: HomeAssistant) -> list[str]:
+    """Return which legacy manual-config filenames exist in the config dir.
+
+    Used to warn that, as of 3.0.0, these files are no longer imported for
+    entity names (they remain only the no-PC-Link inventory fallback).
+    """
+    present: list[str] = []
+    for filename in (MANUAL_MODULE_CONFIG_FILENAME, MANUAL_BUTTON_CONFIG_FILENAME):
+        path = hass.config.path(filename)
+        if await hass.async_add_executor_job(os.path.exists, path):
+            present.append(filename)
+    return present
+
+
 async def _read_json(
     hass: HomeAssistant, filename: str
 ) -> tuple[str | None, dict[str, Any] | None]:
@@ -239,135 +253,6 @@ _CHANNEL_OVERLAY_FIELDS = (
     "led_on",
     "led_off",
 )
-
-
-def _overlay_module(store_entry: dict[str, Any], file_entry: dict[str, Any]) -> bool:
-    """Apply user-editable fields from ``file_entry`` onto ``store_entry``.
-
-    Module-level fields (currently just ``description``) and the
-    per-channel fields listed in ``_CHANNEL_OVERLAY_FIELDS``. Matches
-    channels by INDEX (file's channel 0 → store's channel 0). Returns
-    True if any field was overwritten.
-    """
-    changed = False
-
-    for field in _MODULE_OVERLAY_FIELDS:
-        if field in file_entry and file_entry[field] not in ("", None):
-            if store_entry.get(field) != file_entry[field]:
-                store_entry[field] = file_entry[field]
-                changed = True
-
-    file_channels = file_entry.get("channels") or []
-    store_channels = store_entry.setdefault("channels", [])
-    for idx, file_ch in enumerate(file_channels):
-        if not isinstance(file_ch, dict):
-            continue
-        # Extend store channel list if file declares more than discovery
-        # found — won't happen for real installs but keeps the overlay
-        # robust against partial-discovery edge cases.
-        while idx >= len(store_channels):
-            store_channels.append({})
-        store_ch = store_channels[idx]
-        for field in _CHANNEL_OVERLAY_FIELDS:
-            if field in file_ch and file_ch[field] not in ("", None):
-                if store_ch.get(field) != file_ch[field]:
-                    store_ch[field] = file_ch[field]
-                    changed = True
-
-    return changed
-
-
-async def async_apply_friendly_name_overlay(
-    hass: HomeAssistant,
-    module_store: NikobusModuleStorage,
-    button_data: dict[str, Any],
-) -> bool:
-    """Overlay user-editable fields from the manual config files onto the
-    existing live stores. Does NOT add or remove modules/buttons — only
-    enriches entries that already exist (typically populated by PC-Link
-    inventory).
-
-    Returns True if any field was changed in either store (signal to
-    the caller to persist).
-    """
-    changed_any = False
-
-    # Module overlay
-    path, payload = await _read_json(hass, MANUAL_MODULE_CONFIG_FILENAME)
-    if path is not None and isinstance(payload, dict):
-        flat = convert_legacy_to_flat(payload)
-        store_modules = module_store.data.setdefault("nikobus_module", {})
-        applied = skipped = 0
-        for addr, file_entry in flat.items():
-            store_entry = store_modules.get(addr)
-            if store_entry is None:
-                skipped += 1
-                continue
-            if _overlay_module(store_entry, file_entry):
-                applied += 1
-                changed_any = True
-        _LOGGER.info(
-            "Friendly-name overlay: %d module(s) updated from %s "
-            "(%d file entries had no matching live module — ignored).",
-            applied, path, skipped,
-        )
-
-    # Button overlay — match by physical button address + op-point key.
-    path, payload = await _read_json(hass, MANUAL_BUTTON_CONFIG_FILENAME)
-    if path is not None and isinstance(payload, dict):
-        raw = payload.get("nikobus_button")
-        legacy_iter: list[dict[str, Any]] = []
-        if isinstance(raw, list):
-            legacy_iter = [e for e in raw if isinstance(e, dict)]
-        elif isinstance(raw, dict):
-            for addr, entry in raw.items():
-                if isinstance(entry, dict):
-                    merged = dict(entry)
-                    merged.setdefault("address", addr)
-                    legacy_iter.append(merged)
-
-        store_buttons = button_data.setdefault("nikobus_button", {})
-        applied = skipped = 0
-        for entry in legacy_iter:
-            description = str(entry.get("description") or "").strip()
-            physical = _extract_physical_info(entry)
-            if physical is None:
-                # Synthetic / IR / scene entry — match its standalone
-                # single-key store entry by bus_address.
-                bus_addr = str(entry.get("address") or "").strip().upper()
-                store_btn = store_buttons.get(bus_addr)
-                if store_btn is None or not description:
-                    skipped += 1
-                    continue
-                op = store_btn.get("operation_points", {}).get("1A")
-                if op is not None and op.get("description") != description:
-                    op["description"] = description
-                    store_btn["description"] = description
-                    applied += 1
-                    changed_any = True
-                continue
-
-            phys_addr, key_label, _channels, _type, _model = physical
-            store_btn = store_buttons.get(phys_addr)
-            if store_btn is None:
-                skipped += 1
-                continue
-            op = store_btn.get("operation_points", {}).get(key_label)
-            if op is None:
-                skipped += 1
-                continue
-            if description and op.get("description") != description:
-                op["description"] = description
-                applied += 1
-                changed_any = True
-
-        _LOGGER.info(
-            "Friendly-name overlay: %d op-point(s) updated from %s "
-            "(%d file entries had no matching live op-point — ignored).",
-            applied, path, skipped,
-        )
-
-    return changed_any
 
 
 def _extract_physical_info(

--- a/custom_components/nikobus/repairs.py
+++ b/custom_components/nikobus/repairs.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.selector import (
     SelectSelectorMode,
 )
 
-from .const import DOMAIN, ISSUE_LEGACY_UNDECODED_BUTTONS
+from .const import ISSUE_LEGACY_UNDECODED_BUTTONS
 from .coordinator import NikobusDataCoordinator
 
 

--- a/custom_components/nikobus/router.py
+++ b/custom_components/nikobus/router.py
@@ -140,6 +140,32 @@ def iter_input_module_children(
         if is_input_module_child(phys):
             yield str(addr), phys
 
+
+def iter_operation_points(
+    buttons: Mapping[str, Any] | None,
+) -> Iterator[tuple[str, str, Mapping[str, Any], Mapping[str, Any]]]:
+    """Yield ``(physical_addr, key_label, op_point, phys)`` for every
+    button operation point carrying a ``bus_address``.
+
+    Single source of the guard ladder (entry is a dict → has a dict
+    ``operation_points`` → op-point is a dict → has a truthy
+    ``bus_address``) so the button platform, the binary-sensor platform
+    and the orphan-cleanup known-id set agree. (binary_sensor.py and the
+    known-id loop previously skipped the ``operation_points`` dict check,
+    which would raise ``AttributeError`` on a malformed list-shaped
+    entry.)"""
+    for physical_addr, phys in (buttons or {}).items():
+        if not isinstance(phys, dict):
+            continue
+        op_points = phys.get("operation_points")
+        if not isinstance(op_points, dict):
+            continue
+        for key_label, op_point in op_points.items():
+            if not isinstance(op_point, dict):
+                continue
+            if op_point.get("bus_address"):
+                yield str(physical_addr), str(key_label), op_point, phys
+
 # Module types we recognise but for which no entity schema is validated
 # yet — the inventory record alone makes the device visible in the HA
 # device registry, but no platform creates entities for it.

--- a/custom_components/nikobus/router.py
+++ b/custom_components/nikobus/router.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Iterable, Mapping
+from typing import Any, Iterable, Iterator, Mapping
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -66,6 +66,79 @@ _CAPABILITIES = {
 #   * ``interface_module`` — Modular Interface 6 inputs (05-206).
 #     Promoted out of ``other_module`` into its own bucket in 0.5.10.
 INPUT_MODULE_TYPES: frozenset[str] = frozenset({"pc_logic", "interface_module"})
+
+
+# ---------------------------------------------------------------------------
+# Synthesized input-module children (PC-Logic / Modular Interface inputs)
+#
+# These live in the button store (``nikobus_button``) as synthesized
+# entries carrying ``pc_logic_parent_*`` provenance, not as output-module
+# channels — so they bypass ``build_routing``. The helpers below are the
+# single source of truth for *recognising* such a child, *naming* it, and
+# the *unique_id* of its A/B latch switch, shared by the button platform,
+# the switch platform, and the orphan-cleanup known-id set so those three
+# can't drift apart.
+# ---------------------------------------------------------------------------
+
+def input_label_prefix(phys: Mapping[str, Any]) -> str:
+    """Return the input-naming prefix for a synthesized input child.
+
+    PC-Logic (05-201) inputs use ``LM`` (Logic Module — matches Niko's
+    own terminology); Modular Interface (05-206) inputs use ``MI``
+    (Modular Interface). Both share the ``pc_logic_parent_*`` provenance
+    fields, so ``pc_logic_parent_type`` is the discriminator. Anything
+    that isn't explicitly the Modular Interface stays ``LM`` (covers the
+    PC-Logic value and missing/legacy entries — back-compat).
+    """
+    return "MI" if phys.get("pc_logic_parent_type") == "interface_module" else "LM"
+
+
+def pc_logic_input_naming(
+    phys: Mapping[str, Any],
+) -> tuple[str, tuple[str, str]] | None:
+    """Return ``(device_name, via_device_identifier)`` if ``phys`` is a
+    synthesized input-module child (PC-Logic or Modular Interface);
+    else ``None``.
+
+    The library sets ``pc_logic_parent_address`` (the owning module
+    address), ``pc_logic_parent_type`` (``pc_logic`` /
+    ``interface_module``) and ``pc_logic_slot_index`` (1..N) on the
+    button-store entry when it synthesizes virtual buttons for module
+    inputs. HA parents the device directly under the owning module
+    device (instead of the wall-buttons category) and names it
+    ``LM-INPUT N`` for PC-Logic or ``MI-INPUT N`` for the Modular
+    Interface, matching each product's terminology.
+    """
+    parent_addr = phys.get("pc_logic_parent_address")
+    slot = phys.get("pc_logic_slot_index")
+    if not isinstance(parent_addr, str) or not isinstance(slot, int):
+        return None
+    return f"{input_label_prefix(phys)}-INPUT {slot}", (DOMAIN, parent_addr.upper())
+
+
+def is_input_module_child(phys: Any) -> bool:
+    """True if a button-store entry is a synthesized PC-Logic / Modular
+    Interface input child (vs a real wall button / remote)."""
+    return (
+        isinstance(phys, Mapping)
+        and phys.get("pc_logic_parent_type") in INPUT_MODULE_TYPES
+    )
+
+
+def input_latch_switch_unique_id(physical_addr: str) -> str:
+    """Unique_id for an input's A/B latch switch (switch platform)."""
+    return f"nikobus_input_switch_{str(physical_addr).lower()}"
+
+
+def iter_input_module_children(
+    buttons: Mapping[str, Any] | None,
+) -> Iterator[tuple[str, Mapping[str, Any]]]:
+    """Yield ``(physical_addr, phys)`` for every synthesized input child
+    in the button store — the single enumerator the switch platform and
+    the known-id set both build on."""
+    for addr, phys in (buttons or {}).items():
+        if is_input_module_child(phys):
+            yield str(addr), phys
 
 # Module types we recognise but for which no entity schema is validated
 # yet — the inventory record alone makes the device visible in the HA

--- a/custom_components/nikobus/sensor.py
+++ b/custom_components/nikobus/sensor.py
@@ -7,18 +7,13 @@ from typing import Any
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.const import PERCENTAGE, EntityCategory
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    BRAND,
-    DOMAIN,
-    HUB_IDENTIFIER,
-    SIGNAL_DISCOVERY_STATE,
-)
+from .const import DOMAIN, SIGNAL_DISCOVERY_STATE
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
+from .entity import hub_device_info
 
 PARALLEL_UPDATES = 0
 
@@ -41,15 +36,6 @@ async def async_setup_entry(
     ])
 
 
-def _hub_device_info() -> dr.DeviceInfo:
-    return dr.DeviceInfo(
-        identifiers={(DOMAIN, HUB_IDENTIFIER)},
-        name="Nikobus Bridge",
-        manufacturer=BRAND,
-        model="PC-Link Bridge",
-    )
-
-
 class NikobusConnectionSensor(CoordinatorEntity[NikobusDataCoordinator], SensorEntity):
     """Sensor that exposes the live Nikobus connection status."""
 
@@ -63,7 +49,7 @@ class NikobusConnectionSensor(CoordinatorEntity[NikobusDataCoordinator], SensorE
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{DOMAIN}_connection_status"
-        self._attr_device_info = _hub_device_info()
+        self._attr_device_info = hub_device_info()
 
     @property
     def native_value(self) -> str:
@@ -88,7 +74,7 @@ class _DiscoverySignalEntity(SensorEntity):
 
     def __init__(self, coordinator: NikobusDataCoordinator) -> None:
         self._coordinator = coordinator
-        self._attr_device_info = _hub_device_info()
+        self._attr_device_info = hub_device_info()
 
     async def async_added_to_hass(self) -> None:
         """Register dispatcher listener."""

--- a/custom_components/nikobus/switch.py
+++ b/custom_components/nikobus/switch.py
@@ -27,7 +27,7 @@ try:  # nikobus-connect provides the input-address math
         convert_nikobus_address,
         derive_pc_logic_input_physicals,
     )
-except Exception:  # pragma: no cover - defensive (older library)
+except ImportError:  # pragma: no cover - defensive (older library)
     convert_nikobus_address = None
     derive_pc_logic_input_physicals = None
 
@@ -59,13 +59,13 @@ def input_ab_addresses(phys: dict[str, Any]) -> tuple[str, str] | None:
     if not isinstance(parent, str) or not isinstance(slot, int) or slot < 1:
         return None
     try:
-        physicals = derive_pc_logic_input_physicals(parent, max(slot, 6))
-    except Exception:  # pragma: no cover - defensive
+        # Deriving exactly ``slot`` physicals yields the slot we want at
+        # ``[slot - 1]``; the library raises for an out-of-range slot.
+        physical = derive_pc_logic_input_physicals(parent, slot)[slot - 1]
+    except (ValueError, IndexError):  # pragma: no cover - defensive
         return None
-    if slot > len(physicals):
-        return None
-    addr_1a = convert_nikobus_address(physicals[slot - 1])
-    if not isinstance(addr_1a, str) or len(addr_1a) != 6:
+    addr_1a = convert_nikobus_address(physical)
+    if len(addr_1a) != 6:  # convert returns a "[...]" marker when it can't
         return None
     addr_1a = addr_1a.upper()
     addr_1b = format((int(addr_1a[0], 16) + 4) % 16, "X") + addr_1a[1:]
@@ -324,10 +324,6 @@ class NikobusInputLatchSwitch(NikobusEntity, SwitchEntity, RestoreEntity):
         self._attr_name = "A/B state"
         self._attr_unique_id = f"nikobus_input_switch_{physical_addr.lower()}"
         self._attr_is_on = False
-
-    @property
-    def is_on(self) -> bool:
-        return self._attr_is_on
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/nikobus/switch.py
+++ b/custom_components/nikobus/switch.py
@@ -11,7 +11,7 @@ from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .const import DOMAIN, EVENT_BUTTON_OPERATION, EVENT_BUTTON_PRESSED
+from .const import EVENT_BUTTON_OPERATION, EVENT_BUTTON_PRESSED
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity
 from .router import (

--- a/custom_components/nikobus/switch.py
+++ b/custom_components/nikobus/switch.py
@@ -118,7 +118,11 @@ async def async_setup_entry(
         entities.append(
             NikobusInputLatchSwitch(
                 coordinator,
-                physical_addr=str(physical_addr).upper(),
+                # Use the raw button-store key so the latch's device
+                # identifier matches the input-child device registered in
+                # button.py (which also uses the raw key) — otherwise a
+                # non-uppercase key would split them into two devices.
+                physical_addr=physical_addr,
                 addr_1a=addr_1a,
                 addr_1b=addr_1b,
                 device_name=device_name,

--- a/custom_components/nikobus/switch.py
+++ b/custom_components/nikobus/switch.py
@@ -11,14 +11,15 @@ from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .button import _pc_logic_input_naming
 from .const import DOMAIN, EVENT_BUTTON_OPERATION, EVENT_BUTTON_PRESSED
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity
 from .router import (
-    INPUT_MODULE_TYPES,
     build_unique_id,
     get_routing,
+    input_latch_switch_unique_id,
+    iter_input_module_children,
+    pc_logic_input_naming,
     register_output_module_devices,
 )
 
@@ -105,14 +106,10 @@ async def async_setup_entry(
     # The input itself surfaces as a stateless button (button.py); this
     # adds a persistent on/off mirror: the 1A signal turns it on, 1B
     # turns it off, and turn_on/off drive the corresponding bus frame.
-    for physical_addr, phys in coordinator.dict_button_data.get(
-        "nikobus_button", {}
-    ).items():
-        if not isinstance(phys, dict):
-            continue
-        if phys.get("pc_logic_parent_type") not in INPUT_MODULE_TYPES:
-            continue
-        naming = _pc_logic_input_naming(phys)
+    for physical_addr, phys in iter_input_module_children(
+        coordinator.dict_button_data.get("nikobus_button", {})
+    ):
+        naming = pc_logic_input_naming(phys)
         ab = input_ab_addresses(phys)
         if naming is None or ab is None:
             continue
@@ -322,7 +319,7 @@ class NikobusInputLatchSwitch(NikobusEntity, SwitchEntity, RestoreEntity):
         self._addr_1a = addr_1a
         self._addr_1b = addr_1b
         self._attr_name = "A/B state"
-        self._attr_unique_id = f"nikobus_input_switch_{physical_addr.lower()}"
+        self._attr_unique_id = input_latch_switch_unique_id(physical_addr)
         self._attr_is_on = False
 
     @property

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1611,15 +1611,9 @@ class TestUnifiedStep1Discovery(unittest.IsolatedAsyncioTestCase):
             fake_start
         )
 
-        # Patch overlay so we can verify it's called.
-        with patch(
-            "custom_components.nikobus.coordinator.async_apply_friendly_name_overlay",
-            new_callable=AsyncMock, return_value=False,
-        ) as overlay_mock:
-            await coord.start_pc_link_inventory(auto_reload=False)
+        await coord.start_pc_link_inventory(auto_reload=False)
 
         coord.nikobus_discovery.start_inventory_discovery.assert_awaited_once()
-        overlay_mock.assert_awaited()
 
     async def test_pclink_timeout_falls_back_to_manual_files(self):
         coord = self._make_coord()
@@ -1634,15 +1628,11 @@ class TestUnifiedStep1Discovery(unittest.IsolatedAsyncioTestCase):
         with patch(
             "custom_components.nikobus.nkbmanual.async_apply_manual_config",
             new_callable=AsyncMock, return_value=True,
-        ) as apply_mock, patch(
-            "custom_components.nikobus.coordinator.async_apply_friendly_name_overlay",
-            new_callable=AsyncMock, return_value=False,
-        ) as overlay_mock:
+        ) as apply_mock:
             await coord.start_pc_link_inventory(auto_reload=False)
 
-        # Fallback fired (manual import called); overlay ran afterwards.
+        # Fallback fired (manual import called).
         apply_mock.assert_awaited_once()
-        overlay_mock.assert_awaited()
 
     async def test_pclink_timeout_and_no_files_raises(self):
         from homeassistant.exceptions import HomeAssistantError

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1613,7 +1613,7 @@ class TestUnifiedStep1Discovery(unittest.IsolatedAsyncioTestCase):
 
         # Patch overlay so we can verify it's called.
         with patch(
-            "custom_components.nikobus.nkbmanual.async_apply_friendly_name_overlay",
+            "custom_components.nikobus.coordinator.async_apply_friendly_name_overlay",
             new_callable=AsyncMock, return_value=False,
         ) as overlay_mock:
             await coord.start_pc_link_inventory(auto_reload=False)
@@ -1635,7 +1635,7 @@ class TestUnifiedStep1Discovery(unittest.IsolatedAsyncioTestCase):
             "custom_components.nikobus.nkbmanual.async_apply_manual_config",
             new_callable=AsyncMock, return_value=True,
         ) as apply_mock, patch(
-            "custom_components.nikobus.nkbmanual.async_apply_friendly_name_overlay",
+            "custom_components.nikobus.coordinator.async_apply_friendly_name_overlay",
             new_callable=AsyncMock, return_value=False,
         ) as overlay_mock:
             await coord.start_pc_link_inventory(auto_reload=False)

--- a/tests/test_input_latch_switch.py
+++ b/tests/test_input_latch_switch.py
@@ -111,5 +111,50 @@ class TestInputChildHelpers(unittest.TestCase):
         self.assertEqual(list(iter_input_module_children(None)), [])
 
 
+class TestIterOperationPoints(unittest.TestCase):
+    """Shared op-point enumerator — one guard ladder for the button /
+    binary-sensor platforms and the known-id set."""
+
+    def test_yields_op_points_with_bus_address(self):
+        from custom_components.nikobus.router import iter_operation_points
+
+        buttons = {
+            "1A2B3C": {
+                "operation_points": {
+                    "1A": {"bus_address": "081032"},
+                    "1B": {"bus_address": "481032"},
+                }
+            }
+        }
+        got = [(a, k, op["bus_address"]) for a, k, op, _ in iter_operation_points(buttons)]
+        self.assertEqual(
+            got, [("1A2B3C", "1A", "081032"), ("1A2B3C", "1B", "481032")]
+        )
+
+    def test_skips_op_point_without_bus_address(self):
+        from custom_components.nikobus.router import iter_operation_points
+
+        buttons = {"X": {"operation_points": {"1A": {"description": "no bus addr"}}}}
+        self.assertEqual(list(iter_operation_points(buttons)), [])
+
+    def test_non_dict_operation_points_is_safe(self):
+        # The guard that binary_sensor / the known-id loop previously
+        # lacked: a list-shaped operation_points must not raise.
+        from custom_components.nikobus.router import iter_operation_points
+
+        buttons = {
+            "BAD": {"operation_points": [{"bus_address": "1"}]},  # list, not dict
+            "OK": {"operation_points": {"1A": {"bus_address": "AABBCC"}}},
+        }
+        got = [op["bus_address"] for _, _, op, _ in iter_operation_points(buttons)]
+        self.assertEqual(got, ["AABBCC"])
+
+    def test_non_dict_entry_and_none_are_safe(self):
+        from custom_components.nikobus.router import iter_operation_points
+
+        self.assertEqual(list(iter_operation_points(None)), [])
+        self.assertEqual(list(iter_operation_points({"X": "not-a-dict"})), [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_input_latch_switch.py
+++ b/tests/test_input_latch_switch.py
@@ -77,5 +77,39 @@ class TestInputSwitchKnownIds(unittest.TestCase):
         self.assertNotIn("nikobus_input_switch_1df1e0", known)
 
 
+class TestInputChildHelpers(unittest.TestCase):
+    """Shared router helpers that the switch platform and the known-id
+    set both build on — they must agree on predicate and id format."""
+
+    def test_is_input_module_child(self):
+        from custom_components.nikobus.router import is_input_module_child
+
+        self.assertTrue(is_input_module_child({"pc_logic_parent_type": "pc_logic"}))
+        self.assertTrue(
+            is_input_module_child({"pc_logic_parent_type": "interface_module"})
+        )
+        self.assertFalse(is_input_module_child({"type": "Wall Button"}))
+        self.assertFalse(is_input_module_child(None))
+
+    def test_unique_id_format(self):
+        from custom_components.nikobus.router import input_latch_switch_unique_id
+
+        self.assertEqual(
+            input_latch_switch_unique_id("64A061"), "nikobus_input_switch_64a061"
+        )
+
+    def test_iter_yields_only_input_children(self):
+        from custom_components.nikobus.router import iter_input_module_children
+
+        buttons = {
+            "64A061": {"pc_logic_parent_type": "pc_logic"},
+            "1DF1E0": {"type": "Wall Button"},
+            "0E1234": {"pc_logic_parent_type": "interface_module"},
+        }
+        got = {addr for addr, _ in iter_input_module_children(buttons)}
+        self.assertEqual(got, {"64A061", "0E1234"})
+        self.assertEqual(list(iter_input_module_children(None)), [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_input_module_naming.py
+++ b/tests/test_input_module_naming.py
@@ -57,32 +57,45 @@ def _load_button_module():
     return sys.modules["custom_components.nikobus.button"]
 
 
-# --- _input_label_prefix --------------------------------------------------
+def _load_router_module():
+    _ensure_stubs()
+    if "custom_components.nikobus.router" not in sys.modules:
+        spec = importlib.util.spec_from_file_location(
+            "custom_components.nikobus.router", COMP / "router.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        mod.__package__ = "custom_components.nikobus"
+        sys.modules["custom_components.nikobus.router"] = mod
+        spec.loader.exec_module(mod)
+    return sys.modules["custom_components.nikobus.router"]
+
+
+# --- input_label_prefix (router) ------------------------------------------
 
 def test_prefix_pc_logic_is_lm() -> None:
-    button = _load_button_module()
-    assert button._input_label_prefix({"pc_logic_parent_type": "pc_logic"}) == "LM"
+    router = _load_router_module()
+    assert router.input_label_prefix({"pc_logic_parent_type": "pc_logic"}) == "LM"
 
 
 def test_prefix_interface_module_is_mi() -> None:
-    button = _load_button_module()
+    router = _load_router_module()
     assert (
-        button._input_label_prefix({"pc_logic_parent_type": "interface_module"})
+        router.input_label_prefix({"pc_logic_parent_type": "interface_module"})
         == "MI"
     )
 
 
 def test_prefix_missing_type_defaults_to_lm() -> None:
     # Back-compat: legacy entries without the discriminator stay LM.
-    button = _load_button_module()
-    assert button._input_label_prefix({}) == "LM"
+    router = _load_router_module()
+    assert router.input_label_prefix({}) == "LM"
 
 
-# --- _pc_logic_input_naming (device name) ---------------------------------
+# --- pc_logic_input_naming (device name, router) --------------------------
 
 def test_device_name_pc_logic() -> None:
-    button = _load_button_module()
-    name, via = button._pc_logic_input_naming(
+    router = _load_router_module()
+    name, via = router.pc_logic_input_naming(
         {
             "pc_logic_parent_address": "940c",
             "pc_logic_parent_type": "pc_logic",
@@ -90,12 +103,12 @@ def test_device_name_pc_logic() -> None:
         }
     )
     assert name == "LM-INPUT 3"
-    assert via == (button.DOMAIN, "940C")
+    assert via == (router.DOMAIN, "940C")
 
 
 def test_device_name_interface_module() -> None:
-    button = _load_button_module()
-    name, via = button._pc_logic_input_naming(
+    router = _load_router_module()
+    name, via = router.pc_logic_input_naming(
         {
             "pc_logic_parent_address": "1234",
             "pc_logic_parent_type": "interface_module",
@@ -103,12 +116,12 @@ def test_device_name_interface_module() -> None:
         }
     )
     assert name == "MI-INPUT 5"
-    assert via == (button.DOMAIN, "1234")
+    assert via == (router.DOMAIN, "1234")
 
 
 def test_device_name_non_input_returns_none() -> None:
-    button = _load_button_module()
-    assert button._pc_logic_input_naming({"type": "Bus push button"}) is None
+    router = _load_router_module()
+    assert router.pc_logic_input_naming({"type": "Bus push button"}) is None
 
 
 # --- op_point_display_name (per-key name) ---------------------------------

--- a/tests/test_manual_config.py
+++ b/tests/test_manual_config.py
@@ -953,201 +953,6 @@ class TestRealWorldSample(unittest.TestCase):
                 )
 
 
-class TestApplyFriendlyNameOverlay(unittest.TestCase):
-    """2.11.5: the overlay function enriches existing store entries
-    with user-editable fields from the manual files, without adding
-    or removing entries. Used by the unified step-1 discovery whether
-    the inventory source was PC-Link or the file itself."""
-
-    def setUp(self):
-        self.tmp = tempfile.TemporaryDirectory()
-        self.config_dir = self.tmp.name
-        self.hass = _FakeHass(self.config_dir)
-
-    def tearDown(self):
-        self.tmp.cleanup()
-
-    def _write(self, filename: str, data: dict) -> str:
-        path = os.path.join(self.config_dir, filename)
-        with open(path, "w") as fh:
-            json.dump(data, fh)
-        return path
-
-    def test_overlay_copies_module_and_channel_descriptions(self):
-        # Simulate PC-Link inventory result: address known, generic name.
-        store = _InMemoryModuleStore()
-        store.data["nikobus_module"] = {
-            "C9A5": {
-                "module_type": "switch_module",
-                "description": "Switch Module",  # PC-Link's default
-                "model": "05-000-02",
-                "channels": [
-                    {"description": ""},  # Generic
-                    {"description": ""},
-                ],
-            }
-        }
-        button_data = {"nikobus_button": {}}
-
-        # Manual file with user-edited descriptions.
-        self._write("nikobus_module_config.json", {
-            "switch_module": [{
-                "description": "switch_module_s1",
-                "address": "C9A5",
-                "model": "05-000-02",
-                "channels": [
-                    {"description": "Extérieur Porte Entrée", "entity_type": "light"},
-                    {"description": "Hall 1er Étage", "entity_type": "light"},
-                ],
-            }]
-        })
-
-        changed = _run(
-            nkbmanual.async_apply_friendly_name_overlay(
-                self.hass, store, button_data
-            )
-        )
-
-        self.assertTrue(changed)
-        c9a5 = store.data["nikobus_module"]["C9A5"]
-        self.assertEqual(c9a5["description"], "switch_module_s1")
-        self.assertEqual(c9a5["channels"][0]["description"], "Extérieur Porte Entrée")
-        self.assertEqual(c9a5["channels"][0]["entity_type"], "light")
-        self.assertEqual(c9a5["channels"][1]["description"], "Hall 1er Étage")
-
-    def test_overlay_does_not_add_modules_not_in_store(self):
-        # PC-Link discovered C9A5; manual file declares EXTRA module BEEF.
-        # Overlay must ignore BEEF — PC-Link is the inventory authority.
-        store = _InMemoryModuleStore()
-        store.data["nikobus_module"] = {
-            "C9A5": {
-                "module_type": "switch_module",
-                "description": "Switch Module",
-                "channels": [],
-            }
-        }
-        button_data = {"nikobus_button": {}}
-
-        self._write("nikobus_module_config.json", {
-            "switch_module": [
-                {"description": "s1", "address": "C9A5", "channels": []},
-                {"description": "Phantom", "address": "BEEF", "channels": []},
-            ]
-        })
-
-        _run(
-            nkbmanual.async_apply_friendly_name_overlay(
-                self.hass, store, button_data
-            )
-        )
-
-        modules = store.data["nikobus_module"]
-        self.assertIn("C9A5", modules)
-        self.assertNotIn("BEEF", modules)
-        self.assertEqual(modules["C9A5"]["description"], "s1")
-
-    def test_overlay_preserves_user_fields_for_rollers(self):
-        store = _InMemoryModuleStore()
-        store.data["nikobus_module"] = {
-            "9105": {
-                "module_type": "roller_module",
-                "description": "Roller Shutter Module",
-                "channels": [
-                    {"description": ""},
-                    {"description": ""},
-                ],
-            }
-        }
-        button_data = {"nikobus_button": {}}
-
-        self._write("nikobus_module_config.json", {
-            "roller_module": [{
-                "description": "rollershutter_module_r1",
-                "address": "9105",
-                "channels": [
-                    {"description": "Salon Volet Terrasse", "operation_time_up": "45"},
-                    {"description": "Salon Volet Jardin", "operation_time_up": "51"},
-                ],
-            }]
-        })
-
-        _run(
-            nkbmanual.async_apply_friendly_name_overlay(
-                self.hass, store, button_data
-            )
-        )
-
-        chans = store.data["nikobus_module"]["9105"]["channels"]
-        self.assertEqual(chans[0]["description"], "Salon Volet Terrasse")
-        self.assertEqual(chans[0]["operation_time_up"], "45")
-        self.assertEqual(chans[1]["operation_time_up"], "51")
-
-    def test_overlay_updates_button_op_point_descriptions(self):
-        # Existing physical button in store (from PC-Link discovery).
-        store = _InMemoryModuleStore()
-        button_data = {
-            "nikobus_button": {
-                "0D1C80": {
-                    "type": "IR Button with 4 Operation Points",
-                    "model": "05-348",
-                    "channels": 4,
-                    "description": "IR Button",
-                    "operation_points": {
-                        "1C": {
-                            "bus_address": "004E2C",
-                            "description": "Push button 1C #N004E2C",
-                            "linked_modules": [],
-                        }
-                    },
-                }
-            }
-        }
-
-        # File supplies a friendlier name for OP 1C.
-        self._write("nikobus_button_config.json", {
-            "nikobus_button": [{
-                "address": "004E2C",
-                "description": "BT_GF_Living_Sofa_Wall_Light_Up",
-                "linked_button": [{
-                    "type": "IR Button with 4 Operation Points",
-                    "model": "05-348",
-                    "address": "0D1C80",
-                    "channels": 4,
-                    "key": "1C",
-                }],
-            }]
-        })
-
-        changed = _run(
-            nkbmanual.async_apply_friendly_name_overlay(
-                self.hass, store, button_data
-            )
-        )
-
-        self.assertTrue(changed)
-        op = button_data["nikobus_button"]["0D1C80"]["operation_points"]["1C"]
-        self.assertEqual(op["description"], "BT_GF_Living_Sofa_Wall_Light_Up")
-
-    def test_overlay_noop_when_no_files(self):
-        store = _InMemoryModuleStore()
-        store.data["nikobus_module"] = {
-            "C9A5": {"module_type": "switch_module", "description": "untouched"}
-        }
-        button_data = {"nikobus_button": {}}
-
-        changed = _run(
-            nkbmanual.async_apply_friendly_name_overlay(
-                self.hass, store, button_data
-            )
-        )
-
-        self.assertFalse(changed)
-        # Store unchanged.
-        self.assertEqual(
-            store.data["nikobus_module"]["C9A5"]["description"], "untouched"
-        )
-
-
 class TestConsolidateLegacy1AOnlyButtons(unittest.TestCase):
     """2.11.8: no-PC-Link installs whose manual button-config lists each
     wall-button key face as a separate ``channels=1`` / 1A-only entry
@@ -1448,6 +1253,40 @@ class TestConsolidationEndToEnd(unittest.TestCase):
         self.assertEqual(entry["channels"], 4)
         self.assertEqual(
             set(entry["operation_points"].keys()), {"1A", "1B", "1C", "1D"}
+        )
+
+
+class TestLegacyConfigFilesPresent(unittest.TestCase):
+    """3.0.0: the friendly-name overlay is gone; the helper that warns
+    when the legacy config files still linger on disk."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.hass = _FakeHass(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _touch(self, name):
+        with open(os.path.join(self._tmp.name, name), "w") as f:
+            f.write("{}")
+
+    def test_none_present(self):
+        self.assertEqual(_run(nkbmanual.legacy_config_files_present(self.hass)), [])
+
+    def test_module_file_present(self):
+        self._touch("nikobus_module_config.json")
+        self.assertEqual(
+            _run(nkbmanual.legacy_config_files_present(self.hass)),
+            ["nikobus_module_config.json"],
+        )
+
+    def test_both_present(self):
+        self._touch("nikobus_module_config.json")
+        self._touch("nikobus_button_config.json")
+        self.assertEqual(
+            set(_run(nkbmanual.legacy_config_files_present(self.hass))),
+            {"nikobus_module_config.json", "nikobus_button_config.json"},
         )
 
 


### PR DESCRIPTION
Two related streams on this branch, landing together as **3.0.0**. Full suite **238 passed**; `cover.py` untouched.

---

## 1. 3.0.0 — remove the legacy friendly-name import overlay

The two legacy files (`nikobus_module_config.json` / `nikobus_button_config.json`) were kept so users could import entity names from a previous version, via a "friendly-name overlay" that ran on every boot and after PC-Link discovery. Entity names are now managed in Home Assistant and preserved across reloads (`name_by_user`), so that import is obsolete.

**Removed**
- `nkbmanual.async_apply_friendly_name_overlay` + its overlay-only helper `_overlay_module` (~129 lines)
- The two coordinator call sites (boot overlay in `connect()`; step 3 of `start_pc_link_inventory`)

**Kept (unchanged)** — the **no-PC-Link inventory bootstrap**: `async_apply_manual_config` + `_apply_manual_inventory_as_fallback` still build inventory from the files when no PC-Link is detected. The files are now an **inventory source only**, never a name source.

**Added** — `legacy_config_files_present()` + a startup **WARNING** when either file is still on disk, explaining the name-import is gone and (for PC-Link/bridge installs) the files can be deleted.

**Tests** — dropped the obsolete `TestApplyFriendlyNameOverlay` class + the two overlay assertions in the discovery tests; added coverage for the presence helper.

> Follow-ups (not in this PR): README still documents the friendly-name *import* as a feature and should be updated for 3.0.0; the warning currently fires for all installs with the files present (could be narrowed to only when the module store is already populated).

---

## 2. Codebase cleanup (no behavior change) — net −106 production lines

Driven by a parallel dead-code / duplication / efficiency / altitude audit of every module except `cover.py`; only grep-verified, behavior-neutral findings applied.

**Dead code removed** — const.py (handshake block, listener frame constants, `BUTTON_COMMAND_PREFIX`, `DEFAULT_COVER_ASSUMED_STATE`); coordinator dead attrs + a redundant re-import; nkbconfig dead `load_optional_json_data` + the whole unused write path; redundant `self._address` in binary_sensor; stale migration comment + unused imports in `__init__`; unused `DOMAIN`/`BRAND`/`HUB_IDENTIFIER`/`dr` imports.

**Duplication eliminated** — hub `DeviceInfo` 4→1 (`hub_device_info()` in entity.py); routing-cache block 3→1; input naming/identity logic centralized in `router.py` (no more private cross-module import); `nikobus_button` known-id pass 2→1.

**Simplification** — leaner `input_ab_addresses`; removed a redundant `is_on` property.

**Documented, not changed** — `inventory_query_type` looked never-assigned but is written cross-object by nikobus-connect (it holds the coordinator); added a comment so it isn't mistaken for dead code.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj