### PR TITLE
3.7.0: selectable .nkb import with per-channel names + overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 3.7.0
+
+- **Import per-channel output names.** The `.nkb` import now also reads the
+  name of each output you actually toggle — the light / cover / switch
+  behind a channel (e.g. `Appliques Salon`, `Terrasse`) — and applies it to
+  the matching entity, not just the module/button device names.
+- **Choose what to import.** Settings → Devices & Services → Nikobus →
+  **Configure → Import Names from .nkb** is now a form: tick which
+  categories to apply — **device names**, **channel names**, **Areas**,
+  **scenes** — so you can, say, import channel names without touching the
+  Areas you've already organised.
+- **Overwrite toggle.** Off by default (suggested names only, a manual
+  rename always wins). Turn it on to force the `.nkb` names / Areas onto
+  entries you've previously set yourself.
+- The **Import Names from .nkb** button stays the one-press path: it imports
+  everything, non-destructively.
+
 ## 3.6.0
 
 - **Upload your `.nkb` from the UI.** Settings → Devices & Services →

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -566,12 +566,14 @@ class NikobusImportNkbNamesButton(ButtonEntity):
         user as the button action result.
         """
         _LOGGER.info("Importing Nikobus names from .nkb via UI button")
+        # The button is the quick path: import everything, non-destructive.
         result = await self._coordinator.async_import_nkb_names()
         _LOGGER.info(
-            "Nikobus .nkb import done: %s devices, %s entities, %s areas, "
-            "%s scenes named, %s scenes created",
+            "Nikobus .nkb import done: %s devices, %s entities, %s channels, "
+            "%s areas, %s scenes named, %s scenes created",
             result["devices"],
             result["entities"],
+            result.get("channels", 0),
             result["areas"],
             result["scenes"],
             result.get("scenes_created", 0),

--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -32,7 +32,9 @@ from .const import (
     DEFAULT_PRESS_REPEAT,
     DOMAIN,
 )
-from .coordinator import NikobusConfigEntry
+from homeassistant.exceptions import HomeAssistantError
+
+from .coordinator import NKB_IMPORT_CATEGORIES, NikobusConfigEntry
 from .exceptions import NikobusConnectionError
 from nikobus_connect import NikobusConnect
 from nikobus_connect.discovery import find_module
@@ -435,7 +437,7 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
         the declarative source of truth. Users on manual-config should
         edit the JSON files directly to make customisations stick.
         """
-        menu_options = ["hardware", "configure_modules", "upload_nkb"]
+        menu_options = ["hardware", "configure_modules", "upload_nkb", "import_nkb"]
         return self.async_show_menu(
             step_id="init",
             menu_options=menu_options,
@@ -530,6 +532,50 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
         except Exception as err:  # noqa: BLE001
             _LOGGER.exception("Failed to save uploaded .nkb file")
             raise _NkbUploadError("upload_failed") from err
+
+    # --- Import names / channels / Areas / scenes from the .nkb ------------
+
+    async def async_step_import_nkb(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.FlowResult:
+        """Apply the `.nkb` selectively, with an optional overwrite.
+
+        Lets the user choose which categories to import (device names,
+        per-channel names, Areas, scenes) and whether to overwrite names /
+        Areas they've already set. The ``Import Names from .nkb`` bridge
+        button remains the quick "everything, non-destructive" path.
+        """
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            cats = {c for c in NKB_IMPORT_CATEGORIES if user_input.get(c)}
+            if not cats:
+                errors["base"] = "nkb_nothing_selected"
+            else:
+                try:
+                    await self._coordinator().async_import_nkb_names(
+                        categories=cats, overwrite=bool(user_input.get("overwrite"))
+                    )
+                except HomeAssistantError as err:
+                    errors["base"] = getattr(err, "translation_key", None) \
+                        or "nkb_parse_failed"
+                else:
+                    return self.async_create_entry(
+                        title="", data=dict(self.config_entry.options)
+                    )
+
+        return self.async_show_form(
+            step_id="import_nkb",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional("device_names", default=True): bool,
+                    vol.Optional("channel_names", default=True): bool,
+                    vol.Optional("areas", default=True): bool,
+                    vol.Optional("scenes", default=True): bool,
+                    vol.Optional("overwrite", default=False): bool,
+                }
+            ),
+            errors=errors,
+        )
 
     # --- Module customization ----------------------------------------------
 

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import re
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -126,6 +127,41 @@ def _member_set_from_outputs(outputs) -> frozenset:
 def _cf_member_set(cf: dict) -> frozenset:
     """Member-set key for a stored ``nikobus_cf`` entry."""
     return _member_set_from_outputs((cf or {}).get("outputs"))
+
+
+def _output_entity_key(unique_id) -> tuple[str, int] | None:
+    """``(MODULE_ADDR_UPPER, channel)`` for a per-channel output entity's
+    unique_id (``nikobus_{light|switch|cover}_{kind}_{addr}_{ch}``), else
+    ``None`` — used to match ``.nkb`` output names to entities."""
+    if not isinstance(unique_id, str):
+        return None
+    parts = unique_id.split("_")
+    if len(parts) < 5 or parts[0] != DOMAIN:
+        return None
+    if parts[1] not in ("light", "switch", "cover"):
+        return None
+    addr, ch = parts[-2], parts[-1]
+    if not (ch.isdigit() and re.fullmatch(r"[0-9A-Fa-f]+", addr)):
+        return None
+    return (addr.upper(), int(ch))
+
+
+def _apply_entity_name(ent_reg, ent, name: str, overwrite: bool) -> bool:
+    """Set an entity's name; return True if changed. Non-overwrite only
+    fills a blank (no user name set); overwrite replaces any user name."""
+    if overwrite:
+        if ent.name != name:
+            ent_reg.async_update_entity(ent.entity_id, name=name)
+            return True
+        return False
+    if ent.name is None and ent.original_name != name:
+        ent_reg.async_update_entity(ent.entity_id, name=name)
+        return True
+    return False
+
+
+#: The selectable ``.nkb`` import categories (all applied by default).
+NKB_IMPORT_CATEGORIES = ("device_names", "channel_names", "areas", "scenes")
 
 
 class NikobusDataCoordinator(DataUpdateCoordinator[None]):
@@ -2376,31 +2412,33 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             self._discovery_finished_event.set()
             raise
 
-    async def async_import_nkb_names(self) -> dict[str, int]:
-        """Import names, rooms and scene names from a ``.nkb`` project file.
+    async def async_import_nkb_names(
+        self,
+        categories: set[str] | None = None,
+        overwrite: bool = False,
+    ) -> dict[str, int]:
+        """Import names, rooms, channel names and scenes from a ``.nkb``.
 
-        Reads the Nikobus PC-software export (a ZIP holding an MS Access
-        DB) and applies, all **suggested** / non-destructive:
+        ``categories`` selects what to apply (default: everything):
 
-        * **Device + entity names** — module / button / IR-receiver names
-          keyed on the bus address. A device's user rename
-          (``name_by_user``) is never touched; an entity is named only
-          when it has no user override, and only on single-entity devices
-          (multi-channel modules inherit the device name).
-        * **Areas** — each device is placed in a Home Assistant Area
-          matching its ``.nkb`` room (unless the user already set one).
-        * **Scene names** — a named Central Function group is matched to a
-          discovered CF entity by **member set** (the group has no bus
-          address; its trigger's output links spell out the same
-          ``(module, channel, mode)`` set discovery reads), then the CF's
-          device/entity is named.
+        * ``"device_names"`` — module / button / IR-receiver **device**
+          names (``Name (Room)``).
+        * ``"channel_names"`` — the per-output **entity** names (the
+          light / cover / switch the user actually toggles, e.g.
+          ``Appliques Salon``, ``Terrasse``).
+        * ``"areas"`` — each device into a Home Assistant Area = its room.
+        * ``"scenes"`` — match / create the Central Function scene entities.
 
-        Returns a summary (``devices`` / ``entities`` / ``areas`` /
-        ``scenes``).
+        ``overwrite`` forces a name/Area even where the user has set their
+        own; default off (suggested, never clobbers a manual rename).
+
+        Returns a per-category count summary.
         """
         from homeassistant.helpers import area_registry as ar
 
         from .nkbnames import find_nkb_file, parse_nkb
+
+        cats = set(categories) if categories else set(NKB_IMPORT_CATEGORIES)
 
         path = find_nkb_file(self.hass.config.config_dir)
         if path is None:
@@ -2419,37 +2457,28 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
 
         name_map = data.addresses  # {ADDR: (name, room)}
 
-        # Match named scene groups to **existing** CF entities by member set
-        # → {CF_wire_address_upper: scene_name} (these are the light scenes
-        # discovery already surfaced; we just name them).
-        scene_by_members = {sc.members: sc.name for sc in data.scenes}
+        # Scenes: match named groups to existing CFs (light scenes) and
+        # create entities for the rest (shutter / master groups) — only if
+        # the "scenes" category is selected.
         cf_name_by_addr: dict[str, str] = {}
-        matched_scene_members: set = set()
-        if self.cf_storage is not None:
+        scenes_created = 0
+        if "scenes" in cats and self.cf_storage is not None:
+            scene_by_members = {sc.members: sc.name for sc in data.scenes}
+            matched_scene_members: set = set()
             for cf_addr, cf in self.cf_storage.data.get("nikobus_cf", {}).items():
-                members = _cf_member_set(cf)
-                hit = scene_by_members.get(members)
+                hit = scene_by_members.get(_cf_member_set(cf))
                 if hit:
                     cf_name_by_addr[str(cf_addr).upper()] = hit
-                    matched_scene_members.add(members)
-
-        # Create scenes for named groups that AREN'T a discovered CF — the
-        # shutter / master scenes (no light-scene mode, so discovery never
-        # surfaces them). Find each group's firing address by matching its
-        # member set against the full routing graph (every op-point's linked
-        # outputs), then persist it as an nkb-sourced CF that activates by
-        # firing that address (the module handles roller timing itself).
-        scenes_created = 0
-        if self.cf_storage is not None:
+                    matched_scene_members.add(_cf_member_set(cf))
             graph = self._build_routing_graph()
             existing = self.cf_storage.data.setdefault("nikobus_cf", {})
             new_entries: dict[str, dict] = {}
             for sc in data.scenes:
                 if sc.members in matched_scene_members or not sc.members:
-                    continue  # already a CF, or trigger-less (no members)
+                    continue
                 hit = graph.get(sc.members)
                 if hit is None:
-                    continue  # no on-bus trigger drives this set → can't fire
+                    continue
                 addrs, outputs = hit
                 canonical = addrs[0]
                 if canonical in existing or canonical in new_entries:
@@ -2474,7 +2503,6 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         entry_id = self.config_entry.entry_id
 
         def _lookup(device) -> tuple[str, str] | None:
-            """(name, room) for a device from address names or scene match."""
             for domain, ident in device.identifiers:
                 if domain != DOMAIN:
                     continue
@@ -2485,10 +2513,8 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                     return (cf_name_by_addr[key], "")
             return None
 
-        # 1. Devices — name as ``Name (Room)`` (Nikobus names are often
-        # generic and repeated per room, e.g. "Entree" in every room, so the
-        # room must stay in the name to disambiguate in pickers/automations
-        # where the Area isn't shown) + assign the Area.
+        do_names = "device_names" in cats
+        do_areas = "areas" in cats
         matched: dict[str, str] = {}  # device_id -> display name
         devices_named = areas_set = 0
         for device in dr.async_entries_for_config_entry(dev_reg, entry_id):
@@ -2498,47 +2524,69 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             name, room = hit
             display = f"{name} ({room})" if room else name
             matched[device.id] = display
-            if device.name != display:
-                dev_reg.async_update_device(device.id, name=display)
-                devices_named += 1
-            if room and device.area_id is None:
+            if do_names:
+                # Non-overwrite sets the integration default (``name``), so a
+                # manual rename (``name_by_user``) still wins; overwrite sets
+                # ``name_by_user`` to force the .nkb name.
+                if overwrite:
+                    if device.name_by_user != display:
+                        dev_reg.async_update_device(device.id, name_by_user=display)
+                        devices_named += 1
+                elif device.name != display:
+                    dev_reg.async_update_device(device.id, name=display)
+                    devices_named += 1
+            if do_areas and room and (overwrite or device.area_id is None):
                 area = area_reg.async_get_area_by_name(
                     room
                 ) or area_reg.async_create(room)
-                dev_reg.async_update_device(device.id, area_id=area.id)
-                areas_set += 1
+                if device.area_id != area.id:
+                    dev_reg.async_update_device(device.id, area_id=area.id)
+                    areas_set += 1
 
-        # 2. Entities — single-entity matched devices only, never clobbering
-        # a user-set name.
-        by_device: dict[str, list] = {}
-        for ent in er.async_entries_for_config_entry(ent_reg, entry_id):
-            if ent.device_id:
-                by_device.setdefault(ent.device_id, []).append(ent)
+        entities = list(er.async_entries_for_config_entry(ent_reg, entry_id))
+
+        # Device-name → the entity of a single-entity matched device (wall
+        # buttons, latch switches); multi-entity modules inherit the device
+        # name, and their channels are named individually below.
         entities_named = 0
-        for device_id, display in matched.items():
-            ents = by_device.get(device_id, [])
-            if len(ents) != 1:
-                continue
-            ent = ents[0]
-            if ent.name is None and ent.original_name != display:
-                ent_reg.async_update_entity(ent.entity_id, name=display)
-                entities_named += 1
+        if do_names:
+            by_device: dict[str, list] = {}
+            for ent in entities:
+                if ent.device_id:
+                    by_device.setdefault(ent.device_id, []).append(ent)
+            for device_id, display in matched.items():
+                ents = by_device.get(device_id, [])
+                if len(ents) == 1 and _apply_entity_name(
+                    ent_reg, ents[0], display, overwrite
+                ):
+                    entities_named += 1
+
+        # Channel names — the per-output light / cover / switch entities.
+        channels_named = 0
+        if "channel_names" in cats and data.outputs:
+            for ent in entities:
+                key = _output_entity_key(ent.unique_id)
+                if key is None:
+                    continue
+                nm = data.outputs.get(key)
+                if nm and _apply_entity_name(ent_reg, ent, nm, overwrite):
+                    channels_named += 1
 
         _LOGGER.info(
-            "Imported .nkb from %s: %d devices, %d entities, %d areas, "
-            "%d scenes named, %d scenes created (%d addresses, %d groups "
-            "in file)",
+            "Imported .nkb from %s (overwrite=%s, categories=%s): %d devices, "
+            "%d device-entities, %d channels, %d areas, %d scenes named, "
+            "%d scenes created",
             path.name,
+            overwrite,
+            sorted(cats),
             devices_named,
             entities_named,
+            channels_named,
             areas_set,
             len(cf_name_by_addr) - scenes_created,
             scenes_created,
-            len(name_map),
-            len(data.scenes),
         )
 
-        # New scene entities only appear once the scene platform re-runs.
         if scenes_created:
             self.hass.async_create_task(
                 self.hass.config_entries.async_reload(self.config_entry.entry_id)
@@ -2547,6 +2595,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         return {
             "devices": devices_named,
             "entities": entities_named,
+            "channels": channels_named,
             "areas": areas_set,
             "scenes": len(cf_name_by_addr) - scenes_created,
             "scenes_created": scenes_created,

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -16,5 +16,5 @@
     "nikobus-connect>=0.24.0",
     "construct>=2.10"
   ],
-  "version": "3.6.0"
+  "version": "3.7.0"
 }

--- a/custom_components/nikobus/nkbnames.py
+++ b/custom_components/nikobus/nkbnames.py
@@ -78,6 +78,16 @@ class NkbData(NamedTuple):
     addresses: dict[str, tuple[str, str]]
     #: Named scene groups with member sets, for member-set matching.
     scenes: list[SceneDef]
+    #: ``{(MODULE_ADDR_UPPER, channel): name}`` — per-output channel names
+    #: (the light / cover / switch the user actually toggles). Read-only, so
+    #: the empty-dict default is safe.
+    outputs: dict[tuple[str, int], str] = {}
+
+
+# Generic per-output placeholders in the .nkb that aren't real names.
+_OUTPUT_PLACEHOLDERS = frozenset(
+    {"output", "switch output", "shutter output", "dimmer output"}
+)
 
 
 def find_nkb_file(config_dir: str) -> Path | None:
@@ -137,7 +147,31 @@ def parse_nkb(nkb_path: str | Path) -> NkbData:
     scenes = _extract_scenes(
         components, comp_by_key, objecten, connections, linkmodes, objectbase
     )
-    return NkbData(addresses=addresses, scenes=scenes)
+    outputs = _extract_outputs(comp_by_key, objecten, objectbase)
+    return NkbData(addresses=addresses, scenes=scenes, outputs=outputs)
+
+
+def _extract_outputs(
+    comp_by_key, objecten, objectbase
+) -> dict[tuple[str, int], str]:
+    """``{(MODULE_ADDR, channel): name}`` for output channels with a real
+    user name. Channel is the output's ``Prefix`` number (``O02`` → 2);
+    generic placeholders (``Output``, ``Switch output``…) are skipped."""
+    out: dict[tuple[str, int], str] = {}
+    for o in objecten:
+        comp = comp_by_key.get(o.get("KeyComponent"), {})
+        pa = comp.get("PhysicalAddress")
+        if not (isinstance(pa, int) and 0 < pa < 0x10000):
+            continue  # output modules are 16-bit (4-hex) addresses
+        base = objectbase.get(o.get("KeyObjectBase"), {})
+        m = _OUTPUT_PREFIX_RE.match(str(base.get("Prefix") or ""))
+        if not m:
+            continue
+        name = (o.get("StrUserName") or "").strip()
+        if not name or name.lower() in _OUTPUT_PLACEHOLDERS:
+            continue
+        out[(_fmt_addr(pa), int(m.group(1)))] = name
+    return out
 
 
 def _extract_addresses(

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -177,7 +177,10 @@
     "error": {
       "invalid_hex_address": "LED address must be exactly 6 hexadecimal characters (or empty).",
       "invalid_nkb": "That file isn't a readable Nikobus .nkb project (it must be the .nkb export — a ZIP containing the project database).",
-      "upload_failed": "Could not save the uploaded file. Check the Home Assistant logs."
+      "upload_failed": "Could not save the uploaded file. Check the Home Assistant logs.",
+      "nkb_nothing_selected": "Pick at least one thing to import.",
+      "nkb_not_found": "No .nkb file found — upload one first (Configure → Upload .nkb project file).",
+      "nkb_parse_failed": "Could not read the .nkb file. See the Home Assistant logs."
     },
     "step": {
       "hardware": {
@@ -199,7 +202,8 @@
         "menu_options": {
           "configure_modules": "Customize a module (description, entity type, LED triggers, travel time)",
           "hardware": "Change hardware settings",
-          "upload_nkb": "Upload .nkb project file"
+          "upload_nkb": "Upload .nkb project file",
+          "import_nkb": "Import from .nkb (choose what)"
         },
         "title": "Nikobus"
       },
@@ -246,6 +250,17 @@
         "description": "Select your Nikobus project export (any filename). It's validated and saved as nikobus.nkb in your Home Assistant config folder. Then press “Import Names from .nkb” on the Nikobus Bridge.",
         "data": {
           "file": "Project file (.nkb)"
+        }
+      },
+      "import_nkb": {
+        "title": "Import from .nkb",
+        "description": "Choose what to import from your nikobus.nkb. By default nothing you've renamed by hand is touched — tick **Overwrite** to replace your existing names/Areas with the .nkb ones.",
+        "data": {
+          "device_names": "Device names (modules, buttons, IR receivers)",
+          "channel_names": "Channel names (lights, covers, switches)",
+          "areas": "Areas (from rooms)",
+          "scenes": "Scenes (light + shutter/master)",
+          "overwrite": "Overwrite names/Areas I've already set"
         }
       }
     }

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -62,7 +62,8 @@
         "menu_options": {
           "hardware": "Modifier la configuration matérielle",
           "configure_modules": "Personnaliser un module (description, type d'entité, déclencheurs LED, temps de course)",
-          "upload_nkb": "Téléverser le fichier projet .nkb"
+          "upload_nkb": "Téléverser le fichier projet .nkb",
+          "import_nkb": "Importer depuis .nkb (choisir)"
         }
       },
       "hardware": {
@@ -123,6 +124,17 @@
         "data": {
           "file": "Fichier projet (.nkb)"
         }
+      },
+      "import_nkb": {
+        "title": "Importer depuis .nkb",
+        "description": "Choisissez ce qu'il faut importer depuis votre nikobus.nkb. Par défaut, rien de ce que vous avez renommé manuellement n'est touché — cochez **Écraser** pour remplacer vos noms/zones existants par ceux du .nkb.",
+        "data": {
+          "device_names": "Noms des appareils (modules, boutons, récepteurs IR)",
+          "channel_names": "Noms des canaux (lumières, volets, interrupteurs)",
+          "areas": "Zones (depuis les pièces)",
+          "scenes": "Scènes (lumière + volets/maître)",
+          "overwrite": "Écraser les noms/zones que j'ai déjà définis"
+        }
       }
     },
     "abort": {
@@ -130,7 +142,10 @@
     },
     "error": {
       "invalid_nkb": "Ce fichier n'est pas un projet Nikobus .nkb lisible (il doit s'agir de l'export .nkb — une archive ZIP contenant la base de données du projet).",
-      "upload_failed": "Impossible d'enregistrer le fichier téléversé. Consultez les journaux Home Assistant."
+      "upload_failed": "Impossible d'enregistrer le fichier téléversé. Consultez les journaux Home Assistant.",
+      "nkb_nothing_selected": "Choisissez au moins un élément à importer.",
+      "nkb_not_found": "Aucun fichier .nkb trouvé — téléversez-en un d'abord (Configurer → Téléverser le fichier projet .nkb).",
+      "nkb_parse_failed": "Impossible de lire le fichier .nkb. Consultez les journaux Home Assistant."
     }
   },
   "entity": {

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -62,7 +62,8 @@
         "menu_options": {
           "hardware": "Hardware-instellingen wijzigen",
           "configure_modules": "Module aanpassen (beschrijving, entiteitstype, LED-triggers, looptijd)",
-          "upload_nkb": "Projectbestand .nkb uploaden"
+          "upload_nkb": "Projectbestand .nkb uploaden",
+          "import_nkb": "Importeren uit .nkb (kiezen)"
         }
       },
       "hardware": {
@@ -123,6 +124,17 @@
         "data": {
           "file": "Projectbestand (.nkb)"
         }
+      },
+      "import_nkb": {
+        "title": "Importeren uit .nkb",
+        "description": "Kies wat je wilt importeren uit je nikobus.nkb. Standaard wordt niets aangeraakt wat je handmatig hebt hernoemd — vink **Overschrijven** aan om je bestaande namen/gebieden te vervangen door die uit de .nkb.",
+        "data": {
+          "device_names": "Apparaatnamen (modules, knoppen, IR-ontvangers)",
+          "channel_names": "Kanaalnamen (lichten, rolluiken, schakelaars)",
+          "areas": "Gebieden (uit kamers)",
+          "scenes": "Scènes (licht + rolluik/master)",
+          "overwrite": "Namen/gebieden die ik al heb ingesteld overschrijven"
+        }
       }
     },
     "abort": {
@@ -130,7 +142,10 @@
     },
     "error": {
       "invalid_nkb": "Dit bestand is geen leesbaar Nikobus .nkb-project (het moet de .nkb-export zijn — een ZIP met de projectdatabase).",
-      "upload_failed": "Kon het geüploade bestand niet opslaan. Controleer de Home Assistant-logboeken."
+      "upload_failed": "Kon het geüploade bestand niet opslaan. Controleer de Home Assistant-logboeken.",
+      "nkb_nothing_selected": "Kies minstens één ding om te importeren.",
+      "nkb_not_found": "Geen .nkb-bestand gevonden — upload er eerst een (Configureren → Projectbestand .nkb uploaden).",
+      "nkb_parse_failed": "Kon het .nkb-bestand niet lezen. Zie de Home Assistant-logboeken."
     }
   },
   "entity": {

--- a/tests/test_nkbnames.py
+++ b/tests/test_nkbnames.py
@@ -86,7 +86,7 @@ class _FakeParser:
             "KeyObjectBase": [500, 600, 700],
             "ObjectAddress": [0, 0, 0],
             "PhysicalObjectAddress": [0, 0, 0],
-            "StrUserName": [None, "Input", None],
+            "StrUserName": ["Appliques Salon", "Input", None],
         },
         "ObjectBase": {
             "KeyObjectBase": [500, 600, 700],
@@ -149,6 +149,30 @@ def test_parse_scene_member_set(tmp_path):
     # trigger(200) drives output(100)=0E6C in M12; channel 2 from Prefix
     # O02 (NOT 3 from ObjectAddress+1); MCF link excluded.
     assert sc.members == frozenset({("0E6C", 2, "M12")})
+
+
+def test_parse_extracts_output_channel_names(tmp_path):
+    data = _parse(tmp_path)
+    # output object (0E6C, Prefix O02) carries the real name "Appliques
+    # Salon"; channel 2 from the prefix, not ObjectAddress.
+    assert data.outputs == {("0E6C", 2): "Appliques Salon"}
+
+
+def test_extract_outputs_skips_placeholders(tmp_path):
+    from custom_components.nikobus.nkbnames import _extract_outputs
+
+    comp_by_key = {1: {"PhysicalAddress": 3692}}
+    objecten = [
+        {"KeyComponent": 1, "KeyObjectBase": 5, "StrUserName": "Switch output"},
+        {"KeyComponent": 1, "KeyObjectBase": 6, "StrUserName": "  "},
+        {"KeyComponent": 1, "KeyObjectBase": 7, "StrUserName": "Terrasse"},
+    ]
+    objectbase = {
+        5: {"Prefix": "O01"}, 6: {"Prefix": "O03"}, 7: {"Prefix": "O04"},
+    }
+    assert _extract_outputs(comp_by_key, objecten, objectbase) == {
+        ("0E6C", 4): "Terrasse"
+    }
 
 
 def test_parse_raises_without_mdb(tmp_path):
@@ -214,12 +238,13 @@ def _device(dev_id, addr, name="old", area_id=None):
     return d
 
 
-def _entity(eid, device_id, name=None, original_name=None):
+def _entity(eid, device_id, name=None, original_name=None, unique_id=None):
     e = MagicMock()
     e.entity_id = eid
     e.device_id = device_id
     e.name = name
     e.original_name = original_name
+    e.unique_id = unique_id
     return e
 
 
@@ -281,7 +306,7 @@ def test_import_names_areas_and_scene_match():
     with _patches(data, devices, entities, dev_reg, ent_reg, area_reg):
         result = _run(coord.async_import_nkb_names())
 
-    assert result == {"devices": 3, "entities": 2, "areas": 2,
+    assert result == {"devices": 3, "entities": 2, "channels": 0, "areas": 2,
                       "scenes": 1, "scenes_created": 0}
     names = {c.args[0]: c.kwargs.get("name")
              for c in dev_reg.async_update_device.call_args_list
@@ -403,3 +428,92 @@ def test_import_raises_when_no_file():
                return_value=None):
         with pytest.raises(HomeAssistantError):
             _run(coord.async_import_nkb_names())
+
+
+# --------------------------------------------------------------------------- #
+# channel names, category selection, overwrite
+# --------------------------------------------------------------------------- #
+def test_import_names_output_channels():
+    """Per-output entities get the .nkb channel name (matched by unique_id);
+    a placeholder/unset name is filled, an unmatched channel is left alone."""
+    data = NkbData(
+        addresses={}, scenes=[],
+        outputs={("0E6C", 1): "Appliques Salon", ("9105", 2): "Terrasse"},
+    )
+    coord = _coord()
+    entities = [
+        _entity("light.a", "d1", unique_id="nikobus_light_module_0E6C_1"),
+        _entity("cover.b", "d2", unique_id="nikobus_cover_module_9105_2"),
+        _entity("switch.c", "d3", unique_id="nikobus_switch_module_AAAA_5"),
+        _entity("binary_sensor.btn", "d4", unique_id="nikobus_binary_sensor_1843B4_1"),
+    ]
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    with _patches(data, [], entities, dev_reg, ent_reg, area_reg):
+        result = _run(coord.async_import_nkb_names(categories={"channel_names"}))
+
+    assert result["channels"] == 2
+    renamed = {c.args[0]: c.kwargs.get("name")
+               for c in ent_reg.async_update_entity.call_args_list}
+    assert renamed == {"light.a": "Appliques Salon", "cover.b": "Terrasse"}
+
+
+def test_import_category_selection_limits_work():
+    """Selecting only ``device_names`` touches no areas and no scenes."""
+    data = NkbData(
+        addresses={"1843B4": ("Entree", "Living")}, scenes=[],
+    )
+    coord = _coord()
+    dev = _device("d2", "1843B4")
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    with _patches(data, [dev], [], dev_reg, ent_reg, area_reg):
+        result = _run(coord.async_import_nkb_names(categories={"device_names"}))
+
+    assert result["devices"] == 1
+    assert result["areas"] == 0
+    area_reg.async_create.assert_not_called()
+    area_calls = [c for c in dev_reg.async_update_device.call_args_list
+                  if "area_id" in c.kwargs]
+    assert area_calls == []
+
+
+def test_import_overwrite_replaces_user_set_names():
+    """Overwrite forces the device name onto ``name_by_user`` and the
+    channel name onto an entity the user already renamed."""
+    data = NkbData(
+        addresses={"0E6C": ("Dimcontroller", "Centrale")}, scenes=[],
+        outputs={("0E6C", 1): "Appliques Salon"},
+    )
+    coord = _coord()
+    dev = _device("d1", "0E6C", name="old")
+    dev.name_by_user = "MyOwnName"
+    # two entities -> device-name logic leaves them to the channel loop
+    chan = _entity("light.a", "d1", name="MyOwnLight",
+                   unique_id="nikobus_light_module_0E6C_1")
+    chan2 = _entity("light.b", "d1", unique_id="nikobus_light_module_0E6C_2")
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    with _patches(data, [dev], [chan, chan2], dev_reg, ent_reg, area_reg):
+        result = _run(coord.async_import_nkb_names(
+            categories={"device_names", "channel_names"}, overwrite=True))
+
+    assert result["devices"] == 1
+    assert result["channels"] == 1
+    dev_reg.async_update_device.assert_any_call(
+        "d1", name_by_user="Dimcontroller (Centrale)")
+    ent_reg.async_update_entity.assert_called_once_with(
+        "light.a", name="Appliques Salon")
+
+
+def test_import_no_overwrite_keeps_user_set_channel_name():
+    """Without overwrite, a channel the user already named is left alone."""
+    data = NkbData(
+        addresses={}, scenes=[], outputs={("0E6C", 1): "Appliques Salon"},
+    )
+    coord = _coord()
+    chan = _entity("light.a", "d1", name="MyOwnLight",
+                   unique_id="nikobus_light_module_0E6C_1")
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    with _patches(data, [], [chan], dev_reg, ent_reg, area_reg):
+        result = _run(coord.async_import_nkb_names(categories={"channel_names"}))
+
+    assert result["channels"] == 0
+    ent_reg.async_update_entity.assert_not_called()


### PR DESCRIPTION
## What

Extends the `.nkb` import so you can import **per-channel output entity names** (the light / cover / switch behind a channel, e.g. `Appliques Salon`, `Terrasse`), **choose which categories** to apply, and optionally **overwrite** names/Areas you've already set.

## Changes

- **Per-channel output names.** `nkbnames._extract_outputs` reads each output's `StrUserName`, keyed on `(module_addr, prefix-channel)` (channel from the output `Prefix`, e.g. `O02` → 2 — the same fix that aligned roller scenes); generic placeholders (`Output`, `Switch output`, …) are skipped. Surfaced as `NkbData.outputs`.
- **Selectable import.** `coordinator.async_import_nkb_names(categories, overwrite)` — `categories` ⊆ `{device_names, channel_names, areas, scenes}` (default: everything). New channel-name loop matches output entities by `unique_id` via `_output_entity_key`; `_apply_entity_name` centralises the suggested-vs-overwrite rule.
- **Overwrite toggle.** Off by default — suggested names only, a manual rename always wins (device `name`, entity blank-fill). On forces the `.nkb` values (device `name_by_user`, entity `name`, Area reassignment).
- **Options-flow form.** `Configure → Import Names from .nkb` is now a form with a checkbox per category + an overwrite toggle (`async_step_import_nkb`). Empty selection → `nkb_nothing_selected`.
- **Button unchanged in spirit.** The **Import Names from .nkb** button stays the one-press "everything, non-destructive" path (log now includes the channel count).
- **Translations** en / fr / nl: `import_nkb` step, menu entry, and error strings.

## Tests

New coverage in `tests/test_nkbnames.py`: output extraction (incl. placeholder-skipping and prefix-channel), channel-name application across light/cover/switch, category selection, and overwrite in both directions. Full suite **379 passed**, `ruff check` clean.

## Changelog

Bumped to **3.7.0** with a CHANGELOG entry.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_