### PR TITLE
3.5.0: .nkb-sourced scenes (shutter/master) + parser log fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 3.5.0
+
+**`.nkb`-sourced scenes — shutter & master scenes now import as real scenes.**
+
+Light scenes self-identify on the bus (their preset-recall modes), so they
+were already surfaced. Shutter / "all-off" / master scenes have no such
+fingerprint — they're indistinguishable from an ordinary multi-output
+button — so discovery can't tell they're scenes. But the `.nkb` *does* mark
+them (the Central-Function grouping). "Import Names from .nkb" now uses that:
+
+- For every named CF group that **isn't** already a discovered light-scene,
+  it finds the on-bus address that fires the group by matching the group's
+  **member set** against the full routing graph (every button/IR op-point's
+  linked outputs), then creates a `scene.*` entity with the group's real
+  name (e.g. `ShuttersSalonCuisine`, `CloseHouse - Leave`).
+- Activation **fires the trigger address** — so the modules handle roller
+  run-times themselves (no HA-side timed stops), exactly like pressing the
+  physical button.
+- Authoritative, not heuristic: a group is imported only because the `.nkb`
+  designates it a Central Function. Multi-output buttons are never promoted
+  on their own, and you're never asked to classify anything.
+- A group with no on-bus trigger (e.g. `ShuttersUp`/`Down` with no button)
+  can't be fired from HA, so it's skipped.
+- `.nkb`-sourced scenes are preserved across re-discovery (a re-scan only
+  refreshes the auto-detected CFs).
+
+After an import that creates scenes, the integration reloads so the new
+`scene.*` entities appear.
+
 ## 3.4.0
 
 `.nkb` import v2 — rooms become Areas, and scenes get their real names.

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -569,11 +569,12 @@ class NikobusImportNkbNamesButton(ButtonEntity):
         result = await self._coordinator.async_import_nkb_names()
         _LOGGER.info(
             "Nikobus .nkb import done: %s devices, %s entities, %s areas, "
-            "%s scenes",
+            "%s scenes named, %s scenes created",
             result["devices"],
             result["entities"],
             result["areas"],
             result["scenes"],
+            result.get("scenes_created", 0),
         )
 
 

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -104,6 +104,30 @@ _PROBE_OUTER_DELAY_S = 3.0
 _REGISTRY_SOURCES = frozenset({"pc_link_registry", "pc_logic_registry"})
 
 
+def _member_set_from_outputs(outputs) -> frozenset:
+    """Frozenset of ``(module_upper, channel, mode_code)`` for an output
+    list — the canonical key for matching a scene/CF by its members,
+    used identically on ``.nkb`` groups, CF entries and routing-graph
+    op-points so the three are directly comparable."""
+    from .nkbnames import _mode_code
+
+    out = set()
+    for o in outputs or []:
+        if not isinstance(o, dict):
+            continue
+        mod = o.get("module_address")
+        ch = o.get("channel")
+        code = _mode_code(o.get("mode"))
+        if isinstance(mod, str) and isinstance(ch, int) and code:
+            out.add((mod.upper(), ch, code))
+    return frozenset(out)
+
+
+def _cf_member_set(cf: dict) -> frozenset:
+    """Member-set key for a stored ``nikobus_cf`` entry."""
+    return _member_set_from_outputs((cf or {}).get("outputs"))
+
+
 class NikobusDataCoordinator(DataUpdateCoordinator[None]):
     """Coordinator for managing asynchronous updates and connections to Nikobus."""
 
@@ -1609,12 +1633,20 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 "triggered_by": triggered_by,
             }
 
-        self.cf_storage.data["nikobus_cf"] = flat
+        # Preserve any .nkb-sourced scenes (added by async_import_nkb_names);
+        # discovery never produces them, so a re-scan must not wipe them.
+        preserved = {
+            addr: entry
+            for addr, entry in (self.cf_storage.data.get("nikobus_cf") or {}).items()
+            if isinstance(entry, dict) and entry.get("source") == "nkb"
+        }
+        self.cf_storage.data["nikobus_cf"] = {**preserved, **flat}
         await self.cf_storage.async_save()
         _LOGGER.info(
-            "CF broadcasts persisted: %d entries (%s)",
+            "CF broadcasts persisted: %d discovered + %d nkb-sourced (%s)",
             len(flat),
-            sorted(flat.keys()),
+            len(preserved),
+            sorted({**preserved, **flat}.keys()),
         )
 
     async def async_activate_cf_broadcast(self, bus_address: str) -> None:
@@ -2368,7 +2400,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         """
         from homeassistant.helpers import area_registry as ar
 
-        from .nkbnames import _mode_code, find_nkb_file, parse_nkb
+        from .nkbnames import find_nkb_file, parse_nkb
 
         path = find_nkb_file(self.hass.config.config_dir)
         if path is None:
@@ -2387,27 +2419,54 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
 
         name_map = data.addresses  # {ADDR: (name, room)}
 
-        # Match named scene groups to discovered CF entities by member set
-        # → {CF_wire_address_upper: scene_name}.
+        # Match named scene groups to **existing** CF entities by member set
+        # → {CF_wire_address_upper: scene_name} (these are the light scenes
+        # discovery already surfaced; we just name them).
         scene_by_members = {sc.members: sc.name for sc in data.scenes}
         cf_name_by_addr: dict[str, str] = {}
+        matched_scene_members: set = set()
         if self.cf_storage is not None:
             for cf_addr, cf in self.cf_storage.data.get("nikobus_cf", {}).items():
-                members = frozenset(
-                    (
-                        str(o.get("module_address")).upper(),
-                        int(o["channel"]),
-                        _mode_code(o.get("mode")),
-                    )
-                    for o in (cf.get("outputs") or [])
-                    if isinstance(o, dict)
-                    and o.get("module_address")
-                    and isinstance(o.get("channel"), int)
-                    and _mode_code(o.get("mode"))
-                )
+                members = _cf_member_set(cf)
                 hit = scene_by_members.get(members)
                 if hit:
                     cf_name_by_addr[str(cf_addr).upper()] = hit
+                    matched_scene_members.add(members)
+
+        # Create scenes for named groups that AREN'T a discovered CF — the
+        # shutter / master scenes (no light-scene mode, so discovery never
+        # surfaces them). Find each group's firing address by matching its
+        # member set against the full routing graph (every op-point's linked
+        # outputs), then persist it as an nkb-sourced CF that activates by
+        # firing that address (the module handles roller timing itself).
+        scenes_created = 0
+        if self.cf_storage is not None:
+            graph = self._build_routing_graph()
+            existing = self.cf_storage.data.setdefault("nikobus_cf", {})
+            new_entries: dict[str, dict] = {}
+            for sc in data.scenes:
+                if sc.members in matched_scene_members or not sc.members:
+                    continue  # already a CF, or trigger-less (no members)
+                hit = graph.get(sc.members)
+                if hit is None:
+                    continue  # no on-bus trigger drives this set → can't fire
+                addrs, outputs = hit
+                canonical = addrs[0]
+                if canonical in existing or canonical in new_entries:
+                    continue
+                new_entries[canonical] = {
+                    "bus_address": canonical,
+                    "pattern": "nkb_scene",
+                    "outputs": outputs,
+                    "triggered_by": addrs,
+                    "source": "nkb",
+                    "name": sc.name,
+                }
+                cf_name_by_addr[canonical] = sc.name
+            if new_entries:
+                existing.update(new_entries)
+                await self.cf_storage.async_save()
+                scenes_created = len(new_entries)
 
         dev_reg = dr.async_get(self.hass)
         ent_reg = er.async_get(self.hass)
@@ -2463,18 +2522,88 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
 
         _LOGGER.info(
             "Imported .nkb from %s: %d devices, %d entities, %d areas, "
-            "%d scenes (%d addresses, %d scene groups in file)",
+            "%d scenes named, %d scenes created (%d addresses, %d groups "
+            "in file)",
             path.name,
             devices_named,
             entities_named,
             areas_set,
-            len(cf_name_by_addr),
+            len(cf_name_by_addr) - scenes_created,
+            scenes_created,
             len(name_map),
             len(data.scenes),
         )
+
+        # New scene entities only appear once the scene platform re-runs.
+        if scenes_created:
+            self.hass.async_create_task(
+                self.hass.config_entries.async_reload(self.config_entry.entry_id)
+            )
+
         return {
             "devices": devices_named,
             "entities": entities_named,
             "areas": areas_set,
-            "scenes": len(cf_name_by_addr),
+            "scenes": len(cf_name_by_addr) - scenes_created,
+            "scenes_created": scenes_created,
         }
+
+    def _build_routing_graph(self) -> dict:
+        """Map every op-point's member set → ``(firing addresses, outputs)``.
+
+        The routing graph is the full set of ``trigger → linked outputs``
+        relations from the button store — the same data discovery decodes.
+        Used to find the on-bus address that fires a named ``.nkb`` scene
+        group (matched by member set), including the shutter / master
+        groups that have no light-scene mode and so never become CF
+        entities on their own. Addresses driving an identical output set
+        (one scene, several triggers) are grouped; the sorted-first is the
+        canonical activation address.
+        """
+        graph: dict[frozenset, tuple[list[str], list[dict]]] = {}
+        buttons = (self.dict_button_data or {}).get("nikobus_button", {})
+        if not isinstance(buttons, dict):
+            return {}
+        for phys in buttons.values():
+            if not isinstance(phys, dict):
+                continue
+            for op in (phys.get("operation_points") or {}).values():
+                if not isinstance(op, dict):
+                    continue
+                addr = op.get("bus_address")
+                if not isinstance(addr, str) or not addr:
+                    continue
+                outputs: list[dict] = []
+                seen: set = set()
+                for link in op.get("linked_modules") or []:
+                    if not isinstance(link, dict):
+                        continue
+                    mod = link.get("module_address")
+                    if not isinstance(mod, str):
+                        continue
+                    for o in link.get("outputs") or []:
+                        if not isinstance(o, dict):
+                            continue
+                        ch = o.get("channel")
+                        mode = o.get("mode")
+                        if not (isinstance(ch, int) and isinstance(mode, str)):
+                            continue
+                        dedupe = (mod.upper(), ch, mode)
+                        if dedupe in seen:
+                            continue
+                        seen.add(dedupe)
+                        outputs.append(
+                            {
+                                "module_address": mod.upper(),
+                                "channel": ch,
+                                "mode": mode,
+                                "t1": o.get("t1") if isinstance(o.get("t1"), str) else None,
+                                "t2": o.get("t2") if isinstance(o.get("t2"), str) else None,
+                            }
+                        )
+                members = _member_set_from_outputs(outputs)
+                if not members:
+                    continue
+                entry = graph.setdefault(members, ([], outputs))
+                entry[0].append(addr.upper())
+        return {m: (sorted(set(a)), o) for m, (a, o) in graph.items()}

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/custom_components/nikobus/scene.py
+++ b/custom_components/nikobus/scene.py
@@ -113,17 +113,20 @@ class NikobusCFSceneEntity(NikobusEntity, Scene):
         outputs = cf_config.get("outputs") or []
         member_count = len(outputs) if isinstance(outputs, list) else 0
 
-        # Build a default friendly name from what we know on the bus.
-        # The .nkb-derived user name (if/when the integration ingests
-        # the file) will replace this via the standard HA rename flow.
-        if pattern == "switch_pair":
+        # A name imported from the .nkb (nkb-sourced scenes — shutter /
+        # master groups that carry their real project name) wins outright.
+        # Otherwise build a default from what we know on the bus; the user
+        # can still rename via the standard HA flow.
+        imported = cf_config.get("name")
+        if isinstance(imported, str) and imported.strip():
+            name = imported.strip()
+        elif pattern == "switch_pair":
             name = f"Nikobus switch CF {addr} ({member_count} ch)"
         elif pattern == "roller_pair":
             name = f"Nikobus roller CF {addr} ({member_count} ch)"
-        elif pattern == "light_scene":
-            # CF triggered by a real wall button / IR input, detected
-            # from a light-scene/preset member mode (the "MCF" link
-            # fingerprint). ``addr`` is the trigger's bus address.
+        elif pattern in ("light_scene", "nkb_scene"):
+            # CF triggered by a real wall button / IR input. ``addr`` is
+            # the trigger's bus address.
             name = f"Nikobus scene {addr} ({member_count} ch)"
         else:
             name = f"Nikobus CF {addr} ({member_count} ch)"

--- a/custom_components/nikobus/vendor/access_parser/__init__.py
+++ b/custom_components/nikobus/vendor/access_parser/__init__.py
@@ -3,7 +3,10 @@
 A pure-Python MS Access (.mdb/.accdb) reader. Vendored because the
 upstream PyPI sdist won't build on modern setuptools, and HA manifest
 requirements must be pip-installable. Only ``construct`` is needed at
-runtime (a clean wheel). The ``tabulate`` pretty-printer was stripped.
+runtime (a clean wheel). The ``tabulate`` pretty-printer was stripped,
+and the optional-``MSysObjects`` chunk-parse failures were downgraded
+from ERROR to DEBUG (that metadata is unused and the parser falls back
+cleanly — at ERROR it floods the HA log).
 
 Upstream: https://github.com/claroty/access_parser  — see LICENSE.
 """

--- a/custom_components/nikobus/vendor/access_parser/access_parser.py
+++ b/custom_components/nikobus/vendor/access_parser/access_parser.py
@@ -162,7 +162,7 @@ class AccessParser(object):
         reconstructed_column_data = {}
         for chunk in chunk_type_one:
             if not chunk.data.column_name:
-                LOGGER.error("Error while parsing MSysObjects table chunk.")
+                LOGGER.debug("Skipping unparseable MSysObjects chunk (optional metadata).")
                 continue
             data_values = {}
             for dv in chunk.data.data:
@@ -171,7 +171,7 @@ class AccessParser(object):
                     name = table_names[dv.name_index]
                     data_values[name] = val
                 except IndexError:
-                    LOGGER.error("Error while parsing MSysObjects table chunk.")
+                    LOGGER.debug("Skipping unparseable MSysObjects chunk (optional metadata).")
                     continue
             reconstructed_column_data[chunk.data.column_name] = data_values
         return reconstructed_column_data

--- a/tests/test_known_entity_cf_scenes.py
+++ b/tests/test_known_entity_cf_scenes.py
@@ -40,6 +40,20 @@ class TestKnownEntityIdsIncludeCFScenes(unittest.TestCase):
         self.assertIn("nikobus_cf_0d1c9e", known)
         self.assertIn("nikobus_cf_0ffec8", known)
 
+    def test_nkb_sourced_scene_unique_ids_are_known(self):
+        """.nkb-sourced (source='nkb') scenes live in cf_storage too, so the
+        orphan-cleanup must not evict them on the post-import reload — they
+        ride the same allowlist as discovered CFs (regression guard, since a
+        hard-coded unique_id once slipped the allowlist for the import
+        button)."""
+        coord = _coord_with_cfs([])
+        coord.cf_storage.data = {"nikobus_cf": {
+            "AB1234": {"bus_address": "AB1234", "pattern": "nkb_scene",
+                       "outputs": [], "source": "nkb", "name": "ShuttersUp"},
+        }}
+        known = coord.get_known_entity_unique_ids()
+        self.assertIn("nikobus_cf_ab1234", known)
+
     def test_no_cfs_is_safe(self):
         coord = _coord_with_cfs([])
         known = coord.get_known_entity_unique_ids()

--- a/tests/test_nkbnames.py
+++ b/tests/test_nkbnames.py
@@ -159,7 +159,7 @@ def test_parse_raises_without_mdb(tmp_path):
 # --------------------------------------------------------------------------- #
 # coordinator.async_import_nkb_names — names, areas, scene match
 # --------------------------------------------------------------------------- #
-def _coord(cf=None):
+def _coord(cf=None, button_data=None):
     from custom_components.nikobus.coordinator import NikobusDataCoordinator
 
     c = NikobusDataCoordinator.__new__(NikobusDataCoordinator)
@@ -172,11 +172,34 @@ def _coord(cf=None):
     c.hass.async_add_executor_job = _aaej
     c.config_entry = MagicMock()
     c.config_entry.entry_id = "E1"
+    c.dict_button_data = button_data or {}
     c.cf_storage = None
     if cf is not None:
         c.cf_storage = MagicMock()
-        c.cf_storage.data = {"nikobus_cf": cf}
+        c.cf_storage.data = {"nikobus_cf": dict(cf)}
+
+        async def _save():
+            return None
+
+        c.cf_storage.async_save = _save
     return c
+
+
+def _opbtn(bus_address, *outputs):
+    """Button-store physical with one op-point. outputs: (mod, ch, mode)."""
+    by_mod = {}
+    for mod, ch, mode in outputs:
+        by_mod.setdefault(mod, []).append({"channel": ch, "mode": mode})
+    return {
+        "operation_points": {
+            "K": {
+                "bus_address": bus_address,
+                "linked_modules": [
+                    {"module_address": m, "outputs": o} for m, o in by_mod.items()
+                ],
+            }
+        }
+    }
 
 
 def _device(dev_id, addr, name="old", area_id=None):
@@ -255,7 +278,8 @@ def test_import_names_areas_and_scene_match():
     with _patches(data, devices, entities, dev_reg, ent_reg, area_reg):
         result = _run(coord.async_import_nkb_names())
 
-    assert result == {"devices": 3, "entities": 2, "areas": 2, "scenes": 1}
+    assert result == {"devices": 3, "entities": 2, "areas": 2,
+                      "scenes": 1, "scenes_created": 0}
     names = {c.args[0]: c.kwargs.get("name")
              for c in dev_reg.async_update_device.call_args_list
              if "name" in c.kwargs}
@@ -265,6 +289,79 @@ def test_import_names_areas_and_scene_match():
     area_calls = [c for c in dev_reg.async_update_device.call_args_list
                   if "area_id" in c.kwargs]
     assert {c.args[0] for c in area_calls} == {"d1", "d2"}
+
+
+def test_import_creates_nkb_sourced_shutter_scene():
+    """A named group with no matching CF (shutter scene — no light-scene
+    mode) is created in cf_storage, keyed on the address that fires its
+    member set, sourced 'nkb' with its real name."""
+    data = NkbData(
+        addresses={},
+        scenes=[SceneDef("ShuttersSalonCuisine",
+                         frozenset({("9105", 3, "M01"), ("9105", 5, "M01")}))],
+    )
+    # no CF for these members, but two op-points drive the exact set
+    coord = _coord(cf={}, button_data={"nikobus_button": {
+        "1843B4": _opbtn("AB1234", ("9105", 3, "M01 (Open - stop - close)"),
+                         ("9105", 5, "M01 (Open - stop - close)")),
+        "0D1C80": _opbtn("CD5678", ("9105", 3, "M01 (Open - stop - close)"),
+                         ("9105", 5, "M01 (Open - stop - close)")),
+    }})
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    with _patches(data, [], [], dev_reg, ent_reg, area_reg):
+        result = _run(coord.async_import_nkb_names())
+
+    assert result["scenes_created"] == 1
+    cf = coord.cf_storage.data["nikobus_cf"]
+    # canonical = sorted-first of {AB1234, CD5678}
+    assert "AB1234" in cf
+    entry = cf["AB1234"]
+    assert entry["source"] == "nkb"
+    assert entry["name"] == "ShuttersSalonCuisine"
+    assert entry["triggered_by"] == ["AB1234", "CD5678"]
+    assert {(o["module_address"], o["channel"]) for o in entry["outputs"]} == \
+        {("9105", 3), ("9105", 5)}
+    # a reload is scheduled so the scene platform creates the entity
+    coord.hass.async_create_task.assert_called_once()
+
+
+def test_import_skips_triggerless_group():
+    """A group whose member set no op-point drives (no on-bus trigger) is
+    not created."""
+    data = NkbData(addresses={},
+                   scenes=[SceneDef("ShuttersUp",
+                                    frozenset({("9105", 1, "M02")}))])
+    coord = _coord(cf={}, button_data={"nikobus_button": {}})  # empty graph
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    with _patches(data, [], [], dev_reg, ent_reg, area_reg):
+        result = _run(coord.async_import_nkb_names())
+    assert result["scenes_created"] == 0
+    assert coord.cf_storage.data["nikobus_cf"] == {}
+
+
+def test_ingest_preserves_nkb_sourced_scenes():
+    """A re-discovery must not wipe nkb-sourced scenes."""
+    from unittest.mock import AsyncMock
+
+    coord = _coord(cf={
+        "AB1234": {"bus_address": "AB1234", "pattern": "nkb_scene",
+                   "outputs": [], "source": "nkb", "name": "ShuttersUp"},
+    })
+    # library re-classifies one discovered light scene
+    cfb = MagicMock()
+    cfb.bus_address = "DE4E2C"
+    cfb.pattern = "light_scene"
+    cfb.triggered_by = ["DE4E2C"]
+    cfb.outputs = []
+    coord.nikobus_discovery = MagicMock()
+    coord.nikobus_discovery.discovered_cf_broadcasts = {"DE4E2C": cfb}
+    coord.cf_storage.async_save = AsyncMock()
+
+    _run(coord._ingest_cf_broadcasts())
+
+    cf = coord.cf_storage.data["nikobus_cf"]
+    assert "AB1234" in cf and cf["AB1234"]["source"] == "nkb"  # preserved
+    assert "DE4E2C" in cf  # discovered, freshly ingested
 
 
 def test_import_does_not_override_existing_area():


### PR DESCRIPTION
Follow-up to #403 (which merged at 3.4.0). These three commits landed on the branch after that merge, so they need their own PR.

## 3.5.0 — `.nkb`-sourced scenes (shutter & master)
Light scenes self-identify on the bus (preset-recall modes); shutter / all-off / master scenes don't — they're indistinguishable from an ordinary multi-output button — so discovery can't surface them. The `.nkb` *does* mark them (the Central-Function grouping), so the import now uses it:

- For each named CF group that isn't already a discovered light scene, find the on-bus firing address by matching the group's **member set** against the full routing graph (every op-point's linked outputs), then create a `scene.*` with the group's real name (`ShuttersSalonCuisine`, `CloseHouse - Leave`, …).
- Activation **fires the trigger address** → the modules handle roller timing themselves (no HA-side stops), exactly like pressing the button.
- **Authoritative, not heuristic** — only the `.nkb`'s CF designation promotes a group. Multi-output buttons are never auto-promoted; the user is never asked to classify. Trigger-less groups are skipped.
- `.nkb`-sourced scenes are persisted with `source:"nkb"` and **survive re-discovery** (`_ingest_cf_broadcasts` preserves them). The import reloads the entry so the new `scene.*` entities appear.
- `NikobusCFSceneEntity` uses the stored `.nkb` name.

## Fixes / hardening
- **Quieter logs:** the vendored `access_parser` logged `MSysObjects` chunk failures at ERROR (82× per import) — that catalog metadata is unused and the parser falls back cleanly, so downgraded to DEBUG.
- **Orphan-cleanup guard:** `.nkb` scenes live in `cf_storage`, which `get_known_entity_unique_ids()` already iterates wholesale, so the startup cleanup keeps them (same protection as discovered CFs). Added a regression test pinning a `source:"nkb"` entry's unique_id in the known set — so this can't repeat the import-button eviction (which was a *hard-coded* id that slipped the allowlist).

Bumps manifest to **3.5.0**. Suite green; lint clean (vendored dir excluded).

After merge, cut a **3.5.0** release.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_