### PR TITLE
3.5.1: keep the room in imported device names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ them (the Central-Function grouping). "Import Names from .nkb" now uses that:
 After an import that creates scenes, the integration reloads so the new
 `scene.*` entities appear.
 
+Also: device names now keep the room — `Entree (Living)` — *and* get the
+Area. Nikobus names are often generic and repeated per room (an `Entree`
+in every room), so dropping the room (as 3.4.0 did) left a wall of
+identical names in entity pickers / automations where the Area isn't
+shown. The room stays in the name to disambiguate.
+
 ## 3.4.0
 
 `.nkb` import v2 — rooms become Areas, and scenes get their real names.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 3.5.1
+
+- **Imported device names keep their room** — `Entree (Living)` — *and* still
+  get the Area. Nikobus names are often generic and repeated per room (an
+  `Entree` in every room); 3.4.0/3.5.0 dropped the room from the name, leaving
+  a wall of identical names in entity pickers / automations where the Area
+  isn't shown. The room now stays in the name to disambiguate (scenes, which
+  have no room, keep their bare name). Re-run **Import Names from .nkb** to
+  apply.
+
 ## 3.5.0
 
 **`.nkb`-sourced scenes — shutter & master scenes now import as real scenes.**
@@ -28,12 +38,6 @@ them (the Central-Function grouping). "Import Names from .nkb" now uses that:
 
 After an import that creates scenes, the integration reloads so the new
 `scene.*` entities appear.
-
-Also: device names now keep the room — `Entree (Living)` — *and* get the
-Area. Nikobus names are often generic and repeated per room (an `Entree`
-in every room), so dropping the room (as 3.4.0 did) left a wall of
-identical names in entity pickers / automations where the Area isn't
-shown. The room stays in the name to disambiguate.
 
 ## 3.4.0
 

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -2485,17 +2485,21 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                     return (cf_name_by_addr[key], "")
             return None
 
-        # 1. Devices — name (room dropped; the Area carries it) + Area.
-        matched: dict[str, str] = {}  # device_id -> name
+        # 1. Devices — name as ``Name (Room)`` (Nikobus names are often
+        # generic and repeated per room, e.g. "Entree" in every room, so the
+        # room must stay in the name to disambiguate in pickers/automations
+        # where the Area isn't shown) + assign the Area.
+        matched: dict[str, str] = {}  # device_id -> display name
         devices_named = areas_set = 0
         for device in dr.async_entries_for_config_entry(dev_reg, entry_id):
             hit = _lookup(device)
             if hit is None:
                 continue
             name, room = hit
-            matched[device.id] = name
-            if device.name != name:
-                dev_reg.async_update_device(device.id, name=name)
+            display = f"{name} ({room})" if room else name
+            matched[device.id] = display
+            if device.name != display:
+                dev_reg.async_update_device(device.id, name=display)
                 devices_named += 1
             if room and device.area_id is None:
                 area = area_reg.async_get_area_by_name(
@@ -2511,13 +2515,13 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             if ent.device_id:
                 by_device.setdefault(ent.device_id, []).append(ent)
         entities_named = 0
-        for device_id, name in matched.items():
+        for device_id, display in matched.items():
             ents = by_device.get(device_id, [])
             if len(ents) != 1:
                 continue
             ent = ents[0]
-            if ent.name is None and ent.original_name != name:
-                ent_reg.async_update_entity(ent.entity_id, name=name)
+            if ent.name is None and ent.original_name != display:
+                ent_reg.async_update_entity(ent.entity_id, name=display)
                 entities_named += 1
 
         _LOGGER.info(

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/tests/test_nkbnames.py
+++ b/tests/test_nkbnames.py
@@ -283,8 +283,10 @@ def test_import_names_areas_and_scene_match():
     names = {c.args[0]: c.kwargs.get("name")
              for c in dev_reg.async_update_device.call_args_list
              if "name" in c.kwargs}
-    assert names == {"d1": "Dimcontroller", "d2": "Entree",
-                     "d3": "Scene - Test"}  # name has NO room suffix
+    # name carries the room (disambiguates generic repeated names); scenes
+    # (no room) keep their bare name.
+    assert names == {"d1": "Dimcontroller (Centrale)", "d2": "Entree (Living)",
+                     "d3": "Scene - Test"}
     # areas assigned for the two room-bearing devices (not the scene)
     area_calls = [c for c in dev_reg.async_update_device.call_args_list
                   if "area_id" in c.kwargs]


### PR DESCRIPTION
Follow-up to #404 (merged at 3.5.0).

## Problem
Nikobus projects often name the same function generically in every room — e.g. the entrance button is `Entree` in Living, Cuisine, Buanderie, Bureau, … 3.4.0/3.5.0 **dropped the room from the imported name** (the Area was meant to carry it), which left a wall of identical **`Entree`** devices — fine in the device list (the Area shows), but ambiguous in entity pickers and automations where the Area isn't displayed.

## Fix
Imported device names keep the room — **`Entree (Living)`, `Entree (Cuisine)`, …** — *and* still get the **Area**. Slightly redundant in the device card, but unambiguous everywhere. Scenes (no room) keep their bare name. Non-destructive as before (manual renames / Areas untouched).

Bumps manifest to **3.5.1**; changelog note moved to its own 3.5.1 section. Apply by re-running **Import Names from .nkb** (re-import is idempotent and won't clobber hand-set names).

Suite green; lint clean.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_