### PR TITLE
3.3.0: import names from .nkb (+ 3.2.1 button rename & progress fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 3.2.1
 
+- **Progress bar now spans 0→100 % per button.** *Load Existing
+  Installation* previously opened at 30 % (the combined-pipeline weight of
+  the inventory+identity phases it doesn't run); each standalone scan now
+  rescales to fill the whole bar.
 - Renamed the two discovery buttons to match Nikobus software terminology:
   **Discover modules & buttons → Load Project Overview** (the PC-Link
   inventory read) and **Scan all module links → Load Existing Installation**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 3.3.0
+
+**Import device & entity names from your Nikobus `.nkb` project file.**
+
+The Nikobus PC software stores every module / button / IR receiver under a
+user-given name (with its room). A `.nkb` is a ZIP holding an MS Access
+database; this release reads it directly in HA and applies those names.
+
+- **New bridge button "Import Names from .nkb".** Put your `.nkb` export in
+  the Home Assistant config directory (ideally named `nikobus.nkb`) and
+  press the button. Names are applied as `Name (Room)` — e.g. the dimmer
+  becomes `Dimcontroller (Centrale)`, a wall button `Entree (Living)`.
+- **Non-destructive / suggested.** A device or entity you've already renamed
+  by hand is never overwritten. Multi-channel modules are named at the
+  device level (channels inherit it) so the same name isn't stamped onto
+  every channel; single-entity devices get their entity row named too.
+- **No external services.** Parsing is pure-Python (vendored Apache-2.0
+  `access_parser` + the `construct` dependency); the file never leaves your
+  machine.
+- Scenes (Central Functions) in the `.nkb` have no bus address, so their
+  names aren't auto-applied yet — that mapping is a later step.
+
 ## 3.2.1
 
 - **Progress bar now spans 0→100 % per button.** *Load Existing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.2.1
+
+- Renamed the two discovery buttons to match Nikobus software terminology:
+  **Discover modules & buttons → Load Project Overview** (the PC-Link
+  inventory read) and **Scan all module links → Load Existing Installation**
+  (reading each module's existing programming, Niko's "upload"). Updated for
+  EN/FR/NL. Entity ids are unchanged.
+
 ## 3.2.0
 
 Requires **`nikobus-connect >= 0.24.0`**.

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -48,6 +48,7 @@ async def async_setup_entry(
     entities: list[ButtonEntity] = [
         NikobusPcLinkInventoryButton(coordinator),
         NikobusModuleScanButton(coordinator),
+        NikobusImportNkbNamesButton(coordinator),
     ]
 
     buttons = (coordinator.dict_button_data or {}).get("nikobus_button", {})
@@ -534,6 +535,42 @@ class NikobusModuleScanButton(ButtonEntity):
         self.hass.async_create_background_task(
             self._coordinator.start_module_scan(),
             name="nikobus_module_scan_discovery",
+        )
+
+
+class NikobusImportNkbNamesButton(ButtonEntity):
+    """Bridge button that imports device/entity names from a ``.nkb`` file.
+
+    Reads the Nikobus PC-software project export (a ``.nkb`` placed in the
+    HA config dir) and applies its module / button / IR-receiver names as
+    suggested device and entity names. Non-destructive — manual renames
+    are preserved.
+    """
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "import_nkb_names"
+    _attr_should_poll = False
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, coordinator: NikobusDataCoordinator) -> None:
+        self._coordinator = coordinator
+        self._attr_unique_id = f"{DOMAIN}_import_nkb_names_button"
+        self._attr_device_info = hub_device_info()
+
+    async def async_press(self) -> None:
+        """Import names from the ``.nkb`` in the config dir.
+
+        Awaited directly (not backgrounded): the parse runs in an
+        executor and the registry writes are fast, so this returns
+        quickly while still surfacing not-found / parse errors to the
+        user as the button action result.
+        """
+        _LOGGER.info("Importing Nikobus names from .nkb via UI button")
+        result = await self._coordinator.async_import_nkb_names()
+        _LOGGER.info(
+            "Nikobus .nkb name import done: %s devices, %s entities",
+            result["devices"],
+            result["entities"],
         )
 
 

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -12,6 +12,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -2341,3 +2342,92 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             self.discovery_running = False
             self._discovery_finished_event.set()
             raise
+
+    async def async_import_nkb_names(self) -> dict[str, int]:
+        """Import user names from a ``.nkb`` project file in the config dir.
+
+        Reads the Nikobus PC-software export (a ZIP holding an MS Access
+        DB) and applies its module / button / IR-receiver names — each as
+        ``Name (Room)`` keyed on the bus address — as **suggested**
+        device and entity names.
+
+        Non-destructive: a device's user rename (``name_by_user``) is
+        never touched, and an entity is only named when it has no user
+        override. Entity rows are named only for single-entity devices;
+        multi-channel modules rely on device-name inheritance so we don't
+        stamp the same name onto every channel. Returns a summary dict
+        (``devices`` / ``entities`` / ``addresses`` / ``scenes``).
+        """
+        from .nkbnames import find_nkb_file, parse_nkb_names
+
+        path = find_nkb_file(self.hass.config.config_dir)
+        if path is None:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="nkb_not_found"
+            )
+        try:
+            names = await self.hass.async_add_executor_job(parse_nkb_names, path)
+        except Exception as err:
+            _LOGGER.exception("Failed to read .nkb file %s", path)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="nkb_parse_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err
+
+        name_map = names.addresses  # {ADDRESS_HEX_UPPER: "Name (Room)"}
+        dev_reg = dr.async_get(self.hass)
+        ent_reg = er.async_get(self.hass)
+        entry_id = self.config_entry.entry_id
+
+        # 1. Devices — match any identifier address against the name map.
+        matched: dict[str, str] = {}  # device_id -> imported name
+        devices_named = 0
+        for device in dr.async_entries_for_config_entry(dev_reg, entry_id):
+            imported = next(
+                (
+                    name_map[ident.upper()]
+                    for domain, ident in device.identifiers
+                    if domain == DOMAIN and ident.upper() in name_map
+                ),
+                None,
+            )
+            if imported is None:
+                continue
+            matched[device.id] = imported
+            if device.name != imported:
+                dev_reg.async_update_device(device.id, name=imported)
+                devices_named += 1
+
+        # 2. Entities — only for single-entity matched devices, and only
+        # when the user hasn't set their own name. Multi-entity devices
+        # inherit the device name instead (no per-channel duplication).
+        by_device: dict[str, list] = {}
+        for ent in er.async_entries_for_config_entry(ent_reg, entry_id):
+            if ent.device_id:
+                by_device.setdefault(ent.device_id, []).append(ent)
+        entities_named = 0
+        for device_id, imported in matched.items():
+            ents = by_device.get(device_id, [])
+            if len(ents) != 1:
+                continue
+            ent = ents[0]
+            if ent.name is None and ent.original_name != imported:
+                ent_reg.async_update_entity(ent.entity_id, name=imported)
+                entities_named += 1
+
+        _LOGGER.info(
+            "Imported .nkb names from %s: %d devices, %d entities renamed "
+            "(%d addresses, %d scenes in file)",
+            path.name,
+            devices_named,
+            entities_named,
+            len(name_map),
+            len(names.scenes),
+        )
+        return {
+            "devices": devices_named,
+            "entities": entities_named,
+            "addresses": len(name_map),
+            "scenes": len(names.scenes),
+        }

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -184,6 +184,14 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         # by default (no module's register table has been decoded yet).
         self._last_module_scan_was_full: bool = False
 
+        # Which slice of the full discovery pipeline the running operation
+        # covers, so the progress bar can rescale to 0–100 for each
+        # standalone button. ``"inventory"`` = Load Project Overview
+        # (inventory+identity); ``"module_scan"`` = Load Existing
+        # Installation (register-scan+finalizing); ``"full"`` = the whole
+        # pipeline (no rescale). See ``discovery_progress_percent``.
+        self._discovery_scope: str = "full"
+
         # --- Discovery progress tracking (for UI) ---
         # `discovery_phase` stays on the legacy enum for backward-compat with
         # automations; `discovery_sub_phase` carries the fine-grained state
@@ -2008,7 +2016,20 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 return 40.0
             return 0.0
 
-        return min(99.9, round(floor + phase_frac * phase_weight, 1))
+        raw = floor + phase_frac * phase_weight
+
+        # Each discovery button runs only one slice of the full pipeline.
+        # Rescale that slice to span the whole bar so a standalone scan
+        # reads 0→100 instead of, e.g., Load Existing Installation opening
+        # at 30 % — the cumulative weight of the inventory+identity phases
+        # it skips. ``"full"`` (a combined run) keeps the raw stacked value.
+        overview_span = DISCOVERY_WEIGHT_INVENTORY + DISCOVERY_WEIGHT_IDENTITY
+        if self._discovery_scope == "module_scan":
+            raw = (raw - overview_span) / (100 - overview_span) * 100
+        elif self._discovery_scope == "inventory":
+            raw = raw / overview_span * 100
+
+        return min(99.9, round(max(0.0, raw), 1))
 
     def _update_discovery_state(
         self,
@@ -2094,6 +2115,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         self._discovery_auto_reload = auto_reload
         self._discovery_finished_event.clear()
         self._last_module_scan_was_full = False
+        self._discovery_scope = "inventory"
         self._update_discovery_state(
             phase=DISCOVERY_PHASE_PC_LINK,
             message="Probing for PC-Link…",
@@ -2232,6 +2254,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         # Tracked for ``_reconcile_post_discovery`` — only after a
         # scan-all is ``legacy_undecoded`` a trustworthy signal.
         self._last_module_scan_was_full = module_address is None
+        self._discovery_scope = "module_scan"
 
         if module_address:
             target = module_address.strip().upper()

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
@@ -12,7 +12,8 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.24.0"
+    "nikobus-connect>=0.24.0",
+    "construct>=2.10"
   ],
   "loggers": ["nikobus", "nikobus_connect"]
 }

--- a/custom_components/nikobus/nkbnames.py
+++ b/custom_components/nikobus/nkbnames.py
@@ -1,0 +1,117 @@
+"""Read user-given names from a Nikobus ``.nkb`` project file.
+
+A ``.nkb`` is a ZIP holding ``__niko__.mdb`` — an MS Access (JET)
+database. The Nikobus PC software stores every module / button / IR
+receiver under a user-given name in the ``Component`` table, keyed by
+``PhysicalAddress`` (the decimal of the 24-bit bus address), with the
+room in ``Location``. Central Functions / scenes appear as ``Component``
+rows with ``PhysicalAddress == -1`` (no bus address — named only here).
+
+We surface the addressable names as ``{ADDRESS: "Name (Room)"}`` for the
+integration to apply as suggested device / entity names, plus the
+address-less scene names for reference.
+
+Everything here is best-effort: parsing is wrapped so a malformed or
+unsupported ``.nkb`` never breaks the integration — the caller logs and
+skips. The Access reader is vendored (``.vendor.access_parser``) and the
+only runtime dependency is ``construct``.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import NamedTuple
+
+_LOGGER = logging.getLogger(__name__)
+
+# Canonical filename we look for first; otherwise any single *.nkb.
+CANONICAL_NKB_FILENAME = "nikobus.nkb"
+
+# A room bucket the software uses for virtual groups (scenes); not a real room.
+_GROUP_LOCATION_SENTINEL = "S_DB_GROUPS"
+
+
+class NkbNames(NamedTuple):
+    """Result of parsing a ``.nkb``."""
+
+    #: ``{ADDRESS_HEX_UPPER: "Name (Room)"}`` for modules / buttons / receivers.
+    addresses: dict[str, str]
+    #: ``{scene_name: room}`` for Central Functions with no bus address.
+    scenes: dict[str, str]
+
+
+def find_nkb_file(config_dir: str) -> Path | None:
+    """Return the ``.nkb`` to import from ``config_dir``, or ``None``.
+
+    Prefers the canonical ``nikobus.nkb``; otherwise accepts a single
+    ``*.nkb`` in the directory. With several ``*.nkb`` and no canonical
+    one we decline (ambiguous) and return ``None``.
+    """
+    base = Path(config_dir)
+    canonical = base / CANONICAL_NKB_FILENAME
+    if canonical.is_file():
+        return canonical
+    candidates = sorted(base.glob("*.nkb"))
+    if len(candidates) == 1:
+        return candidates[0]
+    if len(candidates) > 1:
+        _LOGGER.warning(
+            "Multiple .nkb files in %s (%s) — rename the one to import to %s",
+            config_dir,
+            [p.name for p in candidates],
+            CANONICAL_NKB_FILENAME,
+        )
+    return None
+
+
+def parse_nkb_names(nkb_path: str | Path) -> NkbNames:
+    """Parse ``nkb_path`` and return its names. Blocking — run in executor.
+
+    Raises on a genuinely unreadable file (bad zip / no mdb / parser
+    failure); the caller is expected to catch and degrade gracefully.
+    """
+    # Lazy import so a parser/construct issue can't break integration load.
+    from .vendor.access_parser import AccessParser
+
+    with tempfile.TemporaryDirectory() as tmp:
+        with zipfile.ZipFile(nkb_path) as zf:
+            mdb_name = next(
+                (n for n in zf.namelist() if n.lower().endswith(".mdb")), None
+            )
+            if mdb_name is None:
+                raise ValueError("no .mdb inside the .nkb archive")
+            zf.extract(mdb_name, tmp)
+        db = AccessParser(str(Path(tmp) / mdb_name))
+        components = _rows(db, "Component")
+        locations = {
+            r["KeyLocation"]: r["StrUserName"] for r in _rows(db, "Location")
+        }
+
+    addresses: dict[str, str] = {}
+    scenes: dict[str, str] = {}
+    for comp in components:
+        name = (comp.get("StrUserName") or "").strip()
+        if not name:
+            continue
+        room = locations.get(comp.get("KeyLocation")) or ""
+        room_label = "" if room == _GROUP_LOCATION_SENTINEL else room
+        pa = comp.get("PhysicalAddress")
+        if isinstance(pa, int) and pa > 0:
+            addr = f"{pa & 0xFFFFFF:06X}"
+            addresses[addr] = f"{name} ({room_label})" if room_label else name
+        else:
+            # PhysicalAddress == -1 → a Central Function / scene group.
+            scenes[name] = room_label
+
+    return NkbNames(addresses=addresses, scenes=scenes)
+
+
+def _rows(db, table: str) -> list[dict]:
+    """Row-dicts for ``table`` (access_parser returns column->list)."""
+    parsed = db.parse_table(table)
+    cols = list(parsed.keys())
+    n = len(next(iter(parsed.values()))) if cols else 0
+    return [{c: parsed[c][i] for c in cols} for i in range(n)]

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -67,6 +67,9 @@
       },
       "scan_all_module_links": {
         "name": "Load Existing Installation"
+      },
+      "import_nkb_names": {
+        "name": "Import Names from .nkb"
       }
     },
     "sensor": {
@@ -139,6 +142,12 @@
     },
     "discovery_not_initialized": {
       "message": "Nikobus discovery is not initialized."
+    },
+    "nkb_not_found": {
+      "message": "No .nkb file found. Put your Nikobus project export (a .nkb file, ideally named nikobus.nkb) in your Home Assistant config directory, then retry."
+    },
+    "nkb_parse_failed": {
+      "message": "Could not read the .nkb file: {error}. It may be an unsupported version or corrupt."
     },
     "initialization_error": {
       "message": "Failed to initialize Nikobus components: {error}"

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -63,10 +63,10 @@
   "entity": {
     "button": {
       "discover_modules_buttons": {
-        "name": "Discover modules & buttons"
+        "name": "Load Project Overview"
       },
       "scan_all_module_links": {
-        "name": "Scan all module links"
+        "name": "Load Existing Installation"
       }
     },
     "sensor": {

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -147,10 +147,10 @@
     },
     "button": {
       "discover_modules_buttons": {
-        "name": "Découvrir modules et boutons"
+        "name": "Charger l'aperçu du projet"
       },
       "scan_all_module_links": {
-        "name": "Scanner les liens des modules"
+        "name": "Charger l'installation existante"
       }
     }
   },

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -151,6 +151,9 @@
       },
       "scan_all_module_links": {
         "name": "Charger l'installation existante"
+      },
+      "import_nkb_names": {
+        "name": "Importer les noms depuis .nkb"
       }
     }
   },
@@ -194,6 +197,12 @@
     },
     "discovery_not_initialized": {
       "message": "La découverte Nikobus n'est pas initialisée."
+    },
+    "nkb_not_found": {
+      "message": "Aucun fichier .nkb trouvé. Placez l'export de votre projet Nikobus (un fichier .nkb, idéalement nommé nikobus.nkb) dans le répertoire de configuration de Home Assistant, puis réessayez."
+    },
+    "nkb_parse_failed": {
+      "message": "Impossible de lire le fichier .nkb : {error}. Il est peut-être d'une version non prise en charge ou corrompu."
     },
     "initialization_error": {
       "message": "Échec de l'initialisation des composants Nikobus : {error}"

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -151,6 +151,9 @@
       },
       "scan_all_module_links": {
         "name": "Bestaande installatie laden"
+      },
+      "import_nkb_names": {
+        "name": "Namen importeren uit .nkb"
       }
     }
   },
@@ -194,6 +197,12 @@
     },
     "discovery_not_initialized": {
       "message": "Nikobus-ontdekking is niet geïnitialiseerd."
+    },
+    "nkb_not_found": {
+      "message": "Geen .nkb-bestand gevonden. Plaats de export van je Nikobus-project (een .nkb-bestand, bij voorkeur nikobus.nkb genoemd) in de Home Assistant-configuratiemap en probeer het opnieuw."
+    },
+    "nkb_parse_failed": {
+      "message": "Kon het .nkb-bestand niet lezen: {error}. Mogelijk een niet-ondersteunde versie of beschadigd."
     },
     "initialization_error": {
       "message": "Initialisatie van Nikobus-componenten mislukt: {error}"

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -147,10 +147,10 @@
     },
     "button": {
       "discover_modules_buttons": {
-        "name": "Modules en knoppen ontdekken"
+        "name": "Projectoverzicht laden"
       },
       "scan_all_module_links": {
-        "name": "Alle modulekoppelingen scannen"
+        "name": "Bestaande installatie laden"
       }
     }
   },

--- a/custom_components/nikobus/vendor/__init__.py
+++ b/custom_components/nikobus/vendor/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored access_parser package."""

--- a/custom_components/nikobus/vendor/access_parser/LICENSE
+++ b/custom_components/nikobus/vendor/access_parser/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/custom_components/nikobus/vendor/access_parser/__init__.py
+++ b/custom_components/nikobus/vendor/access_parser/__init__.py
@@ -1,0 +1,13 @@
+"""Vendored copy of claroty/access_parser (Apache-2.0).
+
+A pure-Python MS Access (.mdb/.accdb) reader. Vendored because the
+upstream PyPI sdist won't build on modern setuptools, and HA manifest
+requirements must be pip-installable. Only ``construct`` is needed at
+runtime (a clean wheel). The ``tabulate`` pretty-printer was stripped.
+
+Upstream: https://github.com/claroty/access_parser  — see LICENSE.
+"""
+
+from .access_parser import AccessParser
+
+__all__ = ["AccessParser"]

--- a/custom_components/nikobus/vendor/access_parser/access_parser.py
+++ b/custom_components/nikobus/vendor/access_parser/access_parser.py
@@ -1,0 +1,591 @@
+import logging
+import struct
+from collections import defaultdict
+
+from construct import ConstructError
+
+from .parsing_primitives import parse_relative_object_metadata_struct, parse_table_head, parse_data_page_header, \
+    ACCESSHEADER, MEMO, parse_table_data, TDEF_HEADER, LVPROP
+from .utils import categorize_pages, parse_type, TYPE_MEMO, TYPE_TEXT, TYPE_BOOLEAN, read_db_file, numeric_to_string, \
+    TYPE_96_bit_17_BYTES, TYPE_OLE
+
+# Page sizes
+PAGE_SIZE_V3 = 0x800
+PAGE_SIZE_V4 = 0x1000
+
+# Versions
+VERSION_3 = 0x00
+VERSION_4 = 0x01
+VERSION_5 = 0x02
+VERSION_2010 = 0x03
+
+ALL_VERSIONS = {VERSION_3: 3, VERSION_4: 4, VERSION_5: 5, VERSION_2010: 2010}
+NEW_VERSIONS = [VERSION_4, VERSION_5, VERSION_2010]
+
+SYSTEM_TABLE_FLAGS = [-0x80000000, -0x00000002, 0x80000000, 0x00000002]
+
+LOGGER = logging.getLogger("access_parser")
+
+
+class TableObj(object):
+    def __init__(self, offset, val):
+        self.value = val
+        self.offset = offset
+        self.linked_pages = []
+
+
+class AccessParser(object):
+    def __init__(self, db_path):
+        self.db_data = read_db_file(db_path)
+        self._parse_file_header(self.db_data)
+        self._table_defs, self._data_pages, self._all_pages = categorize_pages(self.db_data, self.page_size)
+        self._tables_with_data = self._link_tables_to_data()
+        self.catalog = self._parse_catalog()
+        self.extra_props = self.parse_msys_table()
+
+    def parse_msys_table(self):
+        """The MSysObjects contains extra metadata about tables and columns, like the Format of money field types """
+        msys_table = self.parse_table("MSysObjects")
+        if not msys_table:
+            return None
+        if not msys_table.get('Name') or not msys_table.get('LvProp'):
+            return []
+        table_to_lval_memo = {key: self.parse_lvprop(value) for key, value in zip(msys_table['Name'],
+                                                                                  msys_table['LvProp']) if value}
+        return table_to_lval_memo
+
+    def _parse_file_header(self, db_data):
+        """
+        Parse the basic file header and determine the Access DB version based on the parsing results.
+        :param db_data: db file data
+        """
+        try:
+            head = ACCESSHEADER.parse(db_data)
+        except ConstructError:
+            # This is a very minimal parsing of the header. If we fail this probable is not a valid mdb file
+            raise ValueError("Failed to parse DB file header. Check it is a valid access database")
+        version = head.jet_version
+        if version in NEW_VERSIONS:
+            if version == VERSION_4:
+                self.version = ALL_VERSIONS[VERSION_4]
+            elif version == VERSION_5:
+                self.version = ALL_VERSIONS[VERSION_5]
+            elif version == VERSION_2010:
+                self.version = ALL_VERSIONS[VERSION_2010]
+            self.page_size = PAGE_SIZE_V4
+
+        else:
+            if not version == VERSION_3:
+                LOGGER.error(f"Unknown database version {version} Trying to parse database as version 3")
+            self.version = ALL_VERSIONS[VERSION_3]
+            self.page_size = PAGE_SIZE_V3
+        LOGGER.info(f"DataBase version {version}")
+
+    def _link_tables_to_data(self):
+        """
+        Link tables definitions to their data pages
+        :return: dict of {ofssets : PageObj}
+        """
+        tables_with_data = {}
+        # Link table definitions to data
+        # the offset of the table definition page / 0x800  ==  the owner of a Data page
+        for offset, data in self._data_pages.items():
+            try:
+                parsed_dp = parse_data_page_header(data, version=self.version)
+            except ConstructError:
+                LOGGER.error(f"Failed to parse data page {data}")
+                continue
+            page_offset = parsed_dp.owner * self.page_size
+            if page_offset in self._table_defs:
+                table_page_value = self._table_defs.get(parsed_dp.owner * self.page_size)
+                if page_offset not in tables_with_data:
+                    tables_with_data[page_offset] = TableObj(page_offset, table_page_value)
+                tables_with_data[page_offset].linked_pages.append(data)
+        return tables_with_data
+
+    def _parse_catalog(self):
+        """
+        Parse the catalog to get the DB tables and their offsets
+        :return: dict {table : offset}
+        """
+        catalog_page = self._tables_with_data[2 * self.page_size]
+        access_table = AccessTable(catalog_page, self.version, self.page_size, self._data_pages, self._table_defs)
+        catalog = access_table.parse()
+        tables_mapping = {}
+        for i, table_name in enumerate(catalog['Name']):
+            # We need the MSysObjects table for metadata so exclude it from the system table filter.
+            if table_name == "MSysObjects":
+                tables_mapping[table_name] = catalog['Id'][i]
+            # Visible user tables are type 1
+            table_type = 1
+            if catalog["Type"][i] == table_type:
+                # Don't parse system tables
+                if not catalog["Flags"][i] in SYSTEM_TABLE_FLAGS:
+                    tables_mapping[table_name] = catalog['Id'][i]
+                else:
+                    LOGGER.debug(f"Not parsing system table - {table_name}")
+        return tables_mapping
+
+    def get_table(self, table_name):
+        table_offset = self.catalog.get(table_name)
+        if not table_offset:
+            LOGGER.error(f"Could not find table {table_name} in DataBase")
+            return
+        table_offset = table_offset * self.page_size
+        table = self._tables_with_data.get(table_offset)
+        if not table:
+            table_def = self._table_defs.get(table_offset)
+            if table_def:
+                table = TableObj(offset=table_offset, val=table_def)
+                LOGGER.info(f"Table {table_name} has no data")
+            else:
+                LOGGER.error(f"Could not find table {table_name} offset {table_offset}")
+                return
+
+        # Try to get extra metadata for the table if it exists in the MSysObjects table
+        props = None
+        if table_name != "MSysObjects" and table_name in self.extra_props:
+            props = self.extra_props[table_name]
+
+        return AccessTable(table, self.version, self.page_size, self._data_pages, self._table_defs, props)
+
+    def parse_lvprop(self, lvprop_raw):
+        try:
+            parsed = LVPROP.parse(lvprop_raw)
+        except ConstructError:
+            return None
+        if not parsed.get("chunks"):
+            return None
+        table_names = [x.name for x in parsed.chunks[0].data.names]
+        # Chunk type 0 does not have a column name, so we cannot link it to a column
+        chunk_type_one = [x for x in parsed.chunks if x.chunk_type == 1]
+        reconstructed_column_data = {}
+        for chunk in chunk_type_one:
+            if not chunk.data.column_name:
+                LOGGER.error("Error while parsing MSysObjects table chunk.")
+                continue
+            data_values = {}
+            for dv in chunk.data.data:
+                val = parse_type(dv.type, dv.actual_data, version=self.version)
+                try:
+                    name = table_names[dv.name_index]
+                    data_values[name] = val
+                except IndexError:
+                    LOGGER.error("Error while parsing MSysObjects table chunk.")
+                    continue
+            reconstructed_column_data[chunk.data.column_name] = data_values
+        return reconstructed_column_data
+
+    def parse_table(self, table_name):
+        """
+        Parse a table from the db.
+        tables names are in self.catalog
+        :return defaultdict(list) with the parsed table -- table[column][row_index]
+        """
+        return self.get_table(table_name).parse()
+
+    def print_database(self):
+        """
+        Print data from all database tables
+        """
+        table_names = self.catalog
+        for table_name in table_names:
+            table = self.parse_table(table_name)
+            if not table:
+                continue
+            print(f'TABLE NAME: {table_name}\r\n')
+            # tabulate pretty-printer stripped from the vendored copy.
+            print(table)
+            print('\r\n\r\n\r\n\r\n')
+
+
+class AccessTable(object):
+    def __init__(self, table, version, page_size, data_pages, table_defs, props=None):
+        self.version = version
+        self.props = props
+        self.page_size = page_size
+        self._data_pages = data_pages
+        self._table_defs = table_defs
+        self.table = table
+        self.parsed_table = defaultdict(list)
+        self.columns, self.primary_keys, self.table_header = self._get_table_columns()
+
+    def create_empty_table(self):
+        parsed_table = defaultdict(list)
+        columns, *_ = self._get_table_columns()
+        for i, column in columns.items():
+            parsed_table[column.col_name_str] = ""
+        return parsed_table
+
+    def parse(self):
+        """
+        This is the main table parsing function. We go through all of the data pages linked to the table, separate each
+        data page to rows(records) and parse each record.
+        :return defaultdict(list) with the parsed data -- table[column][row_index]
+        """
+        if not self.table.linked_pages:
+            return self.create_empty_table()
+        for data_chunk in self.table.linked_pages:
+            original_data = data_chunk
+            parsed_data = parse_data_page_header(original_data, version=self.version)
+
+            last_offset = None
+            for rec_offset in parsed_data.record_offsets:
+                # Deleted row - Just skip it
+                if rec_offset & 0x8000:
+                    last_offset = rec_offset & 0xfff
+                    continue
+                # Overflow page
+                if rec_offset & 0x4000:
+                    # overflow ptr is 4 bits flags, 12 bits ptr
+                    rec_ptr_offset = rec_offset & 0xfff
+                    # update last pointer to pointer without flags
+                    last_offset = rec_ptr_offset
+                    # The ptr is the offset in the current data page. we get a 4 byte record_pointer from that
+                    overflow_rec_ptr = original_data[rec_ptr_offset:rec_ptr_offset + 4]
+                    overflow_rec_ptr = struct.unpack("<I", overflow_rec_ptr)[0]
+                    record = self._get_overflow_record(overflow_rec_ptr)
+                    if record:
+                        self._parse_row(record)
+                    continue
+                # First record is actually the last one - from offset until the end of the data
+                if not last_offset:
+                    record = original_data[rec_offset:]
+                else:
+                    record = original_data[rec_offset:last_offset]
+                last_offset = rec_offset
+                if record:
+                    self._parse_row(record)
+        return self.parsed_table
+
+    def _parse_row(self, record):
+        """
+        parse record (row) of data. First parse all fixed-length data field and then parse the relative length data.
+        :param record: the current row data
+        :return:
+        """
+        original_record = record
+        reverse_record = record[::-1]
+        # Records contain null bitmaps for columns. The number of bitmaps is the number of columns / 8 rounded up
+        null_table_len = (self.table_header.column_count + 7) // 8
+        if null_table_len and null_table_len < len(original_record):
+            null_table = record[-null_table_len:]
+            # Turn bitmap to a list of True False values
+            null_table = [((null_table[i // 8]) & (1 << (i % 8))) != 0 for i in range(len(null_table) * 8)]
+        else:
+            LOGGER.error(f"Failed to parse null table column count {self.table_header.column_count}")
+            return
+        if self.version > 3:
+            field_count = struct.unpack_from("h", record)[0]
+            record = record[2:]
+        else:
+            field_count = struct.unpack_from("b", record)[0]
+            record = record[1:]
+
+        relative_records_column_map = {}
+        # Iterate columns
+        for i, column in self.columns.items():
+            # Fixed length columns are handled before variable length. If this is a variable length column add it to
+            # mapping and continue
+            if not column.column_flags.fixed_length:
+                relative_records_column_map[i] = column
+                continue
+
+            self._parse_fixed_length_data(record, column, null_table)
+        if relative_records_column_map:
+            relative_records_column_map = dict(sorted(relative_records_column_map.items()))
+            metadata = self._parse_dynamic_length_records_metadata(reverse_record, original_record,
+                                                                   null_table_len)
+            if not metadata:
+                return
+            if metadata.variable_length_field_offsets:
+                self._parse_dynamic_length_data(original_record, metadata, relative_records_column_map, null_table)
+
+    def _parse_fixed_length_data(self, original_record, column, null_table):
+        """
+        Parse fixed-length data from record
+        :param original_record: unmodified record
+        :param column: column this data belongs to
+        :param null_table: null table of the row
+        """
+        column_name = column.col_name_str
+        # The null table indicates null values in the row.
+        # The only exception is BOOL fields which are encoded in the null table
+        has_value = True
+        if column.column_id > len(null_table):
+            LOGGER.warning("Invalid null table. Bool values may be wrong, deleted values may be shown in the db.")
+            if column.type == TYPE_BOOLEAN:
+                has_value = None
+        else:
+            has_value = null_table[column.column_id]
+        # Boolean fields are encoded in the null table
+        if column.type == TYPE_BOOLEAN:
+            parsed_type = has_value
+        else:
+            if column.fixed_offset > len(original_record):
+                LOGGER.error(f"Column offset is bigger than the length of the record {column.fixed_offset}")
+                return
+            record = original_record[column.fixed_offset:]
+            parsed_type = parse_type(column.type, record, version=self.version, props=column.extra_props or None)
+            if not has_value:
+                self.parsed_table[column_name].append(None)
+                return
+        self.parsed_table[column_name].append(parsed_type)
+
+    def _parse_dynamic_length_records_metadata(self, reverse_record, original_record, null_table_length):
+        """
+        parse the metadata of relative records. The metadata used to parse relative records is found at the end of the
+        record so reverse_record is used for parsing from the bottom up.
+        :param reverse_record: original record in reverse
+        :param original_record: unmodified record
+        :param null_table_length:
+        :return: parsed relative record metadata
+        """
+        if self.version > 3:
+            reverse_record = reverse_record[null_table_length:]
+            return parse_relative_object_metadata_struct(reverse_record, version=self.version)
+        # Parse relative metadata.
+        # Metadata is from the end of the record(reverse_record is used here)
+        variable_length_jump_table_cnt = (len(original_record) - 1) // 256
+        reverse_record = reverse_record[null_table_length:]
+        try:
+            relative_record_metadata = parse_relative_object_metadata_struct(reverse_record,
+                                                                             variable_length_jump_table_cnt,
+                                                                             self.version)
+            # relative_record_metadata = RELATIVE_OBJS.parse(reverse_record)
+            # we use this offset in original_record so we have to update the length with the null_tables
+            relative_record_metadata.relative_metadata_end = relative_record_metadata.relative_metadata_end + null_table_length
+        except ConstructError:
+            relative_record_metadata = None
+            LOGGER.error("Failed parsing record")
+
+        if relative_record_metadata and \
+                relative_record_metadata.variable_length_field_count != self.table_header.variable_columns:
+
+            # best effort - try to find variable column count in the record and parse from there
+            # this is limited to the 10 first bytes to reduce false positives.
+            # most of the time iv'e seen this there was an extra DWORD before the actual metadata
+            metadata_start = reverse_record.find(bytes([self.table_header.variable_columns]))
+            if metadata_start != -1 and metadata_start < 10:
+                reverse_record = reverse_record[metadata_start:]
+                try:
+                    relative_record_metadata = parse_relative_object_metadata_struct(reverse_record,
+                                                                                     variable_length_jump_table_cnt,
+                                                                                     self.version)
+                except ConstructError:
+                    LOGGER.error(f"Failed to parse record metadata: {original_record}")
+                relative_record_metadata.relative_metadata_end = relative_record_metadata.relative_metadata_end + \
+                                                                 metadata_start
+            else:
+                LOGGER.warning(
+                    f"Record did not parse correctly. Number of columns: {self.table_header.variable_columns}"
+                    f" number of parsed columns: {relative_record_metadata.variable_length_field_count}")
+                return None
+        return relative_record_metadata
+
+    def _parse_dynamic_length_data(self, original_record, relative_record_metadata,
+                                   relative_records_column_map, null_table):
+        """
+        Parse dynamic (non fixed length) records from row
+        :param original_record: full unmodified record
+        :param relative_record_metadata: parsed record metadata
+        :param relative_records_column_map: relative records colum mapping {index: column}
+        :param null_table: list indicating which columns have null value
+        """
+        relative_offsets = relative_record_metadata.variable_length_field_offsets
+        jump_table_addition = 0
+        for i, column_index in enumerate(relative_records_column_map):
+            column = relative_records_column_map[column_index]
+            col_name = column.col_name_str
+            has_value = True
+            if column.column_id > len(null_table):
+                LOGGER.warning("Invalid null table. null values may be shown in the db.")
+            else:
+                has_value = null_table[column.column_id]
+            if not has_value:
+                self.parsed_table[col_name].append(None)
+                continue
+
+            if self.version == 3:
+                if i in relative_record_metadata.variable_length_jump_table:
+                    jump_table_addition += 0x100
+            rel_start = relative_offsets[i]
+            # If this is the last one use var_len_count as end offset
+            if i + 1 == len(relative_offsets):
+                rel_end = relative_record_metadata.var_len_count
+            else:
+                rel_end = relative_offsets[i + 1]
+
+            # if rel_start and rel_end are the same there is no data in this slot
+            if rel_start == rel_end:
+                self.parsed_table[col_name].append("")
+                continue
+
+            relative_obj_data = original_record[rel_start + jump_table_addition: rel_end + jump_table_addition]
+            # Parse types that require column data here, call parse_type on all other types
+            if column.type == TYPE_MEMO:
+                try:
+                    parsed_type = self._parse_memo(relative_obj_data)
+                except ConstructError:
+                    LOGGER.warning("Failed to parse memo field. Using data as bytes")
+                    parsed_type = relative_obj_data
+            elif column.type == TYPE_OLE:
+                try:
+                    parsed_type = self._parse_memo(relative_obj_data, return_raw=True)
+                except ConstructError:
+                    LOGGER.warning("Failed to parse OLE field. Using data as bytes")
+                    parsed_type = relative_obj_data
+            elif column.type == TYPE_96_bit_17_BYTES:
+                if len(relative_obj_data) != 17:
+                    LOGGER.warning(f"Relative numeric field has invalid length {len(relative_obj_data)}, expected 17")
+                    parsed_type = relative_obj_data
+                else:
+                    # Get scale or None
+                    scale = column.get('various', {}).get('scale', 6)
+                    parsed_type = numeric_to_string(relative_obj_data, scale)
+            else:
+                parsed_type = parse_type(column.type, relative_obj_data, len(relative_obj_data), version=self.version)
+            self.parsed_table[col_name].append(parsed_type)
+
+    def _get_table_columns(self):
+        """
+        Parse columns for a specific table
+        """
+        try:
+            table_header = parse_table_head(self.table.value, version=self.version)
+            merged_data = self.table.value[table_header.tdef_header_end:]
+            if table_header.TDEF_header.next_page_ptr:
+                merged_data = merged_data + self._merge_table_data(table_header.TDEF_header.next_page_ptr)
+
+            parsed_data = parse_table_data(
+                merged_data,
+                table_header.index_count,
+                table_header.real_index_count,
+                table_header.column_count,
+                version=self.version,
+            )
+
+            # Merge Data back to table_header
+            table_header['column'] = parsed_data['column']
+            table_header['column_names'] = parsed_data['column_names']
+            table_header['real_index_2'] = parsed_data['real_index_2']
+            table_header["all_indexes"] = parsed_data["all_indexes"]
+            table_header["index_names"] = parsed_data["index_names"]
+
+        except ConstructError:
+            LOGGER.error(f"Failed to parse table header {self.table.value}")
+            return
+        col_names = table_header.column_names
+        columns = table_header.column
+
+        # Add names to columns metadata, so we can use only columns for parsing
+        for i, c in enumerate(columns):
+            c.col_name_str = col_names[i].col_name_str
+            c.extra_props = None
+
+        # column_index is more accurate(id is always incremented so it is wrong when a column is deleted).
+        # Some tables like the catalog don't have index, so if indexes are 0 use id.
+
+        # create a dict of index to column to make it easier to access. offset is used to make this zero based
+        offset = min(x.column_index for x in columns)
+        column_dict = {x.column_index - offset: x for x in columns}
+        # If column index is not unique try best effort
+        if len(column_dict) != len(columns):
+            # create a dict of id to column to make it easier to access
+            column_dict = {x.column_id: x for x in columns}
+
+        # Add the extra properties relevant for the column
+        if self.props:
+            for i, col in column_dict.items():
+                if col.col_name_str in self.props:
+                    col.extra_props = self.props[col.col_name_str]
+
+        primary_keys = [
+            column_dict[col.col_id].col_name_str
+            for idx in table_header.all_indexes
+            for col in table_header.real_index_2[idx.idx_col_num].unk_struct
+            if idx.idx_type == 1 and col.col_id ^ 0xFFFF
+        ]
+
+        if len(column_dict) != table_header.column_count:
+            LOGGER.debug(f"expected {table_header.column_count} columns got {len(column_dict)}")
+        return column_dict, primary_keys, table_header
+
+    def _merge_table_data(self, first_page):
+        """
+        Merege data of tdef pages in case the data does not fit in one page
+        :param first_page: index of the next page
+        :return: merged data from all linked table definitions
+        """
+        table = self._table_defs.get(first_page * self.page_size)
+        parsed_header = TDEF_HEADER.parse(table)
+        data = table[parsed_header.header_end:]
+        while parsed_header.next_page_ptr:
+            table = self._table_defs.get(parsed_header.next_page_ptr * self.page_size)
+            parsed_header = TDEF_HEADER.parse(table)
+            data = data + table[parsed_header.header_end:]
+        return data
+
+    def _parse_memo(self, relative_obj_data, return_raw=False):
+        LOGGER.debug(f"Parsing memo field {relative_obj_data}")
+        parsed_memo = MEMO.parse(relative_obj_data)
+        memo_type = TYPE_TEXT
+        if parsed_memo.memo_length & 0x80000000:
+            LOGGER.debug("memo data inline")
+            inline_memo_length = parsed_memo.memo_length & 0x3FFFFFFF
+            if len(relative_obj_data) < parsed_memo.memo_end + inline_memo_length:
+                LOGGER.warning("Inline memo field has invalid length using full data")
+                memo_data = relative_obj_data[parsed_memo.memo_end:]
+            else:
+                memo_data = relative_obj_data[parsed_memo.memo_end:parsed_memo.memo_end + inline_memo_length]
+
+        elif parsed_memo.memo_length & 0x40000000:
+            LOGGER.debug("LVAL type 1")
+            memo_data = self._get_overflow_record(parsed_memo.record_pointer)
+        else:
+            LOGGER.debug("LVAL type 2")
+            rec_data = self._get_overflow_record(parsed_memo.record_pointer)
+            next_page = struct.unpack("I", rec_data[:4])[0]
+            # LVAL2 has data over multiple pages. The first 4 bytes of the page are the next record, then that data.
+            # Concat the data until we get a 0 next_page.
+            memo_data = b""
+            while next_page:
+                memo_data += rec_data[4:]
+                rec_data = self._get_overflow_record(next_page)
+                next_page = struct.unpack("I", rec_data[:4])[0]
+            memo_data += rec_data[4:]
+        if memo_data:
+            if return_raw:
+                return memo_data
+            parsed_type = parse_type(memo_type, memo_data, len(memo_data), version=self.version)
+            return parsed_type
+
+    def _get_overflow_record(self, record_pointer):
+        """
+        Get the actual record from a record pointer
+        :param record_pointer:
+        :return: record
+        """
+        record_offset = record_pointer & 0xff
+        page_num = record_pointer >> 8
+        record_page = self._data_pages.get(page_num * self.page_size)
+        if not record_page:
+            LOGGER.warning(f"Could not find overflow record data page overflow pointer: {record_pointer}")
+            return
+        parsed_data = parse_data_page_header(record_page, version=self.version)
+        if record_offset > len(parsed_data.record_offsets):
+            LOGGER.warning("Failed parsing overflow record offset")
+            return
+        start = parsed_data.record_offsets[record_offset]
+        if start & 0x8000:
+            start = start & 0xfff
+        else:
+            LOGGER.debug(f"Overflow record flag is not present {start}")
+        if record_offset == 0:
+            record = record_page[start:]
+        else:
+            end = parsed_data.record_offsets[record_offset - 1]
+            if end & 0x8000 and (end & 0xff != 0):
+                end = end & 0xfff
+            record = record_page[start: end]
+        return record

--- a/custom_components/nikobus/vendor/access_parser/parsing_primitives.py
+++ b/custom_components/nikobus/vendor/access_parser/parsing_primitives.py
@@ -1,0 +1,261 @@
+from construct import *
+
+
+def version_specific(version, v3_subcon, v4_subcon):
+    """
+    There are some differences in the parsing structure between v3 and v4. Some fields are different length and some
+    exist only in one of the versions. this returns the relevant parsing structure by version
+    :param version: int 3 or 4
+    :param v3_subcon: the parsing struct if version is 3
+    :param v4_subcon: the parsing struct if version is 4
+    """
+    if version == 3:
+        return v3_subcon
+    else:
+        return v4_subcon
+
+
+ACCESSHEADER = Struct(
+    Const(b'\00\x01\x00\x00'),
+    "jet_string" / CString("utf8"),
+    "jet_version" / Int32ul,
+    # RC4 encrypted with key 0x6b39dac7. Database metadata
+    Padding(126))
+
+MEMO = Struct(
+    "memo_length" / Int32ul,
+    "record_pointer" / Int32ul,
+    "memo_unknown" / Int32ul,
+    "memo_end" / Tell)
+
+VERSION_3_FLAGS = BitStruct(
+    "hyperlink" / Flag,
+    "auto_GUID" / Flag,
+    "unk_1" / Flag,
+    "replication" / Flag,
+    "unk_2" / Flag,
+    "autonumber" / Flag,
+    "can_be_null" / Flag,
+    "fixed_length" / Flag)
+
+VERSION_4_FLAGS = BitStruct(
+    "hyperlink" / Flag,
+    "auto_GUID" / Flag,
+    "unk_1" / Flag,
+    "replication" / Flag,
+    "unk_2" / Flag,
+    "autonumber" / Flag,
+    "can_be_null" / Flag,
+    "fixed_length" / Flag,
+    "unk_3" / Flag,
+    "unk_4" / Flag,
+    "unk_5" / Flag,
+    'modern_package_type' / Flag,
+    "unk_6" / Flag,
+    "unk_7" / Flag,
+    "unk_8" / Flag,
+    "compressed_unicode" / Flag)
+
+TDEF_HEADER = Struct(
+    Const(b'\02\x01'),
+    "peek_version" / Peek(Int16ul),
+    "tdef_ver" / IfThenElse(lambda x: x.peek_version == b"VC", Const(b"VC"), Int16ul),
+    "next_page_ptr" / Int32ul,
+    "header_end" / Tell)
+
+LVPROP_CHUNK_NAMES_INT = Struct(
+    "name_length" / Int16ul,
+    "name" / PaddedString(this.name_length, "utf16"),
+)
+LVPROP_CHUNK_NAMES = Struct(
+    "names" / GreedyRange(LVPROP_CHUNK_NAMES_INT),
+    # "leftover" / GreedyBytes
+)
+LVPROP_DATA = Struct(
+    "data_length" / Int16ul,
+    "ddl_flag" / Int8ul,
+    "type" / Int8ul,
+    "name_index" / Int16ul,
+    "only_data_length" / Int16ul,
+    "actual_data" / Bytes(this.only_data_length)
+)
+LVPROP_VALUE = Struct(
+    "val_length" / Int32ul,
+    "name_length" / Int16ul,
+    "column_name" / PaddedString(this.name_length, "utf16"),
+    "data" / GreedyRange(LVPROP_DATA),
+    "left" / GreedyBytes
+)
+
+LVPROP_CHUNK = Struct(
+    "length" / Int32ul,
+    "chunk_type" / Int16ul,
+
+    "data" / Prefixed(Computed(this.length - 6), Switch(this.chunk_type, {
+        # 128: GreedyRange(LVPROP_CHUNK_NAMES)
+        128: LVPROP_CHUNK_NAMES,
+        0:LVPROP_VALUE,
+        1: LVPROP_VALUE
+    }, default=Bytes(this.length - 4)))
+)
+LVPROP = Struct(
+    #'KKD\0' in Jet3 and 'MR2\0' in Jet 4.
+    "magic" / Bytes(4),
+    "chunks" / GreedyRange(LVPROP_CHUNK),
+    "leftover" / GreedyBytes
+)
+
+def parse_table_head(buffer, version=3):
+    return Struct(
+        "TDEF_header" / TDEF_HEADER,
+        # Table
+        "table_definition_length" / Int32ul,
+        "ver4_unknown" / If(lambda x: version > 3, Int32ul),
+        "number_of_rows" / Int32ul,
+        "autonumber" / Int32ul,
+        "autonumber_increment" / If(lambda x: version > 3, Int32ul),
+        "complex_autonumber" / If(lambda x: version > 3, Int32ul),
+        "ver4_unknown_1" / If(lambda x: version > 3, Int32ul),
+        "ver4_unknown_2" / If(lambda x: version > 3, Int32ul),
+        # 0x53 system table
+        # 0x4e user table
+        "table_type_flags" / Int8ul,
+        "next_column_id" / Int16ul,
+        "variable_columns" / Int16ul,
+        "column_count" / Int16ul,
+        "index_count" / Int32ul,
+        "real_index_count" / Int32ul,
+        "row_page_map" / Int32ul,
+        "free_space_page_map" / Int32ul,
+        "tdef_header_end" / Tell).parse(buffer)
+
+
+def parse_table_data(buffer, index_count, real_index_count, column_count, version=3):
+    REAL_INDEX = Struct(
+        "unk1" / Int32ul,
+        "index_row_count" / Int32ul,
+        "ver4_always_zero" /  If(lambda x: version > 3, Int32ul))
+
+    VARIOUS_TEXT_V3 = Struct(
+        "LCID" / Int16ul,
+        "code_page" / Int16ul,
+        "various_text3_unknown" / Int16ul)
+
+    VARIOUS_TEXT_V4 = Struct(
+        "collation" / Int16ul,
+        "various_text4_unknown" / Int8ul,
+        "collation_version_number" / Int8ul)
+
+    VARIOUS_TEXT = VARIOUS_TEXT_V3 if version == 3 else VARIOUS_TEXT_V4
+
+    VARIOUS_DEC_V3 = Struct(
+        "various_dec3_unknown" / Int16ul,
+        "max_number_of_digits" / Int8ul,
+        "number_of_decimal" / Int8ul,
+        "various_dec3_unknown2" / Int16ul)
+
+    VARIOUS_DEC_V4 = Struct(
+        "max_num_of_digits" / Int8ul,
+        "num_of_decimal_digits" / Int8ul,
+        "various_dec4_unknown" / Int16ul)
+
+    VARIOUS_DEC = VARIOUS_DEC_V3 if version == 3 else VARIOUS_DEC_V4
+
+    VARIOUS_NUMERIC_V3 = Struct("prec" / Int8ul, "scale" / Int8ul, "unknown" / Int32ul)
+    VARIOUS_NUMERIC_V4 = Struct("prec" / Int8ul, "scale" / Int8ul, "unknown" / Int16ul)
+    VARIOUS_NUMERIC = VARIOUS_NUMERIC_V3 if version == 3 else VARIOUS_NUMERIC_V4
+
+    COLUMN = Struct(
+        "type" / Int8ul,
+        "ver4_unknown_3" /  If(lambda x: version > 3, Int32ul),
+        "column_id" / Int16ul,
+        "variable_column_number" / Int16ul,
+        "column_index" / Int16ul,
+        "various" / Switch(lambda ctx: ctx.type,
+                           {
+                               9: VARIOUS_TEXT,
+                               10: VARIOUS_TEXT,
+                               11: VARIOUS_TEXT,
+                               12: VARIOUS_TEXT,
+                               16: VARIOUS_NUMERIC,
+
+                               1: VARIOUS_DEC,
+                               2: VARIOUS_DEC,
+                               3: VARIOUS_DEC,
+                               4: VARIOUS_DEC,
+                               5: VARIOUS_DEC,
+                               6: VARIOUS_DEC,
+                               7: VARIOUS_DEC,
+                               8: VARIOUS_DEC,
+
+                           }, default=version_specific(version, Bytes(6), Bytes(4))),
+        "column_flags" / version_specific(version, VERSION_3_FLAGS, VERSION_4_FLAGS),
+        "ver4_unknown_4" / If(lambda x: version > 3, Int32ul),
+        "fixed_offset" / Int16ul,
+        "length" / Int16ul)
+
+    COLUMN_NAMES = Struct(
+        "col_name_len" / version_specific(version, Int8ul, Int16ul),
+        "col_name_str" / version_specific(version,
+                                          PaddedString(lambda x: x.col_name_len, encoding="utf8"),
+                                          PaddedString(lambda x: x.col_name_len, encoding="utf16")),
+    )
+
+    REAL_INDEX2 = Struct(
+        "unknown_b1" / If(lambda x: version > 3, Int32ul),
+        "unk_struct" / Array(10, Struct("col_id" / Int16ul, "idx_flags" / Int8ul)),
+        "runk" / Int32ul,
+        "first_index_page" / Int32ul,
+        "flags" / Int8ul,
+        "unknown_b3" / If(lambda x: version > 3, Padding(9)))
+
+    ALL_INDEXES = Struct(
+        "unknown_c1" / If(lambda x: version > 3, Int32ul),
+        "idx_num" / Int32ul,
+        "idx_col_num" / Int32ul,
+        "rel_tbl_type" / Int8ul,
+        "rel_idx_num" / Int32sl,
+        "rel_tbl_page" / Int32ul,
+        "cascade_ups" / Int8ul,
+        "cascade_dels" / Int8ul,
+        "idx_type" / Int8ul,
+        "unknown_c2" / If(lambda x: version > 3, Int32ul))
+
+    INDEX_NAMES = Struct(
+        "idx_name_len" / version_specific(version, Int8ul, Int16ul),
+        "idx_name_str" / version_specific(version,
+                                          PaddedString(lambda x: x.idx_name_len, encoding="utf8"),
+                                          PaddedString(lambda x: x.idx_name_len, encoding="utf16")),
+    )
+
+    return Struct(
+        "real_index" / Array(real_index_count, REAL_INDEX),
+        "column" / Array(column_count, COLUMN),
+        "column_names" / Array(column_count, COLUMN_NAMES),
+        "real_index_2" / Array(real_index_count, REAL_INDEX2),
+        "all_indexes" / Array(index_count, ALL_INDEXES),
+        "index_names" /  Array(index_count, INDEX_NAMES)).parse(buffer)
+
+
+def parse_data_page_header(buffer, version=3):
+    return Struct(
+        Const(b"\x01\x01"),
+        "data_free_space" / Int16ul,
+        "owner" / Int32ul,
+        "ver4_unknown_dat1" / If(lambda x: version > 3, Int32ul),
+        "record_count" / Int16ul,
+        "record_offsets" / Array(lambda x: x.record_count, Int16ul)).parse(buffer)
+
+
+# buffer should be the record data in reverse
+def parse_relative_object_metadata_struct(buffer, variable_jump_tables_cnt=0, version=3):
+    return Struct(
+        "variable_length_field_count" / version_specific(version, Int8ub, Int16ub),
+        "variable_length_jump_table" / If(lambda x: version == 3, Array(variable_jump_tables_cnt, Int8ub)),
+        # This currently supports up to 255 columns for versions > 3
+        "variable_length_field_offsets" / version_specific(version,
+                                                           Array(lambda x: x.variable_length_field_count, Int8ub),
+                                                           Array(lambda x: x.variable_length_field_count & 0xff,
+                                                                 Int16ub)),
+        "var_len_count" / version_specific(version, Int8ub, Int16ub),
+        "relative_metadata_end" / Tell).parse(buffer)

--- a/custom_components/nikobus/vendor/access_parser/utils.py
+++ b/custom_components/nikobus/vendor/access_parser/utils.py
@@ -1,0 +1,218 @@
+import logging
+import os
+import struct
+import uuid
+import math
+from datetime import datetime, timedelta
+
+LOGGER = logging.getLogger("access_parser.utils")
+
+
+TYPE_BOOLEAN = 1
+TYPE_INT8 = 2
+TYPE_INT16 = 3
+TYPE_INT32 = 4
+TYPE_MONEY = 5
+TYPE_FLOAT32 = 6
+TYPE_FLOAT64 = 7
+TYPE_DATETIME = 8
+TYPE_BINARY = 9
+TYPE_TEXT = 10
+TYPE_OLE = 11
+TYPE_MEMO = 12
+TYPE_GUID = 15
+TYPE_96_bit_17_BYTES = 16
+TYPE_COMPLEX = 18
+
+TABLE_PAGE_MAGIC = b"\x02\x01"
+DATA_PAGE_MAGIC = b"\x01\x01"
+
+
+ACCESS_EPOCH = datetime(1899, 12, 30)
+
+PERCENT_DEFAULT = '0.00%'
+EURO_DEFAULT = '€0.00'
+DOLLAR_DEFAULT = '$0.00'
+GENERAL_NUMBER_DEFAULT = '0'
+FIXED_AND_STANDARD_DEFAULT = '0.00'
+SCIENTIFIC_DEFAULT = '0.00E+00'
+
+FORMAT_PERCENT = "Percent"
+FORMAT_DOLLAR = "$"
+FORMAT_EURO = "€"
+FORMAT_GENERAL_NUMBER = "General Number"
+FORMAT_FIXED = "Fixed"
+FORMAT_STANDARD = "Standard"
+FORMAT_SCIENTIFIC = "Scientific"
+
+FORMAT_TO_DEFAULT_VALUE = {
+    FORMAT_DOLLAR: DOLLAR_DEFAULT,
+    FORMAT_STANDARD: FIXED_AND_STANDARD_DEFAULT,
+    FORMAT_FIXED: FIXED_AND_STANDARD_DEFAULT,
+    FORMAT_PERCENT: PERCENT_DEFAULT,
+    FORMAT_EURO: EURO_DEFAULT,
+    FORMAT_GENERAL_NUMBER: GENERAL_NUMBER_DEFAULT,
+    FORMAT_SCIENTIFIC: SCIENTIFIC_DEFAULT
+}
+
+
+# https://stackoverflow.com/questions/45560782
+def mdb_date_to_readable(double_time):
+    try:
+        dtime_bytes = struct.pack("Q", double_time)
+
+        dtime_double = struct.unpack('<d', dtime_bytes)[0]
+        dtime_frac, dtime_whole = math.modf(dtime_double)
+        dtime = (ACCESS_EPOCH + timedelta(days=dtime_whole) + timedelta(days=dtime_frac))
+        if dtime == ACCESS_EPOCH:
+            return "(Empty Date)"
+        return str(dtime)
+    except OverflowError:
+        return "(Invalid Date)"
+    except struct.error:
+        return "(Invalid Date)"
+
+
+def numeric_to_string(bytes_num, scale=6):
+    neg, num1, num2, num3, num4 = struct.unpack("<BIIII", bytes_num)
+    full_number = (num1 << 96) + (num2 << 64) + (num3 << 32) + num4
+    full_number = str(full_number)
+    # If scale is 6 149804168 will be 149.804168 - 6 from the end.
+    # If scale is bigger than the number ignore the scale(1498 will remain 1498)
+    if len(full_number) > scale:
+        dot_len = len(full_number) - scale
+        full_number = full_number[:dot_len] + "." + full_number[dot_len:]
+    numeric_string = "-" if neg else ""
+    numeric_string += full_number
+    return numeric_string
+
+
+def get_decoded_text(bytes_data):
+    try:
+        decoded = bytes_data.decode('utf-8')
+    except UnicodeDecodeError:
+        try:
+            decoded = bytes_data.decode('latin1')
+        except UnicodeDecodeError:
+            decoded = bytes_data.decode('utf-8', errors='ignore')
+    return decoded
+
+
+def parse_money_type(parsed, prop_format):
+    """
+    Parse and format a money value according to the specified format.
+
+    Args:
+        parsed (int): The numerical value to be parsed.
+        prop_format (str): The format string specifying the desired format.
+
+    Returns:
+        str: The parsed and formatted money value.
+    """
+    parsed = str(parsed)
+    if prop_format == FORMAT_PERCENT:
+        special_format = "{:.2f}%"
+        dot_location = -2
+    elif prop_format.startswith(FORMAT_DOLLAR):
+        special_format = '${:,.2f}'
+        dot_location = -4
+    elif prop_format.startswith(FORMAT_EURO):
+        special_format = '€{:,.2f}'
+        dot_location = -4
+    elif prop_format == FORMAT_GENERAL_NUMBER:
+        special_format = '{:,.1f}'
+        dot_location = -4
+    elif prop_format == FORMAT_SCIENTIFIC:
+        special_format = '{:.2e}'
+        dot_location = -4
+    elif prop_format in [FORMAT_FIXED, FORMAT_STANDARD]:
+        dot_location = -4
+        special_format = '{:,.2f}'
+    else:
+        LOGGER.warning(f"parse_money_type - unsupported format: {prop_format} value {parsed} may be wrong")
+        return parsed
+
+    money_float = parsed[:dot_location] + "." + parsed[dot_location:]
+    if special_format:
+        money_float = special_format.format(float(money_float))
+    return money_float
+
+
+def parse_type(data_type, buffer, length=None, version=3, props=None):
+    parsed = ""
+    # Bool or int8
+    if data_type == TYPE_INT8:
+        parsed = struct.unpack_from("b", buffer)[0]
+    elif data_type == TYPE_INT16:
+        parsed = struct.unpack_from("h", buffer)[0]
+    elif data_type == TYPE_INT32 or data_type == TYPE_COMPLEX:
+        parsed = struct.unpack_from("i", buffer)[0]
+    elif data_type == TYPE_MONEY:
+        parsed = struct.unpack_from("q", buffer)[0]
+        if props and "Format" in props:
+            prop_format = props['Format']
+            if parsed == 0:
+                parsed = [y for x, y in FORMAT_TO_DEFAULT_VALUE.items() if prop_format.startswith(x)]
+                if not parsed:
+                    LOGGER.warning(f"parse_type got unknown format while parsing money field {prop_format}")
+                else:
+                    parsed = parsed[0]
+            else:
+                parsed = parse_money_type(parsed, prop_format)
+    elif data_type == TYPE_FLOAT32:
+        parsed = struct.unpack_from("f", buffer)[0]
+    elif data_type == TYPE_FLOAT64:
+        parsed = struct.unpack_from("d", buffer)[0]
+    elif data_type == TYPE_DATETIME:
+        double_datetime = struct.unpack_from("q", buffer)[0]
+        parsed = mdb_date_to_readable(double_datetime)
+    elif data_type == TYPE_BINARY:
+        parsed = buffer[:length]
+        offset = length
+    elif data_type == TYPE_OLE:
+        parsed = buffer
+    elif data_type == TYPE_GUID:
+        parsed = buffer[:16]
+        guid = uuid.UUID(parsed.hex())
+        parsed = str(guid)
+    elif data_type == TYPE_96_bit_17_BYTES:
+        parsed = buffer[:17]
+    elif data_type == TYPE_TEXT:
+        if version > 3:
+            # Looks like if BOM is present text is already decoded
+            if buffer.startswith(b"\xfe\xff") or buffer.startswith(b"\xff\xfe"):
+                buff = buffer[2:]
+                parsed = get_decoded_text(buff)
+            else:
+                parsed = buffer.decode("utf-16", errors='ignore')
+        else:
+            parsed = get_decoded_text(buffer)
+
+        if "\x00" in parsed:
+            LOGGER.debug(f"Parsed string contains NUL (0x00) characters: {parsed}")
+            parsed = parsed.replace("\x00", "")
+    else:
+        LOGGER.debug(f"parse_type - unsupported data type: {data_type}")
+    return parsed
+
+
+def categorize_pages(db_data, page_size):
+    if len(db_data) % page_size:
+        LOGGER.warning(f"DB is not full or PAGE_SIZE is wrong. page size: {page_size} DB length {len(db_data)}")
+    pages = {i: db_data[i:i + page_size] for i in range(0, len(db_data), page_size)}
+    data_pages = {}
+    table_defs = {}
+    for page in pages:
+        if pages[page].startswith(DATA_PAGE_MAGIC):
+            data_pages[page] = pages[page]
+        elif pages[page].startswith(TABLE_PAGE_MAGIC):
+            table_defs[page] = pages[page]
+    return table_defs, data_pages, pages
+
+
+def read_db_file(path):
+    if not os.path.isfile(path):
+        LOGGER.error(f"File {path} not found")
+        raise FileNotFoundError(f"File {path} not found")
+    with open(path, "rb") as f:
+        return f.read()

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,3 @@
+# Vendored third-party code (Apache-2.0 access_parser) is excluded from
+# linting — it is maintained upstream, not by this project.
+extend-exclude = ["custom_components/nikobus/vendor"]

--- a/tests/test_discovery_progress_vendor_aligned.py
+++ b/tests/test_discovery_progress_vendor_aligned.py
@@ -195,3 +195,56 @@ def test_handler_resets_counters_on_sub_phase_transition() -> None:
     # Fallback to 240 when register_total=0 (legacy/forensic guard)
     # is still applied, but the cached identity-phase total is gone.
     assert kwargs["registers_total"] == 240
+
+
+def _percent_coord(scope, sub_phase, *, regs_done=0, regs_total=0,
+                   mods_done=0, mods_total=0):
+    """Bare coordinator exercising the discovery_progress_percent property."""
+    from custom_components.nikobus.coordinator import NikobusDataCoordinator
+
+    c = NikobusDataCoordinator.__new__(NikobusDataCoordinator)
+    c._discovery_scope = scope
+    c.discovery_sub_phase = sub_phase
+    c.discovery_phase = "scan"
+    c.discovery_registers_done = regs_done
+    c.discovery_registers_total = regs_total
+    c.discovery_modules_done = mods_done
+    c.discovery_modules_total = mods_total
+    return c
+
+
+def test_module_scan_progress_starts_at_zero() -> None:
+    """Load Existing Installation (register_scan only) opens at 0 %, not 30 %."""
+    c = _percent_coord("module_scan", "register_scan",
+                       regs_done=0, regs_total=48, mods_done=0, mods_total=4)
+    assert c.discovery_progress_percent == 0.0
+
+
+def test_module_scan_progress_reaches_full_range() -> None:
+    """Last module fully scanned → ~95 % within the register phase (the
+    remaining 5 % is finalizing), spanning the whole bar not 30→95."""
+    c = _percent_coord("module_scan", "register_scan",
+                       regs_done=48, regs_total=48, mods_done=3, mods_total=4)
+    # 4/4 of the register phase maps to (95-30)/70*100 ≈ 92.9
+    assert c.discovery_progress_percent > 90.0
+
+
+def test_module_scan_finalizing_near_complete() -> None:
+    c = _percent_coord("module_scan", "finalizing")
+    # finalizing midpoint: raw 97.5 → (97.5-30)/70*100 ≈ 96.4
+    assert 95.0 <= c.discovery_progress_percent <= 99.9
+
+
+def test_inventory_scope_spans_full_bar() -> None:
+    """Load Project Overview (inventory+identity) spans 0→100 on its own."""
+    c = _percent_coord("inventory", "identity",
+                       regs_done=0, regs_total=0, mods_done=1, mods_total=1)
+    # identity done=1/1 → raw 30 → /30*100 = 100 → capped 99.9
+    assert c.discovery_progress_percent == 99.9
+
+
+def test_full_scope_unchanged() -> None:
+    """A combined run keeps the stacked value (register_scan floor 30)."""
+    c = _percent_coord("full", "register_scan",
+                       regs_done=0, regs_total=48, mods_done=0, mods_total=4)
+    assert c.discovery_progress_percent == 30.0

--- a/tests/test_nkbnames.py
+++ b/tests/test_nkbnames.py
@@ -1,0 +1,217 @@
+"""Tests for .nkb name extraction and the registry-apply import."""
+
+from __future__ import annotations
+
+import asyncio
+import zipfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.nikobus.nkbnames import (
+    CANONICAL_NKB_FILENAME,
+    NkbNames,
+    find_nkb_file,
+    parse_nkb_names,
+)
+
+
+# --------------------------------------------------------------------------- #
+# find_nkb_file
+# --------------------------------------------------------------------------- #
+def test_find_canonical_preferred(tmp_path):
+    (tmp_path / CANONICAL_NKB_FILENAME).write_bytes(b"x")
+    (tmp_path / "other.nkb").write_bytes(b"x")
+    assert find_nkb_file(str(tmp_path)).name == CANONICAL_NKB_FILENAME
+
+
+def test_find_single_nkb(tmp_path):
+    (tmp_path / "waterloo.nkb").write_bytes(b"x")
+    assert find_nkb_file(str(tmp_path)).name == "waterloo.nkb"
+
+
+def test_find_none_when_absent(tmp_path):
+    assert find_nkb_file(str(tmp_path)) is None
+
+
+def test_find_none_when_ambiguous(tmp_path):
+    (tmp_path / "a.nkb").write_bytes(b"x")
+    (tmp_path / "b.nkb").write_bytes(b"x")
+    assert find_nkb_file(str(tmp_path)) is None
+
+
+# --------------------------------------------------------------------------- #
+# parse_nkb_names — transformation logic, parser stubbed
+# --------------------------------------------------------------------------- #
+class _FakeParser:
+    """Stands in for the vendored AccessParser, column->list shape."""
+
+    _TABLES = {
+        "Component": {
+            "KeyComponent": [1, 2, 3, 4],
+            "KeyLocation": [10, 11, 99, 10],
+            "PhysicalAddress": [3692, 859264, -1, 0],  # 0E6C, 0D1C80, scene, skip
+            "StrUserName": ["Dimcontroller", "Canape", "Scene - Dinner", ""],
+        },
+        "Location": {
+            "KeyLocation": [10, 11, 99],
+            "StrUserName": ["Centrale", "Living", "S_DB_GROUPS"],
+        },
+    }
+
+    def __init__(self, _path):
+        pass
+
+    def parse_table(self, name):
+        return self._TABLES[name]
+
+
+def _make_nkb_zip(tmp_path):
+    nkb = tmp_path / "p.nkb"
+    with zipfile.ZipFile(nkb, "w") as zf:
+        zf.writestr("__niko__.mdb", b"dummy-bytes")
+    return nkb
+
+
+def test_parse_maps_addresses_rooms_and_scenes(tmp_path):
+    nkb = _make_nkb_zip(tmp_path)
+    with patch(
+        "custom_components.nikobus.vendor.access_parser.AccessParser", _FakeParser
+    ):
+        result = parse_nkb_names(nkb)
+    assert isinstance(result, NkbNames)
+    # PhysicalAddress decimal -> 24-bit hex, with room label
+    assert result.addresses == {
+        "000E6C": "Dimcontroller (Centrale)",
+        "0D1C80": "Canape (Living)",
+    }
+    # PhysicalAddress == -1 -> scene name, no room (group sentinel stripped)
+    assert result.scenes == {"Scene - Dinner": ""}
+
+
+def test_parse_raises_without_mdb(tmp_path):
+    nkb = tmp_path / "bad.nkb"
+    with zipfile.ZipFile(nkb, "w") as zf:
+        zf.writestr("notes.txt", b"no mdb here")
+    with pytest.raises(ValueError):
+        parse_nkb_names(nkb)
+
+
+# --------------------------------------------------------------------------- #
+# coordinator.async_import_nkb_names — registry apply + non-clobber guards
+# --------------------------------------------------------------------------- #
+def _coord():
+    from custom_components.nikobus.coordinator import NikobusDataCoordinator
+
+    c = NikobusDataCoordinator.__new__(NikobusDataCoordinator)
+    c.hass = MagicMock()
+    c.hass.config.config_dir = "/cfg"
+
+    async def _aaej(fn, *a):
+        return fn(*a)
+
+    c.hass.async_add_executor_job = _aaej
+    c.config_entry = MagicMock()
+    c.config_entry.entry_id = "E1"
+    return c
+
+
+def _device(dev_id, addr, name="old", name_by_user=None):
+    d = MagicMock()
+    d.id = dev_id
+    d.identifiers = {("nikobus", addr)}
+    d.name = name
+    d.name_by_user = name_by_user
+    return d
+
+
+def _entity(eid, device_id, name=None, original_name=None):
+    e = MagicMock()
+    e.entity_id = eid
+    e.device_id = device_id
+    e.name = name
+    e.original_name = original_name
+    return e
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_import_names_devices_and_single_entity():
+    c = _coord()
+    names = NkbNames(
+        addresses={"0E6C": "Dimcontroller (Centrale)", "1843B4": "Entree (Living)"},
+        scenes={"Scene - TV": ""},
+    )
+    # dimmer device: 3 entities -> device renamed, entities inherit (not renamed)
+    # button device: 1 entity, no user name -> both renamed
+    dev_dim = _device("d1", "0E6C")
+    dev_btn = _device("d2", "1843B4")
+    dev_unmatched = _device("d3", "FFFFFF")
+    devices = [dev_dim, dev_btn, dev_unmatched]
+    entities = [
+        _entity("light.a", "d1"),
+        _entity("light.b", "d1"),
+        _entity("light.c", "d1"),
+        _entity("binary_sensor.btn", "d2", name=None, original_name="Key A"),
+    ]
+    dev_reg, ent_reg = MagicMock(), MagicMock()
+
+    with patch("custom_components.nikobus.nkbnames.find_nkb_file",
+               return_value=__import__("pathlib").Path("/cfg/nikobus.nkb")), \
+         patch("custom_components.nikobus.nkbnames.parse_nkb_names",
+               return_value=names), \
+         patch("custom_components.nikobus.coordinator.dr.async_get",
+               return_value=dev_reg), \
+         patch("custom_components.nikobus.coordinator.er.async_get",
+               return_value=ent_reg), \
+         patch("custom_components.nikobus.coordinator.dr.async_entries_for_config_entry",
+               return_value=devices, create=True), \
+         patch("custom_components.nikobus.coordinator.er.async_entries_for_config_entry",
+               return_value=entities, create=True):
+        result = _run(c.async_import_nkb_names())
+
+    assert result == {"devices": 2, "entities": 1, "addresses": 2, "scenes": 1}
+    # both matched devices renamed
+    renamed = {ca.args[0]: ca.kwargs["name"]
+               for ca in dev_reg.async_update_device.call_args_list}
+    assert renamed == {"d1": "Dimcontroller (Centrale)", "d2": "Entree (Living)"}
+    # only the single-entity device's entity renamed
+    ent_reg.async_update_entity.assert_called_once_with(
+        "binary_sensor.btn", name="Entree (Living)"
+    )
+
+
+def test_import_preserves_user_named_entity():
+    c = _coord()
+    names = NkbNames(addresses={"1843B4": "Entree (Living)"}, scenes={})
+    dev_btn = _device("d2", "1843B4")
+    # entity already user-named -> must NOT be touched
+    ent = _entity("binary_sensor.btn", "d2", name="My Custom Name")
+    dev_reg, ent_reg = MagicMock(), MagicMock()
+    with patch("custom_components.nikobus.nkbnames.find_nkb_file",
+               return_value=__import__("pathlib").Path("/cfg/x.nkb")), \
+         patch("custom_components.nikobus.nkbnames.parse_nkb_names",
+               return_value=names), \
+         patch("custom_components.nikobus.coordinator.dr.async_get",
+               return_value=dev_reg), \
+         patch("custom_components.nikobus.coordinator.er.async_get",
+               return_value=ent_reg), \
+         patch("custom_components.nikobus.coordinator.dr.async_entries_for_config_entry",
+               return_value=[dev_btn], create=True), \
+         patch("custom_components.nikobus.coordinator.er.async_entries_for_config_entry",
+               return_value=[ent], create=True):
+        result = _run(c.async_import_nkb_names())
+    assert result["entities"] == 0
+    ent_reg.async_update_entity.assert_not_called()
+
+
+def test_import_raises_when_no_file():
+    from homeassistant.exceptions import HomeAssistantError
+
+    c = _coord()
+    with patch("custom_components.nikobus.nkbnames.find_nkb_file",
+               return_value=None):
+        with pytest.raises(HomeAssistantError):
+            _run(c.async_import_nkb_names())


### PR DESCRIPTION
This branch now carries two releases (single working branch):

## 3.3.0 — Import device/entity names from a `.nkb` project file

A `.nkb` is a ZIP holding `__niko__.mdb` (MS Access). The Nikobus PC software stores every module / button / IR-receiver name + room there. This reads it directly in HA and applies the names.

- **New bridge button "Import Names from .nkb".** Drop your `.nkb` in the HA config dir (ideally `nikobus.nkb`) and press it. Names applied as `Name (Room)` keyed on the bus address (`PhysicalAddress` decimal → 24-bit hex), e.g. `Dimcontroller (Centrale)`, `Entree (Living)`.
- **Non-destructive / suggested.** Manual renames (`name_by_user`, entity user-name) are never overwritten. Multi-channel modules are named at the device level (channels inherit); single-entity devices also get their entity row named — no per-channel duplication.
- **No external services.** Pure-Python: vendored Apache-2.0 `access_parser` (tabulate stripped) + the `construct` dependency. The file never leaves the machine.
- Scenes (Central Functions) have no bus address, so their names aren't auto-applied yet (later step).
- Validated end-to-end against a real export: 46 addressed names + 9 scene names.

New: `nkbnames.py` (find + parse, runs in executor), `coordinator.async_import_nkb_names` (registry apply), vendored parser under `custom_components/nikobus/vendor/`, `construct>=2.10` requirement, EN/FR/NL strings, `test_nkbnames.py` (9 tests). Suite: **362 passed**.

## 3.2.1 — Cosmetics (already on this branch)

- Renamed the two discovery buttons to Nikobus-software terms: **Load Project Overview** / **Load Existing Installation** (EN/FR/NL).
- Discovery progress bar now spans **0→100 % per button** (Load Existing Installation previously opened at 30 %, the floor of the phases it skips).

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj