### PR TITLE
3.2.0: scene-centric CFs — one scene, many triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 3.1.0
+
+Scene presentation & cross-references (HA-side only, no new dependency).
+
+- **Scenes cross-link with their trigger.** A CF / light scene now exposes
+  a `triggered_by` attribute — the wall button / IR code that fires it,
+  as `Name (ADDRESS)` — and the triggering button / binary_sensor exposes
+  a `triggers_scene` attribute. You can find one from the other at a glance.
+- **Human-readable attributes.** Scene members and button "linked outputs"
+  now show the module's friendly name with the address in brackets
+  (e.g. `dimmer_module_d1 (0E6C)`) plus the level, instead of bare
+  addresses.
+- **New event `nikobus_scene_activated`** fires whenever a scene's trigger
+  address is seen on the bus (physical press *or* HA activation), carrying
+  the scene's `address` / `name` / `entity_id` / `member_count` — so
+  automations can react to a *scene* firing, not just a raw button press.
+- Scenes remain standard `scene.*` entities — activate with `scene.turn_on`.
+
 ## 3.0.1
 
 Requires **`nikobus-connect >= 0.23.0`**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 3.2.0
+
+Requires **`nikobus-connect >= 0.24.0`**.
+
+Scene-centric Central Functions: **one scene, many triggers** — aligned to
+Niko's own model (Nikobus software manual §15.6: a "Light scene / Central
+function" is a single named output group activated from any number of
+inputs via the `MCF` connection mode).
+
+- **Duplicate scenes collapse.** Two buttons / IR codes wired to the
+  identical outputs now surface as a **single** `scene.*` entity instead of
+  two. Its `triggered_by` attribute lists **every** address that fires it
+  (each as `Name (ADDRESS)`), not just one.
+- **Cross-references follow every trigger.** A button/binary_sensor on any
+  of a scene's trigger addresses shows the `triggers_scene` attribute, and
+  the `nikobus_scene_activated` event fires no matter which trigger is
+  pressed (the event's `address` is the one actually seen on the bus).
+- An on-scene and its separate off-trigger stay distinct (their member
+  modes differ), and per-key scenes with different members still split.
+- ⚠️ On the first discovery after upgrade, a scene that previously appeared
+  under a non-canonical trigger address may move to its canonical
+  (sorted-first) trigger address — its `unique_id`/entity id changes once.
+  Re-point any automation/dashboard that referenced the old entity.
+
 ## 3.1.0
 
 Scene presentation & cross-references (HA-side only, no new dependency).

--- a/custom_components/nikobus/binary_sensor.py
+++ b/custom_components/nikobus/binary_sensor.py
@@ -100,6 +100,10 @@ class NikobusButtonBinarySensor(NikobusEntity, BinarySensorEntity):
         if wall_info:
             attrs["wall_button_model"] = wall_info.get("model")
             attrs["wall_button_type"] = wall_info.get("type")
+        scene = self.coordinator.get_scene_for_address(self._address)
+        if scene:
+            members = len(scene.get("outputs") or [])
+            attrs["triggers_scene"] = f"Nikobus scene {self._address} ({members} ch)"
         return attrs
 
     @property

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -605,6 +605,12 @@ class NikobusButtonEntity(NikobusEntity, ButtonEntity):
             status = wall_info.get("status")
             if status in ("legacy_orphan", "legacy_undecoded"):
                 attrs["wall_button_status"] = status
+        # Cross-reference: if this button's address is also a discovered
+        # CF/light scene, surface the scene it fires.
+        scene = self.coordinator.get_scene_for_address(self._address)
+        if scene:
+            members = len(scene.get("outputs") or [])
+            attrs["triggers_scene"] = f"Nikobus scene {self._address} ({members} ch)"
         return attrs
 
     async def async_press(self) -> None:

--- a/custom_components/nikobus/const.py
+++ b/custom_components/nikobus/const.py
@@ -50,6 +50,10 @@ CATEGORY_DEVICES: Final[tuple[tuple[str, str, str], ...]] = (
 # =============================================================================
 EVENT_BUTTON_OPERATION: Final[str] = "nikobus_button_operation"
 EVENT_BUTTON_PRESSED: Final[str] = "nikobus_button_pressed"
+# Fired when a discovered CF/light scene is activated on the bus (its
+# trigger address is seen) — lets automations react to a scene firing,
+# whether triggered physically or from HA.
+EVENT_SCENE_ACTIVATED: Final[str] = "nikobus_scene_activated"
 
 # =============================================================================
 # Discovery

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -926,11 +926,23 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
 
     def get_scene_for_address(self, bus_address: Any) -> dict[str, Any] | None:
         """Return the classified CF/scene record an address triggers, or
-        ``None`` — used to cross-reference a button with the scene it fires."""
+        ``None`` — used to cross-reference a button with the scene it fires.
+
+        A scene can have several trigger addresses (one Central Function,
+        many inputs). The store is keyed on the canonical address, so we
+        match the canonical key first and then any address listed in a
+        scene's ``triggered_by``."""
         if self.cf_storage is None or not bus_address:
             return None
-        cf = self.cf_storage.data.get("nikobus_cf", {}).get(str(bus_address).upper())
-        return cf if isinstance(cf, dict) else None
+        addr = str(bus_address).upper()
+        scenes = self.cf_storage.data.get("nikobus_cf", {})
+        cf = scenes.get(addr)
+        if isinstance(cf, dict):
+            return cf
+        for cf in scenes.values():
+            if isinstance(cf, dict) and addr in (cf.get("triggered_by") or []):
+                return cf
+        return None
 
     def _build_controlled_by_index(self) -> dict[tuple[str, int], list[dict[str, Any]]]:
         """Build a (module_address_upper, channel) -> list[button record] index."""
@@ -1574,10 +1586,17 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 }
                 for m in getattr(cf, "outputs", [])
             ]
+            bus_address = str(getattr(cf, "bus_address", addr)).upper()
+            triggered_by = [
+                str(t).upper()
+                for t in (getattr(cf, "triggered_by", None) or [bus_address])
+            ]
             flat[str(addr).upper()] = {
-                "bus_address": str(getattr(cf, "bus_address", addr)).upper(),
+                "bus_address": bus_address,
                 "pattern": str(getattr(cf, "pattern", "unknown")),
                 "outputs": outputs,
+                # Every address that fires this CF (one CF, many triggers).
+                "triggered_by": triggered_by,
             }
 
         self.cf_storage.data["nikobus_cf"] = flat

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -11,6 +11,7 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -864,6 +865,19 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             "status": phys.get("status"),
         }
 
+    def get_button_context(
+        self, bus_address: str
+    ) -> tuple[str, str, dict[str, Any], dict[str, Any] | None] | None:
+        """Return ``(physical_addr, key_label, op_point, phys)`` for the
+        button op-point at ``bus_address``, or ``None``. Lets callers
+        build the button's display name without re-walking the store."""
+        hit = find_operation_point(self.dict_button_data, bus_address)
+        if hit is None:
+            return None
+        physical_addr, key_label, op_point = hit
+        phys = (self.dict_button_data or {}).get("nikobus_button", {}).get(physical_addr)
+        return physical_addr, key_label, op_point, (phys if isinstance(phys, dict) else None)
+
     def get_button_linked_outputs(self, bus_address: str) -> list[dict[str, Any]]:
         """Return flattened output links for a soft button (bus address).
 
@@ -882,6 +896,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 if not isinstance(out, dict):
                     continue
                 flattened.append({
+                    "module": self.address_label(module_address),
                     "module_address": module_address,
                     "channel": out.get("channel"),
                     "mode": out.get("mode"),
@@ -889,6 +904,33 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                     "t2": out.get("t2"),
                 })
         return flattened
+
+    def address_label(self, address: Any) -> str:
+        """Return ``"Friendly Name (ADDRESS)"`` for a module / button bus
+        address, from the HA device registry (so user renames are
+        reflected), falling back to the bare uppercase address. Lets
+        attributes show a human name while keeping the address for
+        reference."""
+        if not address:
+            return ""
+        addr = str(address).upper()
+        if self.hass is not None:
+            device = dr.async_get(self.hass).async_get_device(
+                identifiers={(DOMAIN, addr)}
+            )
+            if device is not None:
+                name = device.name_by_user or device.name
+                if name and name.upper() != addr and addr not in name.upper():
+                    return f"{name} ({addr})"
+        return addr
+
+    def get_scene_for_address(self, bus_address: Any) -> dict[str, Any] | None:
+        """Return the classified CF/scene record an address triggers, or
+        ``None`` — used to cross-reference a button with the scene it fires."""
+        if self.cf_storage is None or not bus_address:
+            return None
+        cf = self.cf_storage.data.get("nikobus_cf", {}).get(str(bus_address).upper())
+        return cf if isinstance(cf, dict) else None
 
     def _build_controlled_by_index(self) -> dict[tuple[str, int], list[dict[str, Any]]]:
         """Build a (module_address_upper, channel) -> list[button record] index."""

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.23.0"
+    "nikobus-connect>=0.24.0"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/custom_components/nikobus/scene.py
+++ b/custom_components/nikobus/scene.py
@@ -8,10 +8,16 @@ import uuid
 from typing import Any
 
 from homeassistant.components.scene import Scene
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import CATEGORY_SCENES, DOMAIN
+from .button import op_point_display_name
+from .const import (
+    CATEGORY_SCENES,
+    DOMAIN,
+    EVENT_BUTTON_PRESSED,
+    EVENT_SCENE_ACTIVATED,
+)
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity
 
@@ -143,8 +149,63 @@ class NikobusCFSceneEntity(NikobusEntity, Scene):
             "bus_address": self._bus_address,
             "pattern": self._pattern,
             "member_count": len(self._outputs),
-            "outputs": self._outputs,
+            # The button / IR code that fires this scene on the bus (the
+            # scene's own trigger address), as "Name (ADDRESS)".
+            "triggered_by": self._trigger_label(),
+            # Human-readable member list: module name (address) + level.
+            "outputs": self._human_outputs(),
         }
+
+    def _trigger_label(self) -> str:
+        """Display label of the button / IR code that triggers this scene."""
+        ctx = self.coordinator.get_button_context(self._bus_address)
+        if ctx is None:
+            return self._bus_address
+        physical_addr, key_label, op_point, phys = ctx
+        label = op_point_display_name(
+            physical_addr, key_label, op_point, parent_phys=phys
+        )
+        return f"{label} ({self._bus_address})"
+
+    def _human_outputs(self) -> list[dict[str, Any]]:
+        """Members with module names + level; address kept for reference."""
+        out_list: list[dict[str, Any]] = []
+        for member in self._outputs:
+            if not isinstance(member, dict):
+                continue
+            entry: dict[str, Any] = {
+                "module": self.coordinator.address_label(member.get("module_address")),
+                "channel": member.get("channel"),
+                "action": member.get("mode"),
+            }
+            level = member.get("t1")
+            if level not in (None, ""):
+                entry["level"] = level
+            out_list.append(entry)
+        return out_list
+
+    async def async_added_to_hass(self) -> None:
+        """Watch the bus so a physical scene activation fires an event."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.hass.bus.async_listen(EVENT_BUTTON_PRESSED, self._handle_trigger)
+        )
+
+    @callback
+    def _handle_trigger(self, event: Event) -> None:
+        """Fire ``nikobus_scene_activated`` when this scene's trigger address
+        is seen on the bus — physical press or HA-originated frame alike."""
+        if str(event.data.get("address") or "").upper() != self._bus_address:
+            return
+        self.hass.bus.async_fire(
+            EVENT_SCENE_ACTIVATED,
+            {
+                "address": self._bus_address,
+                "name": self._attr_name,
+                "entity_id": self.entity_id,
+                "member_count": len(self._outputs),
+            },
+        )
 
     async def async_activate(self, **kwargs: Any) -> None:
         """Send the CF activation broadcast on the bus."""

--- a/custom_components/nikobus/scene.py
+++ b/custom_components/nikobus/scene.py
@@ -138,6 +138,13 @@ class NikobusCFSceneEntity(NikobusEntity, Scene):
         self._bus_address = addr
         self._pattern = pattern
         self._outputs = outputs if isinstance(outputs, list) else []
+        # Every address that fires this scene (one CF, many triggers).
+        # Falls back to the canonical address for older stored records.
+        triggers = cf_config.get("triggered_by")
+        if isinstance(triggers, list) and triggers:
+            self._triggered_by = [str(t).upper() for t in triggers]
+        else:
+            self._triggered_by = [addr]
         self._attr_name = name
         self._attr_unique_id = f"nikobus_cf_{addr.lower()}"
 
@@ -149,23 +156,27 @@ class NikobusCFSceneEntity(NikobusEntity, Scene):
             "bus_address": self._bus_address,
             "pattern": self._pattern,
             "member_count": len(self._outputs),
-            # The button / IR code that fires this scene on the bus (the
-            # scene's own trigger address), as "Name (ADDRESS)".
-            "triggered_by": self._trigger_label(),
+            # Every button / IR code that fires this scene on the bus, each
+            # as "Name (ADDRESS)" (one Central Function, many triggers).
+            "triggered_by": self._trigger_labels(),
             # Human-readable member list: module name (address) + level.
             "outputs": self._human_outputs(),
         }
 
-    def _trigger_label(self) -> str:
-        """Display label of the button / IR code that triggers this scene."""
-        ctx = self.coordinator.get_button_context(self._bus_address)
+    def _trigger_labels(self) -> list[str]:
+        """Display labels of every button / IR code that triggers this scene."""
+        return [self._trigger_label(addr) for addr in self._triggered_by]
+
+    def _trigger_label(self, address: str) -> str:
+        """Display label of a single trigger address, as "Name (ADDRESS)"."""
+        ctx = self.coordinator.get_button_context(address)
         if ctx is None:
-            return self._bus_address
+            return address
         physical_addr, key_label, op_point, phys = ctx
         label = op_point_display_name(
             physical_addr, key_label, op_point, parent_phys=phys
         )
-        return f"{label} ({self._bus_address})"
+        return f"{label} ({address})"
 
     def _human_outputs(self) -> list[dict[str, Any]]:
         """Members with module names + level; address kept for reference."""
@@ -193,14 +204,16 @@ class NikobusCFSceneEntity(NikobusEntity, Scene):
 
     @callback
     def _handle_trigger(self, event: Event) -> None:
-        """Fire ``nikobus_scene_activated`` when this scene's trigger address
-        is seen on the bus — physical press or HA-originated frame alike."""
-        if str(event.data.get("address") or "").upper() != self._bus_address:
+        """Fire ``nikobus_scene_activated`` when any of this scene's trigger
+        addresses is seen on the bus — physical press or HA-originated frame
+        alike (one Central Function, many triggers)."""
+        fired = str(event.data.get("address") or "").upper()
+        if fired not in self._triggered_by:
             return
         self.hass.bus.async_fire(
             EVENT_SCENE_ACTIVATED,
             {
-                "address": self._bus_address,
+                "address": fired,
                 "name": self._attr_name,
                 "entity_id": self.entity_id,
                 "member_count": len(self._outputs),

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -127,7 +127,7 @@ class TestCFSceneAttributes(unittest.TestCase):
     def test_triggered_by_falls_back_to_address(self):
         e, coord = self._make([])
         coord.get_button_context.return_value = None
-        self.assertEqual(e._trigger_label(), "DE4E2C")
+        self.assertEqual(e._trigger_labels(), ["DE4E2C"])
 
     def test_triggered_by_uses_button_name(self):
         e, coord = self._make([])
@@ -135,7 +135,42 @@ class TestCFSceneAttributes(unittest.TestCase):
             "0D1C80", "IR:30B", {"description": "IR code 30B"},
             {"type": "Push button with IR receiver"},
         )
-        self.assertEqual(e._trigger_label(), "IR 30B on 0D1C80 (DE4E2C)")
+        self.assertEqual(e._trigger_labels(), ["IR 30B on 0D1C80 (DE4E2C)"])
+
+    def test_multiple_triggers_listed(self):
+        coord = MagicMock()
+        coord.address_label = lambda a: a
+        coord.get_button_context = MagicMock(return_value=None)
+        e = NikobusCFSceneEntity(
+            coord,
+            bus_address="8B7086",
+            cf_config={
+                "pattern": "light_scene",
+                "outputs": [],
+                "triggered_by": ["8B7086", "DE4E2C"],
+            },
+        )
+        self.assertEqual(e._triggered_by, ["8B7086", "DE4E2C"])
+        self.assertEqual(e._trigger_labels(), ["8B7086", "DE4E2C"])
+
+    def test_handle_trigger_fires_on_secondary_trigger(self):
+        coord = MagicMock()
+        coord.address_label = lambda a: a
+        coord.get_button_context = MagicMock(return_value=None)
+        e = NikobusCFSceneEntity(
+            coord,
+            bus_address="8B7086",
+            cf_config={"pattern": "light_scene", "outputs": [],
+                       "triggered_by": ["8B7086", "DE4E2C"]},
+        )
+        e.hass = MagicMock()
+        e.entity_id = "scene.x"
+        ev = MagicMock()
+        ev.data = {"address": "DE4E2C"}  # the non-canonical trigger
+        e._handle_trigger(ev)
+        e.hass.bus.async_fire.assert_called_once()
+        _, payload = e.hass.bus.async_fire.call_args.args
+        self.assertEqual(payload["address"], "DE4E2C")
 
     def test_handle_trigger_fires_event_on_match(self):
         e, _ = self._make([{"module_address": "0E6C", "channel": 1,
@@ -174,6 +209,21 @@ class TestCoordinatorSceneHelpers(unittest.TestCase):
         self.assertIsNone(c.get_scene_for_address("FFFFFF"))
         c.cf_storage = None
         self.assertIsNone(c.get_scene_for_address("DE4E2C"))
+
+    def test_get_scene_for_address_matches_secondary_trigger(self):
+        c = self._coord()
+        c.cf_storage = MagicMock()
+        c.cf_storage.data = {"nikobus_cf": {"8B7086": {
+            "pattern": "light_scene", "outputs": [1],
+            "triggered_by": ["8B7086", "DE4E2C"]}}}
+        # canonical key resolves
+        self.assertIsNotNone(c.get_scene_for_address("8B7086"))
+        # a non-canonical trigger resolves to the same scene
+        self.assertEqual(
+            c.get_scene_for_address("de4e2c")["triggered_by"],
+            ["8B7086", "DE4E2C"],
+        )
+        self.assertIsNone(c.get_scene_for_address("FFFFFF"))
 
     def test_address_label_fallback_without_device(self):
         c = self._coord()

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -94,5 +94,106 @@ class TestCFSceneActivation(unittest.TestCase):
         coord.async_activate_cf_broadcast.assert_awaited_once_with("DE4E2C")
 
 
+class TestCFSceneAttributes(unittest.TestCase):
+    def _make(self, outputs):
+        coord = MagicMock()
+        coord.address_label = lambda a: f"mod_{a} ({a})" if a else ""
+        coord.get_button_context = MagicMock(return_value=None)
+        e = NikobusCFSceneEntity(
+            coord,
+            bus_address="DE4E2C",
+            cf_config={"pattern": "light_scene", "outputs": outputs},
+        )
+        return e, coord
+
+    def test_human_outputs_label_module_and_level(self):
+        e, _ = self._make([
+            {"module_address": "0E6C", "channel": 1,
+             "mode": "M04 (Light scene on)", "t1": "6%"},
+            {"module_address": "8394", "channel": 1, "mode": "M02 (Open)", "t1": None},
+        ])
+        outs = e._human_outputs()
+        self.assertEqual(
+            outs[0],
+            {"module": "mod_0E6C (0E6C)", "channel": 1,
+             "action": "M04 (Light scene on)", "level": "6%"},
+        )
+        # no level key when t1 is empty
+        self.assertEqual(
+            outs[1],
+            {"module": "mod_8394 (8394)", "channel": 1, "action": "M02 (Open)"},
+        )
+
+    def test_triggered_by_falls_back_to_address(self):
+        e, coord = self._make([])
+        coord.get_button_context.return_value = None
+        self.assertEqual(e._trigger_label(), "DE4E2C")
+
+    def test_triggered_by_uses_button_name(self):
+        e, coord = self._make([])
+        coord.get_button_context.return_value = (
+            "0D1C80", "IR:30B", {"description": "IR code 30B"},
+            {"type": "Push button with IR receiver"},
+        )
+        self.assertEqual(e._trigger_label(), "IR 30B on 0D1C80 (DE4E2C)")
+
+    def test_handle_trigger_fires_event_on_match(self):
+        e, _ = self._make([{"module_address": "0E6C", "channel": 1,
+                            "mode": "M04 (Light scene on)"}])
+        e.hass = MagicMock()
+        e.entity_id = "scene.nikobus_scene_de4e2c"
+        ev = MagicMock()
+        ev.data = {"address": "DE4E2C"}
+        e._handle_trigger(ev)
+        e.hass.bus.async_fire.assert_called_once()
+        name, payload = e.hass.bus.async_fire.call_args.args
+        self.assertEqual(name, "nikobus_scene_activated")
+        self.assertEqual(payload["address"], "DE4E2C")
+        self.assertEqual(payload["member_count"], 1)
+
+    def test_handle_trigger_ignores_other_address(self):
+        e, _ = self._make([])
+        e.hass = MagicMock()
+        ev = MagicMock()
+        ev.data = {"address": "AAAAAA"}
+        e._handle_trigger(ev)
+        e.hass.bus.async_fire.assert_not_called()
+
+
+class TestCoordinatorSceneHelpers(unittest.TestCase):
+    def _coord(self):
+        from custom_components.nikobus.coordinator import NikobusDataCoordinator
+        return NikobusDataCoordinator.__new__(NikobusDataCoordinator)
+
+    def test_get_scene_for_address(self):
+        c = self._coord()
+        c.cf_storage = MagicMock()
+        c.cf_storage.data = {"nikobus_cf": {"DE4E2C": {"pattern": "light_scene",
+                                                       "outputs": [1, 2, 3]}}}
+        self.assertEqual(c.get_scene_for_address("de4e2c")["outputs"], [1, 2, 3])
+        self.assertIsNone(c.get_scene_for_address("FFFFFF"))
+        c.cf_storage = None
+        self.assertIsNone(c.get_scene_for_address("DE4E2C"))
+
+    def test_address_label_fallback_without_device(self):
+        c = self._coord()
+        c.hass = None
+        self.assertEqual(c.address_label("0e6c"), "0E6C")
+        self.assertEqual(c.address_label(""), "")
+
+    def test_address_label_uses_device_name(self):
+        from unittest.mock import patch
+        c = self._coord()
+        c.hass = MagicMock()
+        dev = MagicMock()
+        dev.name_by_user = None
+        dev.name = "dimmer_module_d1"
+        reg = MagicMock()
+        reg.async_get_device.return_value = dev
+        with patch("custom_components.nikobus.coordinator.dr.async_get",
+                   return_value=reg):
+            self.assertEqual(c.address_label("0E6C"), "dimmer_module_d1 (0E6C)")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Consumes nikobus-connect 0.24.0's de-duplicated light-scene CFs to surface **one scene, many triggers** — aligned to Niko's own model (Nikobus software manual §15.6: a "Light scene / Central function" is a single named output group activated from any number of inputs via the `MCF` connection mode).

**Requires `nikobus-connect >= 0.24.0`.**

## Changes

- **Duplicate scenes collapse** — two buttons / IR codes wired to the identical outputs now surface as a **single** `scene.*` entity. Its `triggered_by` attribute lists **every** address that fires it (each as `Name (ADDRESS)`), not just one.
- **Cross-references follow every trigger** — `get_scene_for_address` resolves any trigger address (the canonical key *or* any `triggered_by` member), so a button/binary_sensor on any trigger shows `triggers_scene`, and the `nikobus_scene_activated` event fires no matter which trigger is pressed (the event's `address` is the one actually seen on the bus).
- An on-scene and its separate off-trigger stay distinct; per-key scenes with different members still split.

## ⚠️ Breaking note

On the first discovery after upgrade, a scene that previously appeared under a non-canonical trigger address may move to its canonical (sorted-first) trigger address — its `unique_id`/entity id changes once. Re-point any automation/dashboard that referenced the old entity. (For installs whose scenes have distinct member sets — e.g. no two scenes share identical outputs — entity ids are unchanged.)

## Tests

- +4 tests covering multi-trigger labels, secondary-trigger event firing, and `get_scene_for_address` matching a non-canonical trigger.
- Full suite: **348 passed**.

## Merge order

Merge nikobus-connect #PR → publish a **v0.24.0** GitHub Release (publish workflow fires on a published release) → merge this PR → restart HA → re-run discovery.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_