### PR TITLE
3.3.2: fix Import-Names button evicted by orphan-cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 3.3.2
+
+- **Fix: the "Import Names from .nkb" button never appeared.** Its
+  unique_id was missing from the known-entity allowlist, so the startup
+  orphan-cleanup evicted it immediately after the button platform created
+  it (visible as the entity flashing in, then vanishing). Added it to the
+  allowlist alongside the other two bridge buttons, with a regression test
+  covering all three.
+
 ## 3.3.1
 
 - Numbered the three bridge config buttons so they show in the intended

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -1366,6 +1366,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         known.add(f"{DOMAIN}_discovery_progress")
         known.add(f"{DOMAIN}_pc_link_inventory_button")
         known.add(f"{DOMAIN}_module_scan_button")
+        known.add(f"{DOMAIN}_import_nkb_names_button")
         return known
 
     def _rebuild_dict_module_data(self) -> None:

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/tests/test_known_entity_cf_scenes.py
+++ b/tests/test_known_entity_cf_scenes.py
@@ -53,5 +53,19 @@ class TestKnownEntityIdsIncludeCFScenes(unittest.TestCase):
         self.assertIsInstance(known, set)
 
 
+class TestKnownEntityIdsIncludeBridgeButtons(unittest.TestCase):
+    """The three hub config buttons must be in the known-id set, else the
+    orphan cleanup evicts them right after the button platform creates them
+    (the import-names button regressed exactly this way: created then
+    immediately removed at startup)."""
+
+    def test_all_three_bridge_buttons_are_known(self):
+        coord = _coord_with_cfs([])
+        known = coord.get_known_entity_unique_ids()
+        self.assertIn("nikobus_pc_link_inventory_button", known)
+        self.assertIn("nikobus_module_scan_button", known)
+        self.assertIn("nikobus_import_nkb_names_button", known)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## The bug

The **"Import Names from .nkb"** button was created by the button platform but **immediately evicted at startup** — you could literally see it flash into the device card and disappear, and it never landed in the entity registry.

Root cause: `_async_cleanup_orphan_entities` removes any Nikobus entity whose `unique_id` isn't returned by `get_known_entity_unique_ids()`. That allowlist included the other two bridge buttons (`nikobus_pc_link_inventory_button`, `nikobus_module_scan_button`) but **not** `nikobus_import_nkb_names_button` — so the cleanup deleted it on every load. Reboots couldn't help; the cleanup ran each time.

This is why diagnostics showed 3.3.1 loaded, the labels updated, but the third button was absent from both the registry and `states`.

## The fix

- Add `nikobus_import_nkb_names_button` to `get_known_entity_unique_ids()`.
- Regression test pins **all three** bridge buttons in the known set so this can't recur.

Patch release **3.3.2**.

## After merge
Release 3.3.2 → HACS update → restart. The third button will now stick.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_