### PR TITLE
3.5.0: .nkb import — names, Areas &amp; scenes (incl. shutter/master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 3.4.0
+
+`.nkb` import v2 — rooms become Areas, and scenes get their real names.
+
+- **Rooms → Home Assistant Areas.** "Import Names from .nkb" now places each
+  device in an **Area** matching its `.nkb` room (`Living`, `Cuisine`,
+  `Chambre Parents`…), and the device name no longer carries the `(Room)`
+  suffix — the Area provides that context. An Area you've already assigned
+  by hand is never changed.
+- **Scene names.** A named Central Function group in the `.nkb`
+  (`Scene - Dinner`, `Scene - TV`…) is matched to a discovered CF entity by
+  **member set** — the group has no bus address, but its trigger's output
+  links spell out the exact `(module, channel, mode)` set discovery reads,
+  so the match is unambiguous (an on-scene and an off-scene on the same
+  channels stay distinct because the mode differs). The matched CF's
+  device/entity is then named.
+- Fixed a latent address-format bug: 16-bit **module** addresses are keyed
+  as 4-hex (`0E6C`), 24-bit button/IR addresses as 6-hex (`1843B4`) — so
+  module names now match (previously they'd have been missed).
+
 ## 3.3.2
 
 - **Fix: the "Import Names from .nkb" button never appeared.** Its

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -568,9 +568,12 @@ class NikobusImportNkbNamesButton(ButtonEntity):
         _LOGGER.info("Importing Nikobus names from .nkb via UI button")
         result = await self._coordinator.async_import_nkb_names()
         _LOGGER.info(
-            "Nikobus .nkb name import done: %s devices, %s entities",
+            "Nikobus .nkb import done: %s devices, %s entities, %s areas, "
+            "%s scenes",
             result["devices"],
             result["entities"],
+            result["areas"],
+            result["scenes"],
         )
 
 

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -2345,21 +2345,30 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             raise
 
     async def async_import_nkb_names(self) -> dict[str, int]:
-        """Import user names from a ``.nkb`` project file in the config dir.
+        """Import names, rooms and scene names from a ``.nkb`` project file.
 
         Reads the Nikobus PC-software export (a ZIP holding an MS Access
-        DB) and applies its module / button / IR-receiver names — each as
-        ``Name (Room)`` keyed on the bus address — as **suggested**
-        device and entity names.
+        DB) and applies, all **suggested** / non-destructive:
 
-        Non-destructive: a device's user rename (``name_by_user``) is
-        never touched, and an entity is only named when it has no user
-        override. Entity rows are named only for single-entity devices;
-        multi-channel modules rely on device-name inheritance so we don't
-        stamp the same name onto every channel. Returns a summary dict
-        (``devices`` / ``entities`` / ``addresses`` / ``scenes``).
+        * **Device + entity names** — module / button / IR-receiver names
+          keyed on the bus address. A device's user rename
+          (``name_by_user``) is never touched; an entity is named only
+          when it has no user override, and only on single-entity devices
+          (multi-channel modules inherit the device name).
+        * **Areas** — each device is placed in a Home Assistant Area
+          matching its ``.nkb`` room (unless the user already set one).
+        * **Scene names** — a named Central Function group is matched to a
+          discovered CF entity by **member set** (the group has no bus
+          address; its trigger's output links spell out the same
+          ``(module, channel, mode)`` set discovery reads), then the CF's
+          device/entity is named.
+
+        Returns a summary (``devices`` / ``entities`` / ``areas`` /
+        ``scenes``).
         """
-        from .nkbnames import find_nkb_file, parse_nkb_names
+        from homeassistant.helpers import area_registry as ar
+
+        from .nkbnames import _mode_code, find_nkb_file, parse_nkb
 
         path = find_nkb_file(self.hass.config.config_dir)
         if path is None:
@@ -2367,7 +2376,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 translation_domain=DOMAIN, translation_key="nkb_not_found"
             )
         try:
-            names = await self.hass.async_add_executor_job(parse_nkb_names, path)
+            data = await self.hass.async_add_executor_job(parse_nkb, path)
         except Exception as err:
             _LOGGER.exception("Failed to read .nkb file %s", path)
             raise HomeAssistantError(
@@ -2376,59 +2385,96 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 translation_placeholders={"error": str(err)},
             ) from err
 
-        name_map = names.addresses  # {ADDRESS_HEX_UPPER: "Name (Room)"}
+        name_map = data.addresses  # {ADDR: (name, room)}
+
+        # Match named scene groups to discovered CF entities by member set
+        # → {CF_wire_address_upper: scene_name}.
+        scene_by_members = {sc.members: sc.name for sc in data.scenes}
+        cf_name_by_addr: dict[str, str] = {}
+        if self.cf_storage is not None:
+            for cf_addr, cf in self.cf_storage.data.get("nikobus_cf", {}).items():
+                members = frozenset(
+                    (
+                        str(o.get("module_address")).upper(),
+                        int(o["channel"]),
+                        _mode_code(o.get("mode")),
+                    )
+                    for o in (cf.get("outputs") or [])
+                    if isinstance(o, dict)
+                    and o.get("module_address")
+                    and isinstance(o.get("channel"), int)
+                    and _mode_code(o.get("mode"))
+                )
+                hit = scene_by_members.get(members)
+                if hit:
+                    cf_name_by_addr[str(cf_addr).upper()] = hit
+
         dev_reg = dr.async_get(self.hass)
         ent_reg = er.async_get(self.hass)
+        area_reg = ar.async_get(self.hass)
         entry_id = self.config_entry.entry_id
 
-        # 1. Devices — match any identifier address against the name map.
-        matched: dict[str, str] = {}  # device_id -> imported name
-        devices_named = 0
-        for device in dr.async_entries_for_config_entry(dev_reg, entry_id):
-            imported = next(
-                (
-                    name_map[ident.upper()]
-                    for domain, ident in device.identifiers
-                    if domain == DOMAIN and ident.upper() in name_map
-                ),
-                None,
-            )
-            if imported is None:
-                continue
-            matched[device.id] = imported
-            if device.name != imported:
-                dev_reg.async_update_device(device.id, name=imported)
-                devices_named += 1
+        def _lookup(device) -> tuple[str, str] | None:
+            """(name, room) for a device from address names or scene match."""
+            for domain, ident in device.identifiers:
+                if domain != DOMAIN:
+                    continue
+                key = ident.upper()
+                if key in name_map:
+                    return name_map[key]
+                if key in cf_name_by_addr:
+                    return (cf_name_by_addr[key], "")
+            return None
 
-        # 2. Entities — only for single-entity matched devices, and only
-        # when the user hasn't set their own name. Multi-entity devices
-        # inherit the device name instead (no per-channel duplication).
+        # 1. Devices — name (room dropped; the Area carries it) + Area.
+        matched: dict[str, str] = {}  # device_id -> name
+        devices_named = areas_set = 0
+        for device in dr.async_entries_for_config_entry(dev_reg, entry_id):
+            hit = _lookup(device)
+            if hit is None:
+                continue
+            name, room = hit
+            matched[device.id] = name
+            if device.name != name:
+                dev_reg.async_update_device(device.id, name=name)
+                devices_named += 1
+            if room and device.area_id is None:
+                area = area_reg.async_get_area_by_name(
+                    room
+                ) or area_reg.async_create(room)
+                dev_reg.async_update_device(device.id, area_id=area.id)
+                areas_set += 1
+
+        # 2. Entities — single-entity matched devices only, never clobbering
+        # a user-set name.
         by_device: dict[str, list] = {}
         for ent in er.async_entries_for_config_entry(ent_reg, entry_id):
             if ent.device_id:
                 by_device.setdefault(ent.device_id, []).append(ent)
         entities_named = 0
-        for device_id, imported in matched.items():
+        for device_id, name in matched.items():
             ents = by_device.get(device_id, [])
             if len(ents) != 1:
                 continue
             ent = ents[0]
-            if ent.name is None and ent.original_name != imported:
-                ent_reg.async_update_entity(ent.entity_id, name=imported)
+            if ent.name is None and ent.original_name != name:
+                ent_reg.async_update_entity(ent.entity_id, name=name)
                 entities_named += 1
 
         _LOGGER.info(
-            "Imported .nkb names from %s: %d devices, %d entities renamed "
-            "(%d addresses, %d scenes in file)",
+            "Imported .nkb from %s: %d devices, %d entities, %d areas, "
+            "%d scenes (%d addresses, %d scene groups in file)",
             path.name,
             devices_named,
             entities_named,
+            areas_set,
+            len(cf_name_by_addr),
             len(name_map),
-            len(names.scenes),
+            len(data.scenes),
         )
         return {
             "devices": devices_named,
             "entities": entities_named,
-            "addresses": len(name_map),
-            "scenes": len(names.scenes),
+            "areas": areas_set,
+            "scenes": len(cf_name_by_addr),
         }

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "3.3.2",
+  "version": "3.4.0",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/custom_components/nikobus/nkbnames.py
+++ b/custom_components/nikobus/nkbnames.py
@@ -1,25 +1,27 @@
-"""Read user-given names from a Nikobus ``.nkb`` project file.
+"""Read user-given names + scenes from a Nikobus ``.nkb`` project file.
 
 A ``.nkb`` is a ZIP holding ``__niko__.mdb`` — an MS Access (JET)
-database. The Nikobus PC software stores every module / button / IR
-receiver under a user-given name in the ``Component`` table, keyed by
-``PhysicalAddress`` (the decimal of the 24-bit bus address), with the
-room in ``Location``. Central Functions / scenes appear as ``Component``
-rows with ``PhysicalAddress == -1`` (no bus address — named only here).
+database. We surface three things for the integration to apply:
 
-We surface the addressable names as ``{ADDRESS: "Name (Room)"}`` for the
-integration to apply as suggested device / entity names, plus the
-address-less scene names for reference.
+* **addresses** — ``{ADDRESS: (name, room)}`` for every module / button /
+  IR receiver (``Component`` keyed by ``PhysicalAddress``, room from
+  ``Location``). Applied as suggested device/entity names + HA Areas.
+* **scenes** — each Central Function group (``Scene - Dinner`` …) with the
+  set of output members that realise it, so we can match a named group to
+  a discovered CF entity by **member set** (the group has no bus address
+  of its own, but its trigger's output links spell out exactly which
+  ``(module, channel, mode)`` it drives — identical to what discovery
+  reads from the modules).
 
-Everything here is best-effort: parsing is wrapped so a malformed or
-unsupported ``.nkb`` never breaks the integration — the caller logs and
-skips. The Access reader is vendored (``.vendor.access_parser``) and the
-only runtime dependency is ``construct``.
+Everything is best-effort: a malformed/unsupported ``.nkb`` raises and the
+caller degrades gracefully. Only ``construct`` is needed at runtime (the
+Access reader is vendored).
 """
 
 from __future__ import annotations
 
 import logging
+import re
 import tempfile
 import zipfile
 from pathlib import Path
@@ -27,28 +29,59 @@ from typing import NamedTuple
 
 _LOGGER = logging.getLogger(__name__)
 
-# Canonical filename we look for first; otherwise any single *.nkb.
 CANONICAL_NKB_FILENAME = "nikobus.nkb"
 
-# A room bucket the software uses for virtual groups (scenes); not a real room.
+# Location bucket the software uses for virtual groups (scenes), not a room.
 _GROUP_LOCATION_SENTINEL = "S_DB_GROUPS"
 
+# Connection mode that links an input to a Central Function group.
+_MCF_MODE = "MCF"
 
-class NkbNames(NamedTuple):
-    """Result of parsing a ``.nkb``."""
+_MODE_CODE_RE = re.compile(r"M\d+", re.IGNORECASE)
 
-    #: ``{ADDRESS_HEX_UPPER: "Name (Room)"}`` for modules / buttons / receivers.
-    addresses: dict[str, str]
-    #: ``{scene_name: room}`` for Central Functions with no bus address.
-    scenes: dict[str, str]
+
+def _fmt_addr(physical_address: int) -> str:
+    """Format a ``PhysicalAddress`` to match our bus-address identifiers.
+
+    Module addresses are 16-bit → 4 hex (``0E6C``); button / IR / RF
+    addresses are 24-bit → 6 hex (``1843B4``). Matching the natural width
+    is essential: our device identifiers use ``0E6C``, not ``000E6C``.
+    """
+    v = physical_address & 0xFFFFFF
+    return f"{v:04X}" if v < 0x10000 else f"{v:06X}"
+
+
+def _mode_code(mode: object) -> str | None:
+    """Leading ``M<n>`` code of a mode string (``"M12 (Preset on)"`` ->
+    ``"M12"``; ``"M12"`` -> ``"M12"``), or ``None``."""
+    if not isinstance(mode, str):
+        return None
+    m = _MODE_CODE_RE.match(mode.strip())
+    return m.group(0).upper() if m else None
+
+
+class SceneDef(NamedTuple):
+    """A named Central Function group and the outputs it drives."""
+
+    name: str
+    #: ``frozenset`` of ``(module_addr_upper, channel, mode_code)``.
+    members: frozenset
+
+
+class NkbData(NamedTuple):
+    """Everything we extract from a ``.nkb``."""
+
+    #: ``{ADDRESS_HEX_UPPER: (name, room)}`` — room is ``""`` if none.
+    addresses: dict[str, tuple[str, str]]
+    #: Named scene groups with member sets, for member-set matching.
+    scenes: list[SceneDef]
 
 
 def find_nkb_file(config_dir: str) -> Path | None:
     """Return the ``.nkb`` to import from ``config_dir``, or ``None``.
 
-    Prefers the canonical ``nikobus.nkb``; otherwise accepts a single
-    ``*.nkb`` in the directory. With several ``*.nkb`` and no canonical
-    one we decline (ambiguous) and return ``None``.
+    Prefers the canonical ``nikobus.nkb``; otherwise a single ``*.nkb``.
+    Declines (``None``) when several ``*.nkb`` exist and none is canonical.
     """
     base = Path(config_dir)
     canonical = base / CANONICAL_NKB_FILENAME
@@ -67,13 +100,12 @@ def find_nkb_file(config_dir: str) -> Path | None:
     return None
 
 
-def parse_nkb_names(nkb_path: str | Path) -> NkbNames:
-    """Parse ``nkb_path`` and return its names. Blocking — run in executor.
+def parse_nkb(nkb_path: str | Path) -> NkbData:
+    """Parse ``nkb_path``. Blocking — run in an executor.
 
     Raises on a genuinely unreadable file (bad zip / no mdb / parser
     failure); the caller is expected to catch and degrade gracefully.
     """
-    # Lazy import so a parser/construct issue can't break integration load.
     from .vendor.access_parser import AccessParser
 
     with tempfile.TemporaryDirectory() as tmp:
@@ -89,24 +121,101 @@ def parse_nkb_names(nkb_path: str | Path) -> NkbNames:
         locations = {
             r["KeyLocation"]: r["StrUserName"] for r in _rows(db, "Location")
         }
+        objecten = _rows(db, "Objecten")
+        connections = _rows(db, "Connection")
+        linkmodes = {
+            r["KeyLinkMode"]: r.get("StrMode") for r in _rows(db, "LinkModeBase")
+        }
+        objectbase = {r["KeyObjectBase"]: r for r in _rows(db, "ObjectBase")}
 
-    addresses: dict[str, str] = {}
-    scenes: dict[str, str] = {}
+    comp_by_key = {c["KeyComponent"]: c for c in components}
+
+    addresses = _extract_addresses(components, locations)
+    scenes = _extract_scenes(
+        components, comp_by_key, objecten, connections, linkmodes, objectbase
+    )
+    return NkbData(addresses=addresses, scenes=scenes)
+
+
+def _extract_addresses(
+    components: list[dict], locations: dict
+) -> dict[str, tuple[str, str]]:
+    """``{ADDRESS: (name, room)}`` for the physically-addressed components."""
+    out: dict[str, tuple[str, str]] = {}
     for comp in components:
         name = (comp.get("StrUserName") or "").strip()
         if not name:
             continue
-        room = locations.get(comp.get("KeyLocation")) or ""
-        room_label = "" if room == _GROUP_LOCATION_SENTINEL else room
         pa = comp.get("PhysicalAddress")
-        if isinstance(pa, int) and pa > 0:
-            addr = f"{pa & 0xFFFFFF:06X}"
-            addresses[addr] = f"{name} ({room_label})" if room_label else name
-        else:
-            # PhysicalAddress == -1 → a Central Function / scene group.
-            scenes[name] = room_label
+        if not (isinstance(pa, int) and pa > 0):
+            continue  # -1 == a scene group (no bus address)
+        room = locations.get(comp.get("KeyLocation")) or ""
+        if room == _GROUP_LOCATION_SENTINEL:
+            room = ""
+        out[_fmt_addr(pa)] = (name, room)
+    return out
 
-    return NkbNames(addresses=addresses, scenes=scenes)
+
+def _extract_scenes(
+    components, comp_by_key, objecten, connections, linkmodes, objectbase
+) -> list[SceneDef]:
+    """Resolve each named CF group to its ``(module, channel, mode)`` members.
+
+    Group → MCF connection → trigger input object → that input's output
+    connections (the real link records) → members. The group object itself
+    carries only the trigger link; the membership lives on the trigger.
+    """
+    obj_by_key = {o["KeyObject"]: o for o in objecten}
+    objs_by_component: dict[object, set] = {}
+    for o in objecten:
+        objs_by_component.setdefault(o.get("KeyComponent"), set()).add(o["KeyObject"])
+    conns_by_in: dict[object, list] = {}
+    for cn in connections:
+        conns_by_in.setdefault(cn["KeyObjectIn"], []).append(cn)
+
+    def module_addr(obj) -> str | None:
+        comp = comp_by_key.get((obj or {}).get("KeyComponent"), {})
+        pa = comp.get("PhysicalAddress")
+        return _fmt_addr(pa) if isinstance(pa, int) and pa > 0 else None
+
+    def channel(obj) -> int | None:
+        base = objectbase.get((obj or {}).get("KeyObjectBase"), {})
+        oa = base.get("ObjectAddress")
+        return (oa + 1) if isinstance(oa, int) else None
+
+    scenes: list[SceneDef] = []
+    for comp in components:
+        if comp.get("PhysicalAddress") != -1:
+            continue
+        name = (comp.get("StrUserName") or "").strip()
+        if not name:
+            continue
+        group_objs = objs_by_component.get(comp["KeyComponent"], set())
+
+        # Trigger input objects = the IN side of each MCF connection whose
+        # OUT side is one of the group's objects.
+        triggers = {
+            cn["KeyObjectIn"]
+            for cn in connections
+            if cn["KeyObjectOut"] in group_objs
+            and linkmodes.get(cn["KeyLinkMode"]) == _MCF_MODE
+        }
+
+        members: set[tuple[str, int, str]] = set()
+        for trig in triggers:
+            for cn in conns_by_in.get(trig, []):
+                code = _mode_code(linkmodes.get(cn["KeyLinkMode"]))
+                if code is None:  # MCF / unknown — not an output member
+                    continue
+                out_obj = obj_by_key.get(cn["KeyObjectOut"])
+                ma = module_addr(out_obj)
+                ch = channel(out_obj)
+                if ma and ch is not None:
+                    members.add((ma, ch, code))
+
+        if members:
+            scenes.append(SceneDef(name=name, members=frozenset(members)))
+    return scenes
 
 
 def _rows(db, table: str) -> list[dict]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,6 +130,9 @@ _mod(
 # homeassistant.helpers.entity_registry
 _mod("homeassistant.helpers.entity_registry", async_get=lambda hass: None)
 
+# homeassistant.helpers.area_registry
+_mod("homeassistant.helpers.area_registry", async_get=lambda hass: None)
+
 # homeassistant.helpers.issue_registry — used by coordinator.refresh_repair_issues
 class _IssueSeverity:
     WARNING = "warning"

--- a/tests/test_nkbnames.py
+++ b/tests/test_nkbnames.py
@@ -1,19 +1,40 @@
-"""Tests for .nkb name extraction and the registry-apply import."""
+"""Tests for .nkb parsing (names + rooms + scenes) and the registry apply."""
 
 from __future__ import annotations
 
 import asyncio
 import zipfile
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from custom_components.nikobus.nkbnames import (
     CANONICAL_NKB_FILENAME,
-    NkbNames,
+    NkbData,
+    SceneDef,
+    _fmt_addr,
+    _mode_code,
     find_nkb_file,
-    parse_nkb_names,
+    parse_nkb,
 )
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def test_fmt_addr_module_is_4hex_button_is_6hex():
+    assert _fmt_addr(3692) == "0E6C"      # 0x0E6C, 16-bit module
+    assert _fmt_addr(37900) == "940C"
+    assert _fmt_addr(1590196) == "1843B4"  # 24-bit button
+    assert _fmt_addr(859264) == "0D1C80"
+
+
+def test_mode_code_extracts_leading_m():
+    assert _mode_code("M12 (Preset on)") == "M12"
+    assert _mode_code("M04") == "M04"
+    assert _mode_code("MCF") is None
+    assert _mode_code(None) is None
 
 
 # --------------------------------------------------------------------------- #
@@ -41,21 +62,49 @@ def test_find_none_when_ambiguous(tmp_path):
 
 
 # --------------------------------------------------------------------------- #
-# parse_nkb_names — transformation logic, parser stubbed
+# parse_nkb — addresses, rooms, scene member sets (parser stubbed)
 # --------------------------------------------------------------------------- #
 class _FakeParser:
-    """Stands in for the vendored AccessParser, column->list shape."""
+    """Stands in for the vendored AccessParser. A tiny but representative
+    install: a dimmer (0E6C/Centrale), a button (1843B4/Living), and a
+    'Scene - Test' group whose trigger drives dimmer ch1 in M12."""
 
     _TABLES = {
         "Component": {
             "KeyComponent": [1, 2, 3, 4],
             "KeyLocation": [10, 11, 99, 10],
-            "PhysicalAddress": [3692, 859264, -1, 0],  # 0E6C, 0D1C80, scene, skip
-            "StrUserName": ["Dimcontroller", "Canape", "Scene - Dinner", ""],
+            "PhysicalAddress": [3692, 1590196, -1, 0],  # 0E6C, 1843B4, scene, skip
+            "StrUserName": ["Dimcontroller", "Entree", "Scene - Test", ""],
         },
         "Location": {
             "KeyLocation": [10, 11, 99],
             "StrUserName": ["Centrale", "Living", "S_DB_GROUPS"],
+        },
+        "Objecten": {
+            "KeyObject": [100, 200, 300],
+            "KeyComponent": [1, 2, 3],     # output, trigger-input, group
+            "KeyObjectBase": [500, 600, 700],
+            "ObjectAddress": [0, 0, 0],
+            "PhysicalObjectAddress": [0, 0, 0],
+            "StrUserName": [None, "Input", None],
+        },
+        "ObjectBase": {
+            "KeyObjectBase": [500, 600, 700],
+            "ObjectAddress": [0, 0, 0],    # ch1 for the output
+            "Prefix": ["O01", "1A", "CF"],
+            "StrDescription": [None, None, None],
+        },
+        "LinkModeBase": {
+            "KeyLinkMode": [10, 13],
+            "StrMode": ["M12", "MCF"],
+        },
+        "Connection": {
+            "KeyConnection": [1, 2],
+            # MCF: group(300) -> trigger(200); member: output(100) <- trigger(200)
+            "KeyObjectOut": [300, 100],
+            "KeyObjectIn": [200, 200],
+            "KeyLinkMode": [13, 10],
+            "ParamValue1": [-1, 10],
         },
     }
 
@@ -69,38 +118,48 @@ class _FakeParser:
 def _make_nkb_zip(tmp_path):
     nkb = tmp_path / "p.nkb"
     with zipfile.ZipFile(nkb, "w") as zf:
-        zf.writestr("__niko__.mdb", b"dummy-bytes")
+        zf.writestr("__niko__.mdb", b"dummy")
     return nkb
 
 
-def test_parse_maps_addresses_rooms_and_scenes(tmp_path):
+def _parse(tmp_path):
     nkb = _make_nkb_zip(tmp_path)
     with patch(
         "custom_components.nikobus.vendor.access_parser.AccessParser", _FakeParser
     ):
-        result = parse_nkb_names(nkb)
-    assert isinstance(result, NkbNames)
-    # PhysicalAddress decimal -> 24-bit hex, with room label
-    assert result.addresses == {
-        "000E6C": "Dimcontroller (Centrale)",
-        "0D1C80": "Canape (Living)",
+        return parse_nkb(nkb)
+
+
+def test_parse_addresses_with_rooms(tmp_path):
+    data = _parse(tmp_path)
+    assert isinstance(data, NkbData)
+    assert data.addresses == {
+        "0E6C": ("Dimcontroller", "Centrale"),
+        "1843B4": ("Entree", "Living"),
     }
-    # PhysicalAddress == -1 -> scene name, no room (group sentinel stripped)
-    assert result.scenes == {"Scene - Dinner": ""}
+
+
+def test_parse_scene_member_set(tmp_path):
+    data = _parse(tmp_path)
+    assert len(data.scenes) == 1
+    sc = data.scenes[0]
+    assert sc.name == "Scene - Test"
+    # trigger(200) drives output(100)=0E6C ch1 in M12; MCF link excluded
+    assert sc.members == frozenset({("0E6C", 1, "M12")})
 
 
 def test_parse_raises_without_mdb(tmp_path):
     nkb = tmp_path / "bad.nkb"
     with zipfile.ZipFile(nkb, "w") as zf:
-        zf.writestr("notes.txt", b"no mdb here")
+        zf.writestr("notes.txt", b"no mdb")
     with pytest.raises(ValueError):
-        parse_nkb_names(nkb)
+        parse_nkb(nkb)
 
 
 # --------------------------------------------------------------------------- #
-# coordinator.async_import_nkb_names — registry apply + non-clobber guards
+# coordinator.async_import_nkb_names — names, areas, scene match
 # --------------------------------------------------------------------------- #
-def _coord():
+def _coord(cf=None):
     from custom_components.nikobus.coordinator import NikobusDataCoordinator
 
     c = NikobusDataCoordinator.__new__(NikobusDataCoordinator)
@@ -113,15 +172,19 @@ def _coord():
     c.hass.async_add_executor_job = _aaej
     c.config_entry = MagicMock()
     c.config_entry.entry_id = "E1"
+    c.cf_storage = None
+    if cf is not None:
+        c.cf_storage = MagicMock()
+        c.cf_storage.data = {"nikobus_cf": cf}
     return c
 
 
-def _device(dev_id, addr, name="old", name_by_user=None):
+def _device(dev_id, addr, name="old", area_id=None):
     d = MagicMock()
     d.id = dev_id
     d.identifiers = {("nikobus", addr)}
     d.name = name
-    d.name_by_user = name_by_user
+    d.area_id = area_id
     return d
 
 
@@ -138,80 +201,103 @@ def _run(coro):
     return asyncio.new_event_loop().run_until_complete(coro)
 
 
-def test_import_names_devices_and_single_entity():
-    c = _coord()
-    names = NkbNames(
-        addresses={"0E6C": "Dimcontroller (Centrale)", "1843B4": "Entree (Living)"},
-        scenes={"Scene - TV": ""},
+def _patches(data, devices, entities, dev_reg, ent_reg, area_reg):
+    import contextlib
+
+    @contextlib.contextmanager
+    def ctx():
+        with patch("custom_components.nikobus.nkbnames.find_nkb_file",
+                   return_value=Path("/cfg/nikobus.nkb")), \
+             patch("custom_components.nikobus.nkbnames.parse_nkb",
+                   return_value=data), \
+             patch("homeassistant.helpers.area_registry.async_get",
+                   return_value=area_reg, create=True), \
+             patch("custom_components.nikobus.coordinator.dr.async_get",
+                   return_value=dev_reg), \
+             patch("custom_components.nikobus.coordinator.er.async_get",
+                   return_value=ent_reg), \
+             patch("custom_components.nikobus.coordinator.dr.async_entries_for_config_entry",
+                   return_value=devices, create=True), \
+             patch("custom_components.nikobus.coordinator.er.async_entries_for_config_entry",
+                   return_value=entities, create=True):
+            yield
+    return ctx()
+
+
+def test_import_names_areas_and_scene_match():
+    data = NkbData(
+        addresses={
+            "0E6C": ("Dimcontroller", "Centrale"),
+            "1843B4": ("Entree", "Living"),
+        },
+        scenes=[SceneDef("Scene - Test", frozenset({("0E6C", 1, "M12")}))],
     )
-    # dimmer device: 3 entities -> device renamed, entities inherit (not renamed)
-    # button device: 1 entity, no user name -> both renamed
-    dev_dim = _device("d1", "0E6C")
-    dev_btn = _device("d2", "1843B4")
-    dev_unmatched = _device("d3", "FFFFFF")
-    devices = [dev_dim, dev_btn, dev_unmatched]
+    # a CF whose members match the scene -> should be named
+    coord = _coord(cf={"DE4E2C": {
+        "outputs": [{"module_address": "0E6C", "channel": 1,
+                     "mode": "M12 (Preset on)"}]}})
+
+    dev_dim = _device("d1", "0E6C")               # module, 3 entities
+    dev_btn = _device("d2", "1843B4")             # button, 1 entity
+    dev_cf = _device("d3", "DE4E2C", name="Nikobus scene DE4E2C")
+    devices = [dev_dim, dev_btn, dev_cf]
     entities = [
-        _entity("light.a", "d1"),
-        _entity("light.b", "d1"),
-        _entity("light.c", "d1"),
-        _entity("binary_sensor.btn", "d2", name=None, original_name="Key A"),
+        _entity("light.a", "d1"), _entity("light.b", "d1"),
+        _entity("binary_sensor.btn", "d2", original_name="Key A"),
+        _entity("scene.de4e2c", "d3"),
     ]
-    dev_reg, ent_reg = MagicMock(), MagicMock()
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    area = MagicMock()
+    area.id = "area_living"
+    area_reg.async_get_area_by_name.return_value = None
+    area_reg.async_create.return_value = area
 
-    with patch("custom_components.nikobus.nkbnames.find_nkb_file",
-               return_value=__import__("pathlib").Path("/cfg/nikobus.nkb")), \
-         patch("custom_components.nikobus.nkbnames.parse_nkb_names",
-               return_value=names), \
-         patch("custom_components.nikobus.coordinator.dr.async_get",
-               return_value=dev_reg), \
-         patch("custom_components.nikobus.coordinator.er.async_get",
-               return_value=ent_reg), \
-         patch("custom_components.nikobus.coordinator.dr.async_entries_for_config_entry",
-               return_value=devices, create=True), \
-         patch("custom_components.nikobus.coordinator.er.async_entries_for_config_entry",
-               return_value=entities, create=True):
-        result = _run(c.async_import_nkb_names())
+    with _patches(data, devices, entities, dev_reg, ent_reg, area_reg):
+        result = _run(coord.async_import_nkb_names())
 
-    assert result == {"devices": 2, "entities": 1, "addresses": 2, "scenes": 1}
-    # both matched devices renamed
-    renamed = {ca.args[0]: ca.kwargs["name"]
-               for ca in dev_reg.async_update_device.call_args_list}
-    assert renamed == {"d1": "Dimcontroller (Centrale)", "d2": "Entree (Living)"}
-    # only the single-entity device's entity renamed
-    ent_reg.async_update_entity.assert_called_once_with(
-        "binary_sensor.btn", name="Entree (Living)"
+    assert result == {"devices": 3, "entities": 2, "areas": 2, "scenes": 1}
+    names = {c.args[0]: c.kwargs.get("name")
+             for c in dev_reg.async_update_device.call_args_list
+             if "name" in c.kwargs}
+    assert names == {"d1": "Dimcontroller", "d2": "Entree",
+                     "d3": "Scene - Test"}  # name has NO room suffix
+    # areas assigned for the two room-bearing devices (not the scene)
+    area_calls = [c for c in dev_reg.async_update_device.call_args_list
+                  if "area_id" in c.kwargs]
+    assert {c.args[0] for c in area_calls} == {"d1", "d2"}
+
+
+def test_import_does_not_override_existing_area():
+    data = NkbData(
+        addresses={"1843B4": ("Entree", "Living")}, scenes=[]
     )
+    coord = _coord()
+    dev = _device("d2", "1843B4", area_id="already_set")
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    with _patches(data, [dev], [], dev_reg, ent_reg, area_reg):
+        result = _run(coord.async_import_nkb_names())
+    assert result["areas"] == 0
+    area_reg.async_create.assert_not_called()
 
 
-def test_import_preserves_user_named_entity():
-    c = _coord()
-    names = NkbNames(addresses={"1843B4": "Entree (Living)"}, scenes={})
-    dev_btn = _device("d2", "1843B4")
-    # entity already user-named -> must NOT be touched
-    ent = _entity("binary_sensor.btn", "d2", name="My Custom Name")
-    dev_reg, ent_reg = MagicMock(), MagicMock()
-    with patch("custom_components.nikobus.nkbnames.find_nkb_file",
-               return_value=__import__("pathlib").Path("/cfg/x.nkb")), \
-         patch("custom_components.nikobus.nkbnames.parse_nkb_names",
-               return_value=names), \
-         patch("custom_components.nikobus.coordinator.dr.async_get",
-               return_value=dev_reg), \
-         patch("custom_components.nikobus.coordinator.er.async_get",
-               return_value=ent_reg), \
-         patch("custom_components.nikobus.coordinator.dr.async_entries_for_config_entry",
-               return_value=[dev_btn], create=True), \
-         patch("custom_components.nikobus.coordinator.er.async_entries_for_config_entry",
-               return_value=[ent], create=True):
-        result = _run(c.async_import_nkb_names())
-    assert result["entities"] == 0
-    ent_reg.async_update_entity.assert_not_called()
+def test_import_scene_no_match_when_members_differ():
+    data = NkbData(
+        addresses={}, scenes=[SceneDef("Scene - X", frozenset({("0E6C", 1, "M12")}))]
+    )
+    coord = _coord(cf={"AAAAAA": {
+        "outputs": [{"module_address": "0E6C", "channel": 2,  # different channel
+                     "mode": "M12 (Preset on)"}]}})
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    with _patches(data, [_device("d", "AAAAAA")], [], dev_reg, ent_reg, area_reg):
+        result = _run(coord.async_import_nkb_names())
+    assert result["scenes"] == 0
 
 
 def test_import_raises_when_no_file():
     from homeassistant.exceptions import HomeAssistantError
 
-    c = _coord()
+    coord = _coord()
     with patch("custom_components.nikobus.nkbnames.find_nkb_file",
                return_value=None):
         with pytest.raises(HomeAssistantError):
-            _run(c.async_import_nkb_names())
+            _run(coord.async_import_nkb_names())


### PR DESCRIPTION
Completes the `.nkb` import. This branch now carries 3.4.0 + 3.5.0.

## 3.5.0 — `.nkb`-sourced scenes (shutter & master scenes)
Light scenes self-identify on the bus (preset-recall modes). Shutter / all-off / master scenes don't — they're indistinguishable from an ordinary multi-output button — so discovery can't surface them. The `.nkb` *does* mark them (the Central-Function grouping), so the import now uses that:

- For each named CF group that isn't already a discovered light scene, find the on-bus firing address by matching the group's **member set** against the full routing graph (every op-point's linked outputs), then create a `scene.*` with the group's real name (`ShuttersSalonCuisine`, `CloseHouse - Leave`, …).
- Activation **fires the trigger address** → modules handle roller timing themselves (no HA-side stops), exactly like pressing the button.
- **Authoritative, not heuristic** — only the `.nkb`'s CF designation promotes a group. Multi-output buttons are never auto-promoted; the user is never asked to classify. Trigger-less groups are skipped.
- `.nkb`-sourced scenes survive re-discovery; the import reloads so they appear.

## 3.4.0 — names, rooms → Areas, light-scene names
- Module/button/IR names from the `.nkb`, keyed on bus address (4-hex modules / 6-hex buttons — fixes a latent mismatch).
- Rooms become Home Assistant **Areas** (the `(Room)` suffix is dropped).
- Light-scene CFs get their real names via member-set match.

All non-destructive (never overrides a manual name/Area). Pure-Python parse (vendored Apache-2.0 `access_parser` + `construct`); the file never leaves the machine. Also quiets the vendored parser's `MSysObjects` ERROR log spam (downgraded to DEBUG). Suite: **370 passed**, lint clean.

Builds on 3.3.2 (orphan-cleanup fix) so the import button exists.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj