### PR TITLE
3.3.1: ship the numbered config-button order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.3.1
+
+- Numbered the three bridge config buttons so they show in the intended
+  order (**1. Load Project Overview**, **2. Load Existing Installation**,
+  **3. Import Names from .nkb**) — HA sorts them alphabetically, which
+  otherwise put "Load Existing Installation" first. Display name only
+  (EN/FR/NL); entity ids unchanged.
+
 ## 3.3.0
 
 **Import device & entity names from your Nikobus `.nkb` project file.**

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -63,13 +63,13 @@
   "entity": {
     "button": {
       "discover_modules_buttons": {
-        "name": "Load Project Overview"
+        "name": "1. Load Project Overview"
       },
       "scan_all_module_links": {
-        "name": "Load Existing Installation"
+        "name": "2. Load Existing Installation"
       },
       "import_nkb_names": {
-        "name": "Import Names from .nkb"
+        "name": "3. Import Names from .nkb"
       }
     },
     "sensor": {

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -147,13 +147,13 @@
     },
     "button": {
       "discover_modules_buttons": {
-        "name": "Charger l'aperçu du projet"
+        "name": "1. Charger l'aperçu du projet"
       },
       "scan_all_module_links": {
-        "name": "Charger l'installation existante"
+        "name": "2. Charger l'installation existante"
       },
       "import_nkb_names": {
-        "name": "Importer les noms depuis .nkb"
+        "name": "3. Importer les noms depuis .nkb"
       }
     }
   },

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -147,13 +147,13 @@
     },
     "button": {
       "discover_modules_buttons": {
-        "name": "Projectoverzicht laden"
+        "name": "1. Projectoverzicht laden"
       },
       "scan_all_module_links": {
-        "name": "Bestaande installatie laden"
+        "name": "2. Bestaande installatie laden"
       },
       "import_nkb_names": {
-        "name": "Namen importeren uit .nkb"
+        "name": "3. Namen importeren uit .nkb"
       }
     }
   },


### PR DESCRIPTION
The config buttons sort alphabetically in HA, so **3.3.0 shipped them in the wrong order** ("Load Existing Installation" above "Load Project Overview"). The fix landed on the branch *after* 3.3.0 was already cut, so it never reached the release.

This PR ships it:

- Numeric prefixes on the three bridge buttons → deterministic order:
  1. Load Project Overview
  2. Load Existing Installation
  3. Import Names from .nkb
- EN / FR / NL. Display name only — entity ids unchanged.
- Manifest bumped to **3.3.1** so HACS actually delivers it.

After merge, cut a **3.3.1** release so users get the corrected labels.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_