### PR TITLE
3.6.0: upload .nkb from the UI + roller-scene fix + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      # Home Assistant is stubbed in tests/conftest.py, so the only real
-      # runtime deps the suite needs are pytest and construct (used by the
-      # vendored access_parser the .nkb tests import).
-      - run: pip install pytest construct
+      # Home Assistant itself is stubbed in tests/conftest.py, but the
+      # integration modules still import the real library + helpers at load
+      # time, so install the manifest's runtime requirements alongside pytest.
+      - run: >
+          pip install pytest
+          aiofiles "pyserial-asyncio-fast>=0.16"
+          "nikobus-connect>=0.24.0" "construct>=2.10"
       - run: python -m pytest -q
 
   hassfest:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Ruff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Lints custom_components/nikobus per ruff.toml (vendored code excluded).
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: "check --output-format=github"
+
+  test:
+    name: Tests (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      # Home Assistant is stubbed in tests/conftest.py, so the only real
+      # runtime deps the suite needs are pytest and construct (used by the
+      # vendored access_parser the .nkb tests import).
+      - run: pip install pytest construct
+      - run: python -m pytest -q
+
+  hassfest:
+    name: Hassfest (manifest validation)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: home-assistant/actions/hassfest@master
+
+  hacs:
+    name: HACS validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hacs/action@main
+        with:
+          category: integration
+          # Not (yet) in home-assistant/brands; skip that check so a valid
+          # custom integration isn't failed for it.
+          ignore: brands

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,9 @@ jobs:
       # Home Assistant itself is stubbed in tests/conftest.py, but the
       # integration modules still import the real library + helpers at load
       # time, so install the manifest's runtime requirements alongside pytest.
+      # async tests use @pytest.mark.asyncio, so pytest-asyncio is required.
       - run: >
-          pip install pytest
+          pip install pytest pytest-asyncio
           aiofiles "pyserial-asyncio-fast>=0.16"
           "nikobus-connect>=0.24.0" "construct>=2.10"
       - run: python -m pytest -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
-## 3.5.2
+## 3.6.0
 
+- **Upload your `.nkb` from the UI.** Settings → Devices & Services →
+  Nikobus → **Configure → Upload .nkb project file**: pick the export (any
+  filename), it's validated (must parse as a real `.nkb`) and saved as
+  `nikobus.nkb` in the config directory. Then press **Import Names from
+  .nkb**. No more copying files over Samba/SSH.
 - **Fix: shutter / roller scenes from the `.nkb` are now created.** The
   scene member channel was read from the wrong field — roller outputs sit
   in output *pairs*, so a roller module's `ObjectAddress` runs `0,2,4,…`
@@ -10,6 +15,8 @@
   Leave`) fail the member-set match, so 0 were created. The channel is now
   taken from the output's `Prefix` (`O02` → 2), which matches HA's
   numbering for every module type. Re-run **Import Names from .nkb**.
+- **CI** (repo): ruff + pytest (py3.12/3.13) + hassfest + HACS validation
+  run on every PR.
 
 ## 3.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 3.5.2
+
+- **Fix: shutter / roller scenes from the `.nkb` are now created.** The
+  scene member channel was read from the wrong field — roller outputs sit
+  in output *pairs*, so a roller module's `ObjectAddress` runs `0,2,4,…`
+  while Home Assistant numbers the rollers `1,2,3,…`. That made every
+  roller-containing group (e.g. `ShuttersSalonCuisine`, `CloseHouse -
+  Leave`) fail the member-set match, so 0 were created. The channel is now
+  taken from the output's `Prefix` (`O02` → 2), which matches HA's
+  numbering for every module type. Re-run **Import Names from .nkb**.
+
 ## 3.5.1
 
 - **Imported device names keep their room** — `Entree (Living)` — *and* still

--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -11,6 +11,8 @@ from homeassistant import config_entries
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.selector import (
+    FileSelector,
+    FileSelectorConfig,
     NumberSelector,
     NumberSelectorConfig,
     NumberSelectorMode,
@@ -36,6 +38,15 @@ from nikobus_connect import NikobusConnect
 from nikobus_connect.discovery import find_module
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class _NkbUploadError(Exception):
+    """A `.nkb` upload failed; ``key`` is the translation/error key."""
+
+    def __init__(self, key: str) -> None:
+        super().__init__(key)
+        self.key = key
+
 
 # Module hardware capabilities: which HA entity types each module type can back.
 #
@@ -424,7 +435,7 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
         the declarative source of truth. Users on manual-config should
         edit the JSON files directly to make customisations stick.
         """
-        menu_options = ["hardware", "configure_modules"]
+        menu_options = ["hardware", "configure_modules", "upload_nkb"]
         return self.async_show_menu(
             step_id="init",
             menu_options=menu_options,
@@ -457,6 +468,68 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
             step_id="polling",
             data_schema=_polling_schema(self._current()),
         )
+
+    # --- Upload the .nkb project file --------------------------------------
+
+    async def async_step_upload_nkb(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.FlowResult:
+        """Upload a Nikobus ``.nkb`` project file into the config dir.
+
+        Prompts for a file (any name), validates it parses as a real
+        ``.nkb`` (a ZIP holding the MS Access DB), and saves it as the
+        canonical ``nikobus.nkb`` in the HA config directory so the
+        **Import Names from .nkb** button can pick it up. Doesn't change
+        any options; the file *is* the result.
+        """
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                await self._save_uploaded_nkb(user_input["file"])
+            except _NkbUploadError as err:
+                errors["base"] = err.key
+            else:
+                # No options change — just close the flow with success.
+                return self.async_create_entry(
+                    title="", data=dict(self.config_entry.options)
+                )
+
+        return self.async_show_form(
+            step_id="upload_nkb",
+            data_schema=vol.Schema(
+                {vol.Required("file"): FileSelector(FileSelectorConfig(accept=".nkb"))}
+            ),
+            errors=errors,
+        )
+
+    async def _save_uploaded_nkb(self, file_id: str) -> None:
+        """Validate the uploaded file is a real ``.nkb`` and save it as
+        ``nikobus.nkb`` in the config dir. Runs the blocking file work in
+        an executor; raises :class:`_NkbUploadError` on a bad file."""
+        from homeassistant.components.file_upload import process_uploaded_file
+
+        from .nkbnames import CANONICAL_NKB_FILENAME, parse_nkb
+
+        hass = self.hass
+        dest = hass.config.path(CANONICAL_NKB_FILENAME)
+
+        def _validate_and_save() -> None:
+            import shutil
+
+            with process_uploaded_file(hass, file_id) as src:
+                try:
+                    parse_nkb(src)  # parses → it's a usable .nkb
+                except Exception as err:  # noqa: BLE001 — surface as flow error
+                    raise _NkbUploadError("invalid_nkb") from err
+                shutil.copyfile(src, dest)
+
+        try:
+            await hass.async_add_executor_job(_validate_and_save)
+        except _NkbUploadError:
+            raise
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.exception("Failed to save uploaded .nkb file")
+            raise _NkbUploadError("upload_failed") from err
 
     # --- Module customization ----------------------------------------------
 

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,14 +1,14 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "3.6.0",
-  "documentation": "https://github.com/fdebrus/nikobus-ha",
-  "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
   "config_flow": true,
   "dependencies": ["file_upload"],
+  "documentation": "https://github.com/fdebrus/nikobus-ha",
   "integration_type": "hub",
   "iot_class": "local_polling",
+  "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
+  "loggers": ["nikobus", "nikobus_connect"],
   "quality_scale": "gold",
   "requirements": [
     "aiofiles>=25.1.0",
@@ -16,5 +16,5 @@
     "nikobus-connect>=0.24.0",
     "construct>=2.10"
   ],
-  "loggers": ["nikobus", "nikobus_connect"]
+  "version": "3.6.0"
 }

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,11 +1,12 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "3.5.2",
+  "version": "3.6.0",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],
   "config_flow": true,
+  "dependencies": ["file_upload"],
   "integration_type": "hub",
   "iot_class": "local_polling",
   "quality_scale": "gold",

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
   "codeowners": ["@fdebrus"],

--- a/custom_components/nikobus/nkbnames.py
+++ b/custom_components/nikobus/nkbnames.py
@@ -39,6 +39,9 @@ _MCF_MODE = "MCF"
 
 _MODE_CODE_RE = re.compile(r"M\d+", re.IGNORECASE)
 
+# Output object prefix → channel number (``O01`` → 1, ``O12`` → 12).
+_OUTPUT_PREFIX_RE = re.compile(r"^O(\d+)$", re.IGNORECASE)
+
 
 def _fmt_addr(physical_address: int) -> str:
     """Format a ``PhysicalAddress`` to match our bus-address identifiers.
@@ -179,9 +182,14 @@ def _extract_scenes(
         return _fmt_addr(pa) if isinstance(pa, int) and pa > 0 else None
 
     def channel(obj) -> int | None:
+        # Channel = the output's ``Prefix`` number (``O01`` -> 1), which
+        # matches Home Assistant's per-channel numbering for EVERY module
+        # type. (``ObjectAddress`` can't be used: roller outputs occupy
+        # pairs, so a roller module's ``ObjectAddress`` runs 0,2,4,… while
+        # HA numbers the rollers 1,2,3,… — the prefix is the aligned index.)
         base = objectbase.get((obj or {}).get("KeyObjectBase"), {})
-        oa = base.get("ObjectAddress")
-        return (oa + 1) if isinstance(oa, int) else None
+        m = _OUTPUT_PREFIX_RE.match(str(base.get("Prefix") or ""))
+        return int(m.group(1)) if m else None
 
     scenes: list[SceneDef] = []
     for comp in components:

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -175,7 +175,9 @@
       "channel_not_found": "The selected channel was not found."
     },
     "error": {
-      "invalid_hex_address": "LED address must be exactly 6 hexadecimal characters (or empty)."
+      "invalid_hex_address": "LED address must be exactly 6 hexadecimal characters (or empty).",
+      "invalid_nkb": "That file isn't a readable Nikobus .nkb project (it must be the .nkb export — a ZIP containing the project database).",
+      "upload_failed": "Could not save the uploaded file. Check the Home Assistant logs."
     },
     "step": {
       "hardware": {
@@ -196,7 +198,8 @@
         "description": "What would you like to do?",
         "menu_options": {
           "configure_modules": "Customize a module (description, entity type, LED triggers, travel time)",
-          "hardware": "Change hardware settings"
+          "hardware": "Change hardware settings",
+          "upload_nkb": "Upload .nkb project file"
         },
         "title": "Nikobus"
       },
@@ -236,6 +239,13 @@
           "led_off": "LED-off trigger (6-hex bus address, optional)",
           "operation_time_up": "Travel time up (seconds)",
           "operation_time_down": "Travel time down (seconds)"
+        }
+      },
+      "upload_nkb": {
+        "title": "Upload Nikobus project (.nkb)",
+        "description": "Select your Nikobus project export (any filename). It's validated and saved as nikobus.nkb in your Home Assistant config folder. Then press “Import Names from .nkb” on the Nikobus Bridge.",
+        "data": {
+          "file": "Project file (.nkb)"
         }
       }
     }

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -61,7 +61,8 @@
         "description": "Que souhaitez-vous faire ?",
         "menu_options": {
           "hardware": "Modifier la configuration matérielle",
-          "configure_modules": "Personnaliser un module (description, type d'entité, déclencheurs LED, temps de course)"
+          "configure_modules": "Personnaliser un module (description, type d'entité, déclencheurs LED, temps de course)",
+          "upload_nkb": "Téléverser le fichier projet .nkb"
         }
       },
       "hardware": {
@@ -115,10 +116,21 @@
           "operation_time_up": "Temps de course à l'ouverture (secondes)",
           "operation_time_down": "Temps de course à la fermeture (secondes)"
         }
+      },
+      "upload_nkb": {
+        "title": "Téléverser le projet Nikobus (.nkb)",
+        "description": "Sélectionnez l'export de votre projet Nikobus (n'importe quel nom). Il est validé et enregistré sous nikobus.nkb dans votre dossier de configuration. Appuyez ensuite sur « Importer les noms depuis .nkb » sur le Nikobus Bridge.",
+        "data": {
+          "file": "Fichier projet (.nkb)"
+        }
       }
     },
     "abort": {
       "not_loaded": "L'intégration Nikobus n'est pas chargée. Veuillez la recharger puis réessayer."
+    },
+    "error": {
+      "invalid_nkb": "Ce fichier n'est pas un projet Nikobus .nkb lisible (il doit s'agir de l'export .nkb — une archive ZIP contenant la base de données du projet).",
+      "upload_failed": "Impossible d'enregistrer le fichier téléversé. Consultez les journaux Home Assistant."
     }
   },
   "entity": {

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -61,7 +61,8 @@
         "description": "Wat wilt u doen?",
         "menu_options": {
           "hardware": "Hardware-instellingen wijzigen",
-          "configure_modules": "Module aanpassen (beschrijving, entiteitstype, LED-triggers, looptijd)"
+          "configure_modules": "Module aanpassen (beschrijving, entiteitstype, LED-triggers, looptijd)",
+          "upload_nkb": "Projectbestand .nkb uploaden"
         }
       },
       "hardware": {
@@ -115,10 +116,21 @@
           "operation_time_up": "Looptijd omhoog (seconden)",
           "operation_time_down": "Looptijd omlaag (seconden)"
         }
+      },
+      "upload_nkb": {
+        "title": "Nikobus-project (.nkb) uploaden",
+        "description": "Selecteer de export van je Nikobus-project (elke bestandsnaam). Het wordt gevalideerd en opgeslagen als nikobus.nkb in je configuratiemap. Druk daarna op “Namen importeren uit .nkb” op de Nikobus Bridge.",
+        "data": {
+          "file": "Projectbestand (.nkb)"
+        }
       }
     },
     "abort": {
       "not_loaded": "De Nikobus-integratie is niet geladen. Herlaad de integratie en probeer het opnieuw."
+    },
+    "error": {
+      "invalid_nkb": "Dit bestand is geen leesbaar Nikobus .nkb-project (het moet de .nkb-export zijn — een ZIP met de projectdatabase).",
+      "upload_failed": "Kon het geüploade bestand niet opslaan. Controleer de Home Assistant-logboeken."
     }
   },
   "entity": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -311,8 +311,13 @@ _mod(
     NumberSelectorMode=type("NumberSelectorMode", (), {"BOX": "box", "SLIDER": "slider"}),
     TextSelector=lambda *a, **k: None,
     TextSelectorConfig=lambda *a, **k: None,
+    FileSelector=lambda *a, **k: None,
+    FileSelectorConfig=lambda *a, **k: None,
 )
 _mod("homeassistant.data_entry_flow", FlowResult=dict)
+# homeassistant.components.file_upload — process_uploaded_file is patched
+# per-test; stub the module so config_flow's lazy import resolves.
+_mod("homeassistant.components.file_upload", process_uploaded_file=None)
 _mod("homeassistant.components.repairs", RepairsFlow=type("RepairsFlow", (), {}))
 
 

--- a/tests/test_nkb_upload.py
+++ b/tests/test_nkb_upload.py
@@ -1,0 +1,72 @@
+"""Tests for the options-flow .nkb upload (validate + save as nikobus.nkb)."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _flow(tmp_path):
+    from custom_components.nikobus.config_flow import NikobusOptionsFlow
+
+    f = NikobusOptionsFlow.__new__(NikobusOptionsFlow)
+    f.hass = MagicMock()
+    f.hass.config.path = lambda name: str(tmp_path / name)
+
+    async def _aaej(fn, *a):
+        return fn(*a)
+
+    f.hass.async_add_executor_job = _aaej
+    return f
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _uploaded(src_path):
+    """Fake process_uploaded_file: a CM yielding the source path."""
+
+    @contextlib.contextmanager
+    def cm(_hass, _file_id):
+        yield src_path
+
+    return cm
+
+
+def test_save_uploaded_nkb_valid_copies_to_canonical(tmp_path):
+    src = tmp_path / "WhateverName.nkb"
+    src.write_bytes(b"pretend-zip-bytes")
+    flow = _flow(tmp_path)
+
+    with patch("homeassistant.components.file_upload.process_uploaded_file",
+               _uploaded(str(src))), \
+         patch("custom_components.nikobus.nkbnames.parse_nkb",
+               return_value=MagicMock()):
+        _run(flow._save_uploaded_nkb("file-id"))
+
+    dest = tmp_path / "nikobus.nkb"
+    assert dest.exists()
+    assert dest.read_bytes() == b"pretend-zip-bytes"  # saved verbatim
+
+
+def test_save_uploaded_nkb_invalid_rejected_and_not_saved(tmp_path):
+    from custom_components.nikobus.config_flow import _NkbUploadError
+
+    src = tmp_path / "not-really.nkb"
+    src.write_bytes(b"garbage")
+    flow = _flow(tmp_path)
+
+    with patch("homeassistant.components.file_upload.process_uploaded_file",
+               _uploaded(str(src))), \
+         patch("custom_components.nikobus.nkbnames.parse_nkb",
+               side_effect=ValueError("not a .nkb")):
+        with pytest.raises(_NkbUploadError) as ei:
+            _run(flow._save_uploaded_nkb("file-id"))
+
+    assert ei.value.key == "invalid_nkb"
+    # the canonical file must NOT be written when validation fails
+    assert not (tmp_path / "nikobus.nkb").exists()

--- a/tests/test_nkbnames.py
+++ b/tests/test_nkbnames.py
@@ -90,8 +90,10 @@ class _FakeParser:
         },
         "ObjectBase": {
             "KeyObjectBase": [500, 600, 700],
-            "ObjectAddress": [0, 0, 0],    # ch1 for the output
-            "Prefix": ["O01", "1A", "CF"],
+            # output's ObjectAddress=2 (e.g. a roller pair) but Prefix=O02 →
+            # channel must come from the prefix (2), not ObjectAddress+1 (3).
+            "ObjectAddress": [2, 0, 0],
+            "Prefix": ["O02", "1A", "CF"],
             "StrDescription": [None, None, None],
         },
         "LinkModeBase": {
@@ -144,8 +146,9 @@ def test_parse_scene_member_set(tmp_path):
     assert len(data.scenes) == 1
     sc = data.scenes[0]
     assert sc.name == "Scene - Test"
-    # trigger(200) drives output(100)=0E6C ch1 in M12; MCF link excluded
-    assert sc.members == frozenset({("0E6C", 1, "M12")})
+    # trigger(200) drives output(100)=0E6C in M12; channel 2 from Prefix
+    # O02 (NOT 3 from ObjectAddress+1); MCF link excluded.
+    assert sc.members == frozenset({("0E6C", 2, "M12")})
 
 
 def test_parse_raises_without_mdb(tmp_path):


### PR DESCRIPTION
Three things; the new CI runs on this PR and validates itself.

## New: upload your `.nkb` from the UI
**Settings → Devices & Services → Nikobus → Configure → "Upload .nkb project file"** opens a file picker (HA `FileSelector`). The file (any name) is **validated** — it must parse as a real `.nkb` (a ZIP holding the MS Access DB) — and saved as the canonical **`nikobus.nkb`** in the config dir via `process_uploaded_file`. Then press **Import Names from .nkb** on the bridge. No more copying files over Samba/SSH.
- Adds the `file_upload` manifest dependency; EN/FR/NL strings; tests for validate-and-save and reject-invalid.

## Fix: `.nkb` roller/shutter scenes now create
`0 scenes created` was a channel-numbering bug: roller outputs occupy output **pairs**, so a roller module's `ObjectAddress` runs `0,2,4,…` while HA numbers rollers `1,2,3,…`. The parser used `ObjectAddress+1` → `1,3,5,7,…`, so `ShuttersSalonCuisine` / `CloseHouse - Leave` never matched the routing graph. Now the channel comes from the output **`Prefix`** (`O02`→2), which matches HA for every module type. Validated on a real export.

## CI: make merges meaningful
`.github/workflows/ci.yml`, on every PR + push to `main`:
- **Ruff** (`ruff check`, vendored code excluded — `ruff check` only, the tree isn't `ruff format`-clean)
- **Tests** (`pytest`, Python 3.12 + 3.13; HA stubbed, deps `pytest`+`construct`)
- **Hassfest** (manifest validation)
- **HACS** (integration validation, `ignore: brands`)

Version **3.6.0** (folds the unreleased 3.5.2 roller fix in). Local: **373 passed**, `ruff check` clean, manifests valid.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj