### PR TITLE
3.1.0: scene cross-references + human-readable attributes + scene event (and per-code CFs / test suite)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 3.0.1
+
+Requires **`nikobus-connect >= 0.23.0`**.
+
+- **Light-scene CFs now surface one scene per trigger / IR code**, keyed on
+  the address that actually fires it (e.g. IR `30A` → `9E4E2C`, `30B` →
+  `DE4E2C`). Previously every preset/light-scene IR code on a receiver
+  collapsed into one mega-scene keyed on the receiver base (e.g. `0D1C80`),
+  whose activation frame the bus ignored — so those scenes did nothing from
+  HA. Each scene is now individually activatable via `scene.turn_on`
+  (including scenes with no physical trigger button). 38xx PC-Logic
+  broadcast CFs are unaffected.
+- ⚠️ On the first discovery after upgrade the affected CF scene
+  `unique_id`s change (receiver-base → per-code wire form), so the old
+  merged `scene.nikobus_*` entity is replaced by the per-code ones —
+  re-point any automation/dashboard that referenced it.
+
 ## 3.0.0
 
 Major release — **please read the breaking changes before upgrading.**

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.22.0"
+    "nikobus-connect>=0.23.0"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,7 @@ _mod(
     "homeassistant.core",
     HomeAssistant=type("HomeAssistant", (), {}),
     Event=type("Event", (), {}),
+    CALLBACK_TYPE=object,
     callback=_ha_callback,
 )
 class _ConfigEntry:
@@ -244,6 +245,14 @@ _mod(
     ATTR_POSITION="position",
     DOMAIN="cover",
 )
+_mod(
+    "homeassistant.components.light",
+    LightEntity=type("LightEntity", (), {}),
+    ColorMode=type("ColorMode", (), {"BRIGHTNESS": "brightness", "ONOFF": "onoff"}),
+    ATTR_BRIGHTNESS="brightness",
+    DOMAIN="light",
+)
+_mod("homeassistant.components.scene", Scene=type("Scene", (), {}))
 
 
 class _RestoreEntityStub:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ Bootstrap sys.modules so all nikobus modules can be imported and tested
 without a full Home Assistant installation.
 """
 
-import asyncio
 import importlib.machinery
 import importlib.util
 import sys
@@ -67,7 +66,28 @@ class _ConfigEntry:
         return cls
 
 
-_mod("homeassistant.config_entries", ConfigEntry=_ConfigEntry)
+class _ConfigFlow:
+    # Allow ``class X(ConfigFlow, domain="nikobus")`` subclassing.
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__()
+
+
+class _OptionsFlow:
+    pass
+
+
+class _ConfigEntryState:
+    LOADED = "loaded"
+    NOT_LOADED = "not_loaded"
+
+
+_mod(
+    "homeassistant.config_entries",
+    ConfigEntry=_ConfigEntry,
+    ConfigFlow=_ConfigFlow,
+    OptionsFlow=_OptionsFlow,
+    ConfigEntryState=_ConfigEntryState,
+)
 class _HomeAssistantError(Exception):
     """Test stub that accepts the same kwargs as the real
     HomeAssistantError (``translation_domain``, ``translation_key``,
@@ -253,6 +273,44 @@ _mod(
     DOMAIN="light",
 )
 _mod("homeassistant.components.scene", Scene=type("Scene", (), {}))
+
+# --- config-flow / repairs import surface -------------------------------
+# voluptuous + the HA flow/selector helpers aren't installed in this env;
+# stub just enough to import config_flow.py / repairs.py and exercise
+# their pure helpers (schema builders themselves are not invoked).
+_mod(
+    "voluptuous",
+    Invalid=type("Invalid", (Exception,), {}),
+    Schema=lambda *a, **k: (a[0] if a else None),
+    Optional=lambda *a, **k: (a[0] if a else None),
+    Required=lambda *a, **k: (a[0] if a else None),
+    All=lambda *a, **k: a,
+    Range=lambda *a, **k: None,
+    Coerce=lambda *a, **k: None,
+    In=lambda *a, **k: None,
+)
+_mod(
+    "homeassistant.helpers.config_validation",
+    positive_int=int,
+    string=str,
+    config_entry_only_config_schema=lambda *a, **k: None,
+)
+_mod(
+    "homeassistant.helpers.selector",
+    SelectSelector=lambda *a, **k: None,
+    SelectSelectorConfig=lambda *a, **k: None,
+    SelectSelectorMode=type(
+        "SelectSelectorMode", (), {"LIST": "list", "DROPDOWN": "dropdown"}
+    ),
+    SelectOptionDict=lambda **k: dict(**k),
+    NumberSelector=lambda *a, **k: None,
+    NumberSelectorConfig=lambda *a, **k: None,
+    NumberSelectorMode=type("NumberSelectorMode", (), {"BOX": "box", "SLIDER": "slider"}),
+    TextSelector=lambda *a, **k: None,
+    TextSelectorConfig=lambda *a, **k: None,
+)
+_mod("homeassistant.data_entry_flow", FlowResult=dict)
+_mod("homeassistant.components.repairs", RepairsFlow=type("RepairsFlow", (), {}))
 
 
 class _RestoreEntityStub:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,6 +181,12 @@ class _CoordinatorEntityStub:
     def async_on_remove(self, fn):
         pass
 
+    def async_write_ha_state(self):
+        pass
+
+    def _handle_coordinator_update(self):
+        pass
+
 
 _mod(
     "homeassistant.helpers.update_coordinator",
@@ -227,6 +233,17 @@ _mod(
 _mod("homeassistant.components.binary_sensor", BinarySensorEntity=type("BinarySensorEntity", (), {}), DOMAIN="binary_sensor")
 _mod("homeassistant.components.switch", SwitchEntity=type("SwitchEntity", (), {}), DOMAIN="switch")
 _mod("homeassistant.components.button", ButtonEntity=type("ButtonEntity", (), {}), DOMAIN="button")
+_mod(
+    "homeassistant.components.cover",
+    CoverEntity=type("CoverEntity", (), {}),
+    CoverDeviceClass=type("CoverDeviceClass", (), {"SHUTTER": "shutter"}),
+    CoverEntityFeature=type(
+        "CoverEntityFeature", (), {"OPEN": 1, "CLOSE": 2, "STOP": 4, "SET_POSITION": 8}
+    ),
+    ATTR_CURRENT_POSITION="current_position",
+    ATTR_POSITION="position",
+    DOMAIN="cover",
+)
 
 
 class _RestoreEntityStub:

--- a/tests/test_actuator_burst.py
+++ b/tests/test_actuator_burst.py
@@ -19,13 +19,11 @@ Pins:
 
 from __future__ import annotations
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from custom_components.nikobus.const import (
-    BURST_GAP_THRESHOLD_S,
     BURST_RECENT_GAPS_WINDOW,
     FRAME_CADENCE_S,
     MAX_EXTENDED_RELEASE_MS,

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,77 @@
+"""Characterization tests for the button binary sensor.
+
+Event-driven: a matching bus press flips it to 'pressed' and schedules a
+reset back to 'idle'. Pins the address match + reset-timer behavior.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest.mock import MagicMock
+
+from custom_components.nikobus.binary_sensor import NikobusButtonBinarySensor
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _make():
+    coord = MagicMock()
+    e = NikobusButtonBinarySensor(
+        coord, "1A2B3C", "1A", {"bus_address": "081032"}, parent_phys=None
+    )
+    e.hass = MagicMock()
+    return e, coord
+
+
+def _press(address):
+    ev = MagicMock()
+    ev.data = {"address": address}
+    return ev
+
+
+class TestButtonBinarySensor(unittest.TestCase):
+    def test_initial_state_idle(self):
+        e, _ = _make()
+        self.assertFalse(e._attr_is_on)
+        self.assertEqual(e.state, "idle")
+
+    def test_press_match_sets_pressed_and_schedules_reset(self):
+        e, _ = _make()
+        e._handle_button_event(_press("081032"))
+        self.assertTrue(e._attr_is_on)
+        self.assertEqual(e.state, "pressed")
+        # async_call_later (stubbed) returns a cancel handle
+        self.assertIsNotNone(e._reset_timer_cancel)
+
+    def test_press_other_address_ignored(self):
+        e, _ = _make()
+        e._handle_button_event(_press("FFFFFF"))
+        self.assertFalse(e._attr_is_on)
+
+    def test_second_press_cancels_prior_timer(self):
+        e, _ = _make()
+        cancel = MagicMock()
+        e._reset_timer_cancel = cancel
+        e._handle_button_event(_press("081032"))
+        cancel.assert_called_once()
+
+    def test_reset_returns_to_idle(self):
+        e, _ = _make()
+        e._attr_is_on = True
+        e._reset_timer_cancel = MagicMock()
+        e._reset_state(None)
+        self.assertFalse(e._attr_is_on)
+        self.assertIsNone(e._reset_timer_cancel)
+
+    def test_coordinator_update_is_noop(self):
+        e, _ = _make()
+        e._attr_is_on = True
+        e._handle_coordinator_update()  # event-driven sensor ignores it
+        self.assertTrue(e._attr_is_on)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config_flow_helpers.py
+++ b/tests/test_config_flow_helpers.py
@@ -1,0 +1,124 @@
+"""Tests for the pure helpers in config_flow.py.
+
+The flow steps need HA's flow framework; these cover the deterministic
+logic helpers (hex validation, type ordering, default channels,
+set-or-drop, int coercion, polling decision).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import voluptuous as vol
+
+from custom_components.nikobus.config_flow import (
+    _validate_optional_hex6,
+    _module_type_order,
+    _make_default_channel,
+    _module_label,
+    _set_or_drop,
+    _set_time_or_drop,
+    _coerce_int,
+    _needs_polling,
+)
+from custom_components.nikobus.const import CONF_HAS_FEEDBACK_MODULE, CONF_PRIOR_GEN3
+
+
+class TestValidateOptionalHex6(unittest.TestCase):
+    def test_empty_and_none_pass(self):
+        self.assertEqual(_validate_optional_hex6(None), "")
+        self.assertEqual(_validate_optional_hex6(""), "")
+        self.assertEqual(_validate_optional_hex6("   "), "")
+
+    def test_valid_normalized_upper(self):
+        self.assertEqual(_validate_optional_hex6("  1a2b3c "), "1A2B3C")
+
+    def test_invalid_raises(self):
+        with self.assertRaises(vol.Invalid):
+            _validate_optional_hex6("12345")  # too short
+        with self.assertRaises(vol.Invalid):
+            _validate_optional_hex6("GGGGGG")  # non-hex
+
+
+class TestModuleTypeOrder(unittest.TestCase):
+    def test_known_and_unknown(self):
+        self.assertEqual(_module_type_order("switch_module"), 0)
+        self.assertEqual(_module_type_order("dimmer_module"), 1)
+        self.assertEqual(_module_type_order("roller_module"), 2)
+        self.assertEqual(_module_type_order("pc_logic"), 99)
+        self.assertEqual(_module_type_order(None), 99)
+
+
+class TestMakeDefaultChannel(unittest.TestCase):
+    def test_output_label(self):
+        self.assertEqual(
+            _make_default_channel("switch_module", 5),
+            {"description": "not_in_use output_5"},
+        )
+
+    def test_roller_gets_operation_time(self):
+        ch = _make_default_channel("roller_module", 2)
+        self.assertEqual(ch["operation_time_up"], "30")
+
+    def test_input_label_for_pc_logic(self):
+        self.assertEqual(
+            _make_default_channel("pc_logic", 1),
+            {"description": "not_in_use input_1"},
+        )
+
+
+class TestModuleLabel(unittest.TestCase):
+    def test_label(self):
+        label = _module_label(
+            "3851", {"description": "Kitchen", "module_type": "switch_module"}
+        )
+        self.assertEqual(label, "Switch Module — 3851 — Kitchen")
+
+    def test_label_defaults(self):
+        self.assertEqual(_module_label("ABCD", {}), "Module — ABCD — Module ABCD")
+
+
+class TestSetOrDrop(unittest.TestCase):
+    def test_sets_when_truthy(self):
+        m = {}
+        _set_or_drop(m, "k", "v")
+        self.assertEqual(m, {"k": "v"})
+
+    def test_drops_when_empty(self):
+        m = {"k": "old"}
+        _set_or_drop(m, "k", "")
+        self.assertEqual(m, {})
+
+
+class TestSetTimeOrDrop(unittest.TestCase):
+    def test_valid_stored_as_str(self):
+        m = {}
+        _set_time_or_drop(m, "t", 12.7)
+        self.assertEqual(m, {"t": "12"})
+
+    def test_drops_on_empty_zero_negative_invalid(self):
+        for bad in ("", None, 0, -5, "abc"):
+            m = {"t": "old"}
+            _set_time_or_drop(m, "t", bad)
+            self.assertEqual(m, {}, bad)
+
+
+class TestCoerceInt(unittest.TestCase):
+    def test_values(self):
+        self.assertEqual(_coerce_int("5", 1), 5)
+        self.assertEqual(_coerce_int(3.9, 1), 3)
+        self.assertEqual(_coerce_int("abc", 7), 7)
+        self.assertEqual(_coerce_int(None, 7), 7)
+
+
+class TestNeedsPolling(unittest.TestCase):
+    def test_feedback_or_gen3_skip_polling(self):
+        self.assertFalse(_needs_polling({CONF_HAS_FEEDBACK_MODULE: True}))
+        self.assertFalse(_needs_polling({CONF_PRIOR_GEN3: True}))
+
+    def test_plain_install_needs_polling(self):
+        self.assertTrue(_needs_polling({}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -1,0 +1,349 @@
+"""Characterization tests for the Nikobus cover platform.
+
+cover.py is the integration's most complex, stateful code (time-based
+position dead-reckoning, motor-protection handling, HA-vs-Nikobus move
+sourcing) and previously had no direct test coverage. These tests pin
+the current behavior so the file can be refactored safely later. They
+deliberately avoid the live 0.5s motion loop (timing-flaky) and instead
+exercise the calculator, the pure helpers, the properties, and the
+state-machine transitions with the scheduled tasks mocked out.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.nikobus.cover import (
+    NikobusCoverEntity,
+    _parse_operation_time,
+    STATE_STOPPED,
+    STATE_OPENING,
+    STATE_CLOSING,
+    STATE_ERROR,
+)
+from custom_components.nikobus.nkbtravelcalculator import NikobusTravelCalculator
+
+_MONO = "custom_components.nikobus.nkbtravelcalculator.time.monotonic"
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# NikobusTravelCalculator — pure position math
+# ---------------------------------------------------------------------------
+class TestTravelCalculator(unittest.TestCase):
+    def test_set_position_clamps(self):
+        c = NikobusTravelCalculator(10, 10)
+        c.set_position(150)
+        self.assertEqual(c.position, 100.0)
+        c.set_position(-5)
+        self.assertEqual(c.position, 0.0)
+
+    def test_opening_progress(self):
+        c = NikobusTravelCalculator(10, 10)
+        c.set_position(0)
+        clock = {"t": 1000.0}
+        with patch(_MONO, lambda: clock["t"]):
+            c.start_travel("opening")
+            clock["t"] = 1005.0  # 5s of a 10s up-travel = +50%
+            self.assertEqual(c.current_position(), 50.0)
+
+    def test_closing_progress(self):
+        c = NikobusTravelCalculator(10, 10)
+        c.set_position(100)
+        clock = {"t": 2000.0}
+        with patch(_MONO, lambda: clock["t"]):
+            c.start_travel("closing")
+            clock["t"] = 2003.0  # 3s of a 10s down-travel = -30%
+            self.assertEqual(c.current_position(), 70.0)
+
+    def test_opening_clamps_at_100(self):
+        c = NikobusTravelCalculator(10, 10)
+        c.set_position(80)
+        clock = {"t": 0.0}
+        with patch(_MONO, lambda: clock["t"]):
+            c.start_travel("opening")
+            clock["t"] = 5.0  # +50% from 80 -> 130 -> clamp 100
+            self.assertEqual(c.current_position(), 100.0)
+
+    def test_closing_clamps_at_0(self):
+        c = NikobusTravelCalculator(10, 10)
+        c.set_position(20)
+        clock = {"t": 0.0}
+        with patch(_MONO, lambda: clock["t"]):
+            c.start_travel("closing")
+            clock["t"] = 5.0  # -50% from 20 -> -30 -> clamp 0
+            self.assertEqual(c.current_position(), 0.0)
+
+    def test_latency_backdates_start(self):
+        c = NikobusTravelCalculator(10, 10)
+        c.set_position(0)
+        clock = {"t": 1000.0}
+        with patch(_MONO, lambda: clock["t"]):
+            # 2s already elapsed before we noticed -> immediately at 20%.
+            c.start_travel("opening", latency=2.0)
+            self.assertEqual(c.current_position(), 20.0)
+
+    def test_stop_locks_position_and_clears_direction(self):
+        c = NikobusTravelCalculator(10, 10)
+        c.set_position(0)
+        clock = {"t": 1000.0}
+        with patch(_MONO, lambda: clock["t"]):
+            c.start_travel("opening")
+            clock["t"] = 1005.0
+            c.stop()
+            self.assertEqual(c.position, 50.0)
+            clock["t"] = 9999.0  # time moves on, but we're stopped
+            self.assertEqual(c.current_position(), 50.0)
+
+    def test_zero_active_time_guard(self):
+        c = NikobusTravelCalculator(0, 0)
+        c.set_position(50)
+        clock = {"t": 0.0}
+        with patch(_MONO, lambda: clock["t"]):
+            c.start_travel("opening")
+            clock["t"] = 100.0
+            self.assertEqual(c.current_position(), 50.0)
+
+
+# ---------------------------------------------------------------------------
+# _parse_operation_time
+# ---------------------------------------------------------------------------
+class TestParseOperationTime(unittest.TestCase):
+    def test_none_uses_fallback_silently(self):
+        self.assertEqual(_parse_operation_time(None, 30.0, "t", "ADDR"), 30.0)
+
+    def test_valid_positive(self):
+        self.assertEqual(_parse_operation_time("12.5", 30.0, "t", "ADDR"), 12.5)
+
+    def test_zero_and_negative_fall_back(self):
+        self.assertEqual(_parse_operation_time(0, 30.0, "t", "ADDR"), 30.0)
+        self.assertEqual(_parse_operation_time(-4, 30.0, "t", "ADDR"), 30.0)
+
+    def test_non_numeric_falls_back(self):
+        self.assertEqual(_parse_operation_time("abc", 30.0, "t", "ADDR"), 30.0)
+
+
+# ---------------------------------------------------------------------------
+# NikobusCoverEntity — state machine
+# ---------------------------------------------------------------------------
+def _make_cover(op_up=10.0, op_down=10.0):
+    coord = MagicMock()
+    coord.api.open_cover = AsyncMock()
+    coord.api.close_cover = AsyncMock()
+    coord.api.stop_cover = AsyncMock()
+    coord.set_bytearray_state = MagicMock()
+    ent = NikobusCoverEntity(
+        coord, "9105", 1, "Shutter 1", "Roller module", "05-001", op_up, op_down
+    )
+    ent.hass = MagicMock()
+
+    # async_create_task must not leak un-awaited coroutines.
+    def _fake_create_task(arg):
+        if asyncio.iscoroutine(arg):
+            arg.close()
+        return MagicMock()
+
+    ent.hass.async_create_task = MagicMock(side_effect=_fake_create_task)
+    ent.async_write_ha_state = MagicMock()
+    return ent, coord
+
+
+class TestCoverProperties(unittest.TestCase):
+    def test_position_rounds(self):
+        ent, _ = _make_cover()
+        ent._position = 42.6
+        self.assertEqual(ent.current_cover_position, 43)
+
+    def test_is_opening_closing_open_closed(self):
+        ent, _ = _make_cover()
+        ent._state, ent._position = STATE_OPENING, 50.0
+        self.assertTrue(ent.is_opening)
+        self.assertFalse(ent.is_closing)
+        ent._state, ent._position = STATE_CLOSING, 50.0
+        self.assertTrue(ent.is_closing)
+        ent._position = 0.0
+        self.assertTrue(ent.is_closed)
+        self.assertFalse(ent.is_closing)  # position 0 → not "closing" anymore
+        ent._position = 100.0
+        self.assertTrue(ent.is_open)
+
+
+class TestShouldStop(unittest.TestCase):
+    def test_opening_reaches_target(self):
+        ent, _ = _make_cover()
+        ent._state = STATE_OPENING
+        ent._target_position = 50
+        ent._position = 49.0
+        self.assertFalse(ent._should_stop())
+        ent._position = 50.0
+        self.assertTrue(ent._should_stop())
+
+    def test_closing_reaches_target(self):
+        ent, _ = _make_cover()
+        ent._state = STATE_CLOSING
+        ent._target_position = 50
+        ent._position = 51.0
+        self.assertFalse(ent._should_stop())
+        ent._position = 50.0
+        self.assertTrue(ent._should_stop())
+
+    def test_no_target_never_stops(self):
+        ent, _ = _make_cover()
+        ent._state = STATE_OPENING
+        ent._target_position = None
+        ent._position = 100.0
+        self.assertFalse(ent._should_stop())
+
+
+class TestStop(unittest.TestCase):
+    def test_finalizes_state_and_optimistic_write(self):
+        ent, coord = _make_cover()
+        ent._state = STATE_OPENING
+        ent._target_position = 50
+        _run(ent._stop(send_stop=False))
+        self.assertEqual(ent._state, STATE_STOPPED)
+        self.assertIsNone(ent._target_position)
+        coord.set_bytearray_state.assert_called_once_with("9105", 1, STATE_STOPPED)
+        coord.api.stop_cover.assert_not_awaited()
+
+    def test_send_stop_while_moving_calls_api(self):
+        ent, coord = _make_cover()
+        ent._state = STATE_OPENING
+        _run(ent._stop(send_stop=True))
+        coord.api.stop_cover.assert_awaited_once_with("9105", 1, "opening")
+
+    def test_send_stop_when_already_stopped_skips_api(self):
+        ent, coord = _make_cover()
+        ent._state = STATE_STOPPED
+        _run(ent._stop(send_stop=True))
+        coord.api.stop_cover.assert_not_awaited()
+
+    def test_force_api_sends_even_when_stopped(self):
+        ent, coord = _make_cover()
+        ent._state = STATE_STOPPED
+        _run(ent._stop(send_stop=True, force_api=True))
+        coord.api.stop_cover.assert_awaited_once()
+
+
+class TestHandleButtonPressed(unittest.TestCase):
+    def _event(self, **data):
+        ev = MagicMock()
+        ev.data = data
+        return ev
+
+    def test_ignores_other_module(self):
+        ent, _ = _make_cover()
+        ent._state = STATE_STOPPED
+        _run(ent._handle_button_pressed(self._event(module_address="DEAD", channel=1)))
+        self.assertIsNone(ent._last_button_press_monotonic)
+
+    def test_ignores_other_channel(self):
+        ent, _ = _make_cover()
+        ent._state = STATE_STOPPED
+        _run(ent._handle_button_pressed(self._event(module_address="9105", channel=2)))
+        self.assertIsNone(ent._last_button_press_monotonic)
+
+    def test_records_timestamp_when_stopped(self):
+        ent, _ = _make_cover()
+        ent._state = STATE_STOPPED
+        _run(ent._handle_button_pressed(self._event(module_address="9105", channel=1)))
+        self.assertIsNotNone(ent._last_button_press_monotonic)
+
+    def test_press_while_moving_is_a_stop(self):
+        ent, _ = _make_cover()
+        ent._state = STATE_OPENING
+        ent._movement_source = "ha"
+        ent._stop = AsyncMock()
+        _run(ent._handle_button_pressed(self._event(module_address="9105", channel=1)))
+        ent._stop.assert_awaited_once_with(send_stop=True)
+
+
+class TestHandleCoordinatorUpdate(unittest.TestCase):
+    def _setup(self, bus_state, *, state=STATE_STOPPED, source="ha"):
+        ent, coord = _make_cover()
+        ent._state = state
+        ent._movement_source = source
+        coord.get_cover_state = MagicMock(return_value=bus_state)
+        ent._stop = MagicMock()
+        ent._start_motion_logic = MagicMock()
+        return ent, coord
+
+    def test_same_state_is_noop(self):
+        ent, _ = self._setup(STATE_STOPPED, state=STATE_STOPPED)
+        ent._handle_coordinator_update()
+        ent._stop.assert_not_called()
+        ent._start_motion_logic.assert_not_called()
+
+    def test_error_after_ha_move_sends_active_stop(self):
+        ent, _ = self._setup(STATE_ERROR, state=STATE_OPENING, source="ha")
+        ent._handle_coordinator_update()
+        ent._stop.assert_called_once_with(send_stop=True, force_api=True)
+
+    def test_error_after_nikobus_move_waits_and_schedules_recovery(self):
+        ent, _ = self._setup(STATE_ERROR, state=STATE_OPENING, source="nikobus")
+        ent._handle_coordinator_update()
+        ent._stop.assert_called_once_with(send_stop=False)
+        # one task for the stop, one for the deferred error-clear refresh
+        self.assertEqual(ent.hass.async_create_task.call_count, 2)
+
+    def test_bus_stopped_triggers_stop(self):
+        ent, _ = self._setup(STATE_STOPPED, state=STATE_OPENING)
+        ent._handle_coordinator_update()
+        ent._stop.assert_called_once_with(send_stop=False)
+
+    def test_bus_moving_starts_motion_as_nikobus(self):
+        ent, _ = self._setup(STATE_OPENING, state=STATE_STOPPED)
+        ent._handle_coordinator_update()
+        ent._start_motion_logic.assert_called_once()
+        self.assertEqual(ent._start_motion_logic.call_args.args[0], "opening")
+        self.assertEqual(ent._movement_source, "nikobus")
+
+
+class TestSetCoverPosition(unittest.TestCase):
+    def test_noop_when_already_at_target(self):
+        ent, _ = _make_cover()
+        ent._position = 50.0
+        _run(ent.async_set_cover_position(position=50))
+        ent.hass.async_create_task.assert_not_called()
+
+    def test_schedules_debounced_move(self):
+        ent, _ = _make_cover()
+        ent._position = 0.0
+        _run(ent.async_set_cover_position(position=60))
+        ent.hass.async_create_task.assert_called_once()
+
+    def test_cancels_prior_coalesce_task(self):
+        ent, _ = _make_cover()
+        ent._position = 0.0
+        prior = MagicMock()
+        ent._coalesce_task = prior
+        _run(ent.async_set_cover_position(position=60))
+        prior.cancel.assert_called_once()
+
+
+class TestRequestMove(unittest.TestCase):
+    def test_open_from_stopped_calls_api(self):
+        ent, coord = _make_cover()
+        ent._state = STATE_STOPPED
+        _run(ent._request_move("opening"))
+        self.assertEqual(ent._movement_source, "ha")
+        coord.api.open_cover.assert_awaited_once()
+        self.assertEqual(coord.api.open_cover.await_args.args[:2], ("9105", 1))
+
+    def test_reverse_stops_first(self):
+        ent, coord = _make_cover()
+        ent._state = STATE_OPENING  # moving up; request down → must stop first
+        ent._stop = AsyncMock()
+        with patch("custom_components.nikobus.cover.asyncio.sleep", new=AsyncMock()):
+            _run(ent._request_move("closing"))
+        ent._stop.assert_awaited_once_with(send_stop=True)
+        coord.api.close_cover.assert_awaited_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_discovery_progress_vendor_aligned.py
+++ b/tests/test_discovery_progress_vendor_aligned.py
@@ -13,8 +13,6 @@ import asyncio
 from dataclasses import dataclass
 from unittest.mock import MagicMock
 
-import sys
-from pathlib import Path
 
 # Conftest sets up the coordinator stubs; we just need to import the
 # coordinator module after conftest has run.

--- a/tests/test_inventory_parsing.py
+++ b/tests/test_inventory_parsing.py
@@ -1,5 +1,3 @@
-import importlib.util
-import os
 import tempfile
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1,0 +1,168 @@
+"""Characterization tests for the Nikobus light platform.
+
+Covers the dimmer / relay / cover-as-light entities: optimistic state,
+brightness composition, the bus command each issues, and the
+revert-on-error path. No source changes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.nikobus.light import (
+    NikobusDimmerEntity,
+    NikobusRelayEntity,
+    NikobusCoverLightEntity,
+)
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _coord():
+    c = MagicMock()
+    c.api.turn_on_light = AsyncMock()
+    c.api.turn_off_light = AsyncMock()
+    c.api.turn_on_switch = AsyncMock()
+    c.api.turn_off_switch = AsyncMock()
+    c.api.open_cover = AsyncMock()
+    c.api.stop_cover = AsyncMock()
+    c.get_light_brightness = MagicMock(return_value=0)
+    c.get_switch_state = MagicMock(return_value=False)
+    c.get_cover_state = MagicMock(return_value=0x00)
+    return c
+
+
+def _event(module_address):
+    ev = MagicMock()
+    ev.data = {"impacted_module_address": module_address}
+    return ev
+
+
+class TestDimmer(unittest.TestCase):
+    def _make(self):
+        c = _coord()
+        return NikobusDimmerEntity(c, "0E6C", 1, "Lamp", "Dimmer", "05-007"), c
+
+    def test_is_on_optimistic_then_brightness(self):
+        e, c = self._make()
+        e._is_on = True
+        self.assertTrue(e.is_on)
+        e._is_on = None
+        c.get_light_brightness.return_value = 120
+        self.assertTrue(e.is_on)
+        c.get_light_brightness.return_value = 0
+        self.assertFalse(e.is_on)
+
+    def test_brightness_optimistic_then_coordinator(self):
+        e, c = self._make()
+        e._optimistic_brightness = 200
+        self.assertEqual(e.brightness, 200)
+        e._optimistic_brightness = None
+        c.get_light_brightness.return_value = 77
+        self.assertEqual(e.brightness, 77)
+
+    def test_turn_on_default_full_brightness(self):
+        e, c = self._make()
+        c.get_light_brightness.return_value = 40
+        _run(e.async_turn_on())
+        self.assertTrue(e._is_on)
+        self.assertEqual(e._optimistic_brightness, 255)
+        c.api.turn_on_light.assert_awaited_once_with(
+            "0E6C", 1, 255, current_brightness=40
+        )
+
+    def test_turn_on_with_brightness(self):
+        e, c = self._make()
+        _run(e.async_turn_on(brightness=128))
+        self.assertEqual(e._optimistic_brightness, 128)
+        self.assertEqual(c.api.turn_on_light.await_args.args[2], 128)
+
+    def test_turn_on_reverts_on_error(self):
+        e, c = self._make()
+        c.api.turn_on_light.side_effect = RuntimeError("bus down")
+        with self.assertRaises(RuntimeError):
+            _run(e.async_turn_on())
+        self.assertIsNone(e._is_on)
+        self.assertIsNone(e._optimistic_brightness)
+
+    def test_turn_off(self):
+        e, c = self._make()
+        c.get_light_brightness.return_value = 90
+        _run(e.async_turn_off())
+        self.assertFalse(e._is_on)
+        self.assertIsNone(e._optimistic_brightness)
+        c.api.turn_off_light.assert_awaited_once_with("0E6C", 1, current_brightness=90)
+
+    def test_nikobus_event_clears_optimistic_on_match(self):
+        e, _ = self._make()
+        e._optimistic_brightness = 100
+        e._is_on = True
+        e._handle_nikobus_event(_event("0E6C"))
+        self.assertIsNone(e._optimistic_brightness)
+
+    def test_nikobus_event_ignores_other_module(self):
+        e, _ = self._make()
+        e._optimistic_brightness = 100
+        e._handle_nikobus_event(_event("DEAD"))
+        self.assertEqual(e._optimistic_brightness, 100)
+
+
+class TestRelayLight(unittest.TestCase):
+    def _make(self):
+        c = _coord()
+        return NikobusRelayEntity(c, "3851", 2, "Relay", "Switch", "05-002"), c
+
+    def test_is_on_optimistic_then_coordinator(self):
+        e, c = self._make()
+        e._is_on = True
+        self.assertTrue(e.is_on)
+        e._is_on = None
+        c.get_switch_state.return_value = True
+        self.assertTrue(e.is_on)
+
+    def test_turn_on_off(self):
+        e, c = self._make()
+        _run(e.async_turn_on())
+        self.assertTrue(e._is_on)
+        c.api.turn_on_switch.assert_awaited_once_with("3851", 2)
+        _run(e.async_turn_off())
+        self.assertFalse(e._is_on)
+        c.api.turn_off_switch.assert_awaited_once_with("3851", 2)
+
+    def test_turn_on_reverts_on_error(self):
+        e, c = self._make()
+        c.api.turn_on_switch.side_effect = RuntimeError("x")
+        with self.assertRaises(RuntimeError):
+            _run(e.async_turn_on())
+        self.assertIsNone(e._is_on)
+
+
+class TestCoverLight(unittest.TestCase):
+    def _make(self):
+        c = _coord()
+        return NikobusCoverLightEntity(c, "9105", 1, "CoverLight", "Roller", "05-001"), c
+
+    def test_is_on_from_cover_state(self):
+        e, c = self._make()
+        c.get_cover_state.return_value = 0x01
+        self.assertTrue(e.is_on)
+        c.get_cover_state.return_value = 0x00
+        self.assertFalse(e.is_on)
+
+    def test_turn_on_opens_cover(self):
+        e, c = self._make()
+        _run(e.async_turn_on())
+        c.api.open_cover.assert_awaited_once_with("9105", 1)
+
+    def test_turn_off_stops_cover_closing(self):
+        e, c = self._make()
+        _run(e.async_turn_off())
+        c.api.stop_cover.assert_awaited_once_with("9105", 1, direction="closing")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reconnect.py
+++ b/tests/test_reconnect.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import unittest
-from unittest.mock import AsyncMock, MagicMock, patch, call
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from custom_components.nikobus.coordinator import NikobusDataCoordinator
 from custom_components.nikobus.const import RECONNECT_DELAY_INITIAL, RECONNECT_DELAY_MAX

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -1,0 +1,78 @@
+"""Tests for the pure label/table helpers in the legacy-undecoded repair.
+
+The flow steps need HA's RepairsFlow machinery; these cover the
+static/class string builders that render the candidate list.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from custom_components.nikobus.repairs import LegacyUndecodedButtonsRepairFlow as RF
+
+
+class TestFormatLabel(unittest.TestCase):
+    def test_full_label_strips_n_suffix(self):
+        label = RF._format_label(
+            "0A0908",
+            {
+                "type": "Bus push button, 2 control buttons",
+                "model": "05-060",
+                "description": "Kitchen light #N0A0908",
+            },
+        )
+        self.assertEqual(
+            label, "0A0908 — Bus push button, 2 control buttons — 05-060 — Kitchen light"
+        )
+
+    def test_unknown_model_omitted(self):
+        self.assertEqual(
+            RF._format_label("AAAA", {"type": "Wall", "model": "Unknown"}),
+            "AAAA — Wall",
+        )
+
+    def test_empty_phys_defaults(self):
+        self.assertEqual(RF._format_label("AAAA", {}), "AAAA — Unknown type")
+
+    def test_description_equal_to_type_not_duplicated(self):
+        label = RF._format_label(
+            "BBBB", {"type": "Foo", "description": "Foo #NBBBB"}
+        )
+        self.assertEqual(label, "BBBB — Foo")
+
+
+class TestRenderTable(unittest.TestCase):
+    def test_header_and_row(self):
+        out = RF._render_table(
+            ["0A0908"],
+            {
+                "0A0908": {
+                    "type": "Bus push button",
+                    "model": "05-060",
+                    "status": "legacy_undecoded",
+                    "description": "Foo #N0A0908",
+                }
+            },
+        )
+        lines = out.splitlines()
+        self.assertEqual(lines[0], "| Address | Type | Model | Reason | Description |")
+        self.assertEqual(
+            lines[2], "| `0A0908` | Bus push button | 05-060 | no decoded links | Foo |"
+        )
+
+    def test_orphan_reason_and_pipe_sanitized(self):
+        out = RF._render_table(
+            ["X"],
+            {"X": {"type": "T", "status": "legacy_orphan", "description": "a|b"}},
+        )
+        row = out.splitlines()[2]
+        self.assertIn("residue / stale links", row)
+        self.assertIn("a/b", row)  # pipe replaced so it doesn't break the table
+
+    def test_missing_address_uses_defaults(self):
+        out = RF._render_table(["ZZZZ"], {})
+        self.assertEqual(out.splitlines()[2], "| `ZZZZ` | Unknown | — | — | — |")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -1,0 +1,98 @@
+"""Characterization tests for the scene platform.
+
+Covers the software-scene helpers (state→byte mapping, feedback-LED
+normalization + dispatch) and CF-scene activation. The full async_activate
+fan-out (module writes + timed roller stops) is integration-level and left
+to the live system; these pin the deterministic pieces.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.nikobus.scene import (
+    NikobusSceneEntity,
+    NikobusCFSceneEntity,
+)
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _scene(**cfg):
+    base = {"id": "s1", "channels": [], "feedback_led": None}
+    base.update(cfg)
+    return NikobusSceneEntity(MagicMock(), base)
+
+
+class TestStateToByte(unittest.TestCase):
+    def test_dimmer_clamps_0_255(self):
+        e = _scene()
+        self.assertEqual(e._state_to_byte("dimmer_module", "128"), 128)
+        self.assertEqual(e._state_to_byte("dimmer_module", 300), 255)
+        self.assertEqual(e._state_to_byte("dimmer_module", -5), 0)
+
+    def test_dimmer_invalid_is_none(self):
+        e = _scene()
+        self.assertIsNone(e._state_to_byte("dimmer_module", "abc"))
+
+    def test_switch_on_off(self):
+        e = _scene()
+        self.assertEqual(e._state_to_byte("switch_module", "on"), 0xFF)
+        self.assertEqual(e._state_to_byte("switch_module", "off"), 0x00)
+        self.assertEqual(e._state_to_byte("switch_module", "true"), 0xFF)
+
+    def test_roller_open_close_stop(self):
+        e = _scene()
+        self.assertEqual(e._state_to_byte("roller_module", "open"), 0x01)
+        self.assertEqual(e._state_to_byte("roller_module", "close"), 0x02)
+        self.assertEqual(e._state_to_byte("roller_module", "stop"), 0x00)
+
+    def test_unknown_type_or_value_is_none(self):
+        e = _scene()
+        self.assertIsNone(e._state_to_byte("nope_module", "on"))
+        self.assertIsNone(e._state_to_byte("switch_module", "weird"))
+
+
+class TestNormalizeFeedbackLeds(unittest.TestCase):
+    def test_none(self):
+        self.assertEqual(_scene()._normalize_feedback_leds(None), [])
+
+    def test_single_string_stripped(self):
+        self.assertEqual(_scene()._normalize_feedback_leds("  AABBCC "), ["AABBCC"])
+
+    def test_list_strips_and_drops_empty(self):
+        self.assertEqual(
+            _scene()._normalize_feedback_leds(["A", " B ", ""]), ["A", "B"]
+        )
+
+
+class TestFeedbackLedDispatch(unittest.TestCase):
+    def test_each_led_sent_as_press(self):
+        e = _scene(feedback_led=["AABBCC", "DDEEFF"])
+        e.coordinator.async_send_button_press = AsyncMock()
+        _run(e._process_feedback_leds())
+        self.assertEqual(
+            [c.args[0] for c in e.coordinator.async_send_button_press.await_args_list],
+            ["AABBCC", "DDEEFF"],
+        )
+
+
+class TestCFSceneActivation(unittest.TestCase):
+    def test_activate_broadcasts_bus_address(self):
+        coord = MagicMock()
+        coord.async_activate_cf_broadcast = AsyncMock()
+        e = NikobusCFSceneEntity(
+            coord,
+            bus_address="de4e2c",
+            cf_config={"pattern": "light_scene", "outputs": []},
+        )
+        _run(e.async_activate())
+        coord.async_activate_cf_broadcast.assert_awaited_once_with("DE4E2C")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,11 +1,10 @@
 """Tests for the Nikobus connection status sensor."""
 
-import asyncio
 import json
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
-from unittest.mock import MagicMock, AsyncMock
+from unittest.mock import MagicMock
 
 from custom_components.nikobus.sensor import NikobusConnectionSensor
 from custom_components.nikobus.const import DOMAIN, HUB_IDENTIFIER

--- a/tests/test_switch_entities.py
+++ b/tests/test_switch_entities.py
@@ -1,0 +1,97 @@
+"""Characterization tests for the relay / cover switch entities.
+
+(The input A/B latch switch is covered by test_input_latch_switch.py.)
+Covers optimistic state, the bus command each issues, and revert-on-error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.nikobus.switch import (
+    NikobusRelaySwitchEntity,
+    NikobusCoverSwitchEntity,
+)
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _coord():
+    c = MagicMock()
+    c.api.turn_on_switch = AsyncMock()
+    c.api.turn_off_switch = AsyncMock()
+    c.api.open_cover = AsyncMock()
+    c.api.stop_cover = AsyncMock()
+    c.get_switch_state = MagicMock(return_value=False)
+    c.get_cover_state = MagicMock(return_value=0x00)
+    return c
+
+
+class TestRelaySwitch(unittest.TestCase):
+    def _make(self):
+        c = _coord()
+        return NikobusRelaySwitchEntity(c, "3851", 3, "Relay", "Switch", "05-002"), c
+
+    def test_is_on_optimistic_then_coordinator(self):
+        e, c = self._make()
+        e._is_on = True
+        self.assertTrue(e.is_on)
+        e._is_on = None
+        c.get_switch_state.return_value = True
+        self.assertTrue(e.is_on)
+        c.get_switch_state.return_value = False
+        self.assertFalse(e.is_on)
+
+    def test_turn_on_off(self):
+        e, c = self._make()
+        _run(e.async_turn_on())
+        self.assertTrue(e._is_on)
+        c.api.turn_on_switch.assert_awaited_once_with("3851", 3)
+        _run(e.async_turn_off())
+        self.assertFalse(e._is_on)
+        c.api.turn_off_switch.assert_awaited_once_with("3851", 3)
+
+    def test_turn_on_reverts_on_error(self):
+        e, c = self._make()
+        c.api.turn_on_switch.side_effect = RuntimeError("x")
+        with self.assertRaises(RuntimeError):
+            _run(e.async_turn_on())
+        self.assertIsNone(e._is_on)
+
+
+class TestCoverSwitch(unittest.TestCase):
+    def _make(self):
+        c = _coord()
+        return NikobusCoverSwitchEntity(c, "9105", 1, "CoverSwitch", "Roller", "05-001"), c
+
+    def test_is_on_from_cover_state(self):
+        e, c = self._make()
+        c.get_cover_state.return_value = 0x01
+        self.assertTrue(e.is_on)
+        c.get_cover_state.return_value = 0x02
+        self.assertFalse(e.is_on)
+
+    def test_turn_on_opens(self):
+        e, c = self._make()
+        _run(e.async_turn_on())
+        c.api.open_cover.assert_awaited_once_with("9105", 1)
+
+    def test_turn_off_stops_closing(self):
+        e, c = self._make()
+        _run(e.async_turn_off())
+        c.api.stop_cover.assert_awaited_once_with("9105", 1, direction="closing")
+
+    def test_turn_off_reverts_on_error(self):
+        e, c = self._make()
+        c.api.stop_cover.side_effect = RuntimeError("x")
+        with self.assertRaises(RuntimeError):
+            _run(e.async_turn_off())
+        self.assertIsNone(e._is_on)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Everything on this branch ships as **3.1.0** (HA-side only beyond the `nikobus-connect >= 0.23.0` pin).

## 1. 3.1.0 — scene presentation & cross-references (the new feature)
Per the forum discussion:
- **`triggered_by` / `triggers_scene`** — a CF/light scene exposes the button/IR code that fires it (`Name (ADDRESS)`); the triggering button + binary_sensor expose the scene they fire. Cross-link both ways.
- **Human-readable attributes** — scene members and button linked-outputs now show the module's friendly name + address in brackets (`dimmer_module_d1 (0E6C)`) + level, via `coordinator.address_label()` (device-registry backed, reflects renames). Raw addresses kept for machine use.
- **New event `nikobus_scene_activated`** — fired when a scene's trigger address appears on the bus (physical or HA), with `address`/`name`/`entity_id`/`member_count`.
- Scenes stay standard `scene.*` entities. (`.nkb` name import deliberately deferred.)

## 2. 3.0.1 — per-code light-scene CFs (requires `nikobus-connect 0.23.0`, #103)
Light-scene CFs now surface **one scene per trigger / IR code** on its real firing wire address (IR `30A`→`9E4E2C`, `30B`→`DE4E2C`) instead of one dead receiver-base mega-scene (`0D1C80`). Validated against a real install. **Merge #103 + release `v0.23.0` first** so the pin resolves.

## 3. Characterization test suite
~95 tests across cover / light / switch / binary_sensor / scene + config_flow & repairs helpers.

**Full suite: 345 passed; ruff clean.**

> On upgrade + re-discovery the old merged `0D1C80` scene is replaced by per-code scenes (one-time entity_id change) — re-point automations.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj