### PR TITLE
3.8.0: performance pass — per-address wakeups, state-write diffing, recorder hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 3.8.0
+
+Performance & logging pass — no behaviour or configuration changes.
+
+- **Per-address wakeups.** A button press used to wake *every* output/button
+  entity on a shared bus event, each filtering itself out by address — O(N)
+  per press. Presses (and per-module poll refreshes) are now routed by
+  address so only the impacted module's / button's entities are notified.
+  On a large install that's a handful of callbacks per press instead of one
+  per entity.
+- **Skip redundant state writes.** Switch, light and cover now diff their
+  resolved state before writing, so an unchanged poll cycle is a cheap
+  comparison instead of a full re-render. Availability changes and real
+  state changes still write.
+- **Quieter polling.** A module is only re-broadcast to its entities when its
+  bytes actually changed; the coordinator's own post-poll refresh still
+  covers everything.
+- **Cleaner discovery history.** The discovery-status sensor's state is now
+  the coarse phase (`idle` / `pc_link` / `module_scan` / `finished` /
+  `error`); the live per-register line moved to a `message` attribute and the
+  volatile detail is kept out of the recorder.
+- **Standardised log messages** across the integration (one consistent style;
+  levels unchanged).
+
 ## 3.7.0
 
 - **Import per-channel output names.** The `.nkb` import now also reads the

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Everything is driven from the **Nikobus Bridge** device page. The three buttons 
 Press **1. Load Project Overview**. The integration probes the PC-Link, walks its inventory, and creates a device for every module and every physical button on the bus.
 
 Two diagnostic sensors track progress:
-- **Discovery status** — live per-register message (with a coarse `phase` attribute for automations).
+- **Discovery status** — its state is the coarse phase (`idle` / `pc_link` / `module_scan` / `finished` / `error`), so history stays clean; the live per-register line is in the `message` attribute, alongside the fine-grained detail (all kept out of the recorder).
 - **Discovery progress** — 0–100 %.
 
 ### 2. Load Existing Installation

--- a/custom_components/nikobus/__init__.py
+++ b/custom_components/nikobus/__init__.py
@@ -167,7 +167,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             await coordinator.nikobus_discovery.start_inventory_discovery()
         elif custom_range:
             _LOGGER.info(
-                "Forensic Nikobus scan | module=%s registers=0x%02X..0x%02X sub=%s",
+                "Forensic scan of module %s — registers 0x%02X..0x%02X, sub=%s",
                 module_address,
                 register_start,
                 register_end,
@@ -180,7 +180,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 sub_byte=sub_byte,
             )
         else:
-            _LOGGER.info("Starting manual Nikobus discovery for module: %s", module_address)
+            _LOGGER.info("Starting discovery for module %s", module_address)
             await coordinator.nikobus_discovery.query_module_inventory(module_address)
 
     hass.services.async_register(

--- a/custom_components/nikobus/binary_sensor.py
+++ b/custom_components/nikobus/binary_sensor.py
@@ -7,12 +7,13 @@ from datetime import datetime
 from typing import Any
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 
 from .button import op_point_display_name, register_wall_button_devices
-from .const import DOMAIN, EVENT_BUTTON_PRESSED
+from .const import DOMAIN, press_signal
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .router import iter_operation_points
 from .entity import NikobusEntity
@@ -115,9 +116,13 @@ class NikobusButtonBinarySensor(NikobusEntity, BinarySensorEntity):
         """Register event listeners when added to Home Assistant."""
         await super().async_added_to_hass()
         
-        # Listen directly for button press events for this specific address
+        # Per-address signal: only this button's sensor is woken on its
+        # own press, instead of a global EVENT_BUTTON_PRESSED listener
+        # that every button sensor runs and filters by address.
         self.async_on_remove(
-            self.hass.bus.async_listen(EVENT_BUTTON_PRESSED, self._handle_button_event)
+            async_dispatcher_connect(
+                self.hass, press_signal(self._address), self._handle_button_event
+            )
         )
 
         def _cancel_reset_timer() -> None:
@@ -128,13 +133,10 @@ class NikobusButtonBinarySensor(NikobusEntity, BinarySensorEntity):
         self.async_on_remove(_cancel_reset_timer)
 
     @callback
-    def _handle_button_event(self, event: Event) -> None:
-        """Handle button press events from the Nikobus bus."""
-        if event.data.get("address") != self._address:
-            return
-
+    def _handle_button_event(self, data: dict) -> None:
+        """This button was pressed (routed by address) — pulse to 'pressed'."""
         _LOGGER.debug("Button %s pressed", self._address)
-        
+
         self._attr_is_on = True
         self.async_write_ha_state()
 

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -470,7 +470,7 @@ class NikobusPcLinkInventoryButton(ButtonEntity):
         flow through the same channel as the discovery state's error
         field, plus the integration log.
         """
-        _LOGGER.info("PC Link inventory discovery triggered via UI button")
+        _LOGGER.info("PC-Link inventory discovery triggered via UI button")
         if self._coordinator.discovery_running:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
@@ -658,7 +658,7 @@ class NikobusButtonEntity(NikobusEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Execute the button press command on the Nikobus bus."""
-        _LOGGER.debug("UI Button pressed for address: %s", self._address)
+        _LOGGER.debug("UI button pressed for address %s", self._address)
         await self.coordinator.async_event_handler(
             "ha_button_pressed", {"address": self._address}
         )

--- a/custom_components/nikobus/const.py
+++ b/custom_components/nikobus/const.py
@@ -63,6 +63,18 @@ def operation_signal(address: str) -> str:
     Mirrors the coordinator's per-address ``{DOMAIN}_update_{address}``.
     """
     return f"{DOMAIN}_operation_{address.upper()}"
+
+
+def press_signal(address: str) -> str:
+    """Per-address dispatcher signal for a button-press notification.
+
+    Sent when a button frame is seen on the bus, keyed by both the button
+    ``address`` and the impacted ``module_address``, so only the entities
+    concerned with that address wake — instead of every binary sensor /
+    cover / scene running a shared ``EVENT_BUTTON_PRESSED`` listener and
+    filtering itself out. The payload mirrors the bus event's data dict.
+    """
+    return f"{DOMAIN}_press_{address.upper()}"
 # Fired when a discovered CF/light scene is activated on the bus (its
 # trigger address is seen) — lets automations react to a scene firing,
 # whether triggered physically or from HA.

--- a/custom_components/nikobus/const.py
+++ b/custom_components/nikobus/const.py
@@ -50,6 +50,19 @@ CATEGORY_DEVICES: Final[tuple[tuple[str, str, str], ...]] = (
 # =============================================================================
 EVENT_BUTTON_OPERATION: Final[str] = "nikobus_button_operation"
 EVENT_BUTTON_PRESSED: Final[str] = "nikobus_button_pressed"
+
+
+def operation_signal(address: str) -> str:
+    """Per-address dispatcher signal for a button-operation notification.
+
+    Sent when a press impacts a module so that module's output entities
+    can invalidate their optimistic state. Routing by address means only
+    the impacted module's entities wake — unlike a listener on the shared
+    ``EVENT_BUTTON_OPERATION`` bus event, where every output entity is
+    invoked and all but the matching channels filter themselves out.
+    Mirrors the coordinator's per-address ``{DOMAIN}_update_{address}``.
+    """
+    return f"{DOMAIN}_operation_{address.upper()}"
 # Fired when a discovered CF/light scene is activated on the bus (its
 # trigger address is seen) — lets automations react to a scene firing,
 # whether triggered physically or from HA.

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -762,6 +762,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             chan_count = len(channels)
             groups = (1,) if chan_count <= 6 else (1, 2)
 
+            changed = False
             for g in groups:
                 polled += 1
                 try:
@@ -772,7 +773,10 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                         if buf is None:
                             buf = bytearray(12)
                             self._module_states[normalized] = buf
-                        buf[start : start + 6] = bytes.fromhex(state_hex[:12])
+                        new_bytes = bytes.fromhex(state_hex[:12])
+                        if buf[start : start + 6] != new_bytes:
+                            buf[start : start + 6] = new_bytes
+                            changed = True
                     else:
                         failed += 1
                 except asyncio.CancelledError:
@@ -794,10 +798,16 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                         "Error refreshing %s group %d: %s", normalized, g, err
                     )
 
-            await self.async_event_handler(
-                "nikobus_refreshed",
-                {"impacted_module_address": normalized},
-            )
+            # Only wake this module's entities when its state actually
+            # changed. The coordinator's own post-poll ``async_update_
+            # listeners`` still re-renders everything (cheaply, since
+            # entities diff before writing), so an unchanged module needs
+            # no targeted dispatch — which on a quiet bus is every module.
+            if changed:
+                await self.async_event_handler(
+                    "nikobus_refreshed",
+                    {"impacted_module_address": normalized},
+                )
         return polled, failed
 
     # ------------------------------------------------------------------

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -431,7 +431,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
     async def _event_callback(self, message: str) -> None:
         """Route non-feedback bus events (buttons, ACKs, discovery frames)."""
         _LOGGER.debug(
-            "Nikobus press frame: %s  (raw bytes hex: %s)",
+            "Press frame %s (raw hex %s)",
             message,
             message.encode().hex(),
         )
@@ -483,7 +483,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         except asyncio.CancelledError:
             raise
         except Exception as err:
-            _LOGGER.error("Feedback callback error: %s", err)
+            _LOGGER.error("Feedback callback failed: %s", err)
 
     async def _inventory_callback(self, message: str, discovery_active: bool) -> None:
         """Route $18 inventory frames."""
@@ -690,7 +690,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 registers_total=effective_register_total,
             )
         except Exception as err:  # pragma: no cover - defensive
-            _LOGGER.debug("Discovery progress handler error: %s", err)
+            _LOGGER.debug("Discovery progress handler failed: %s", err)
 
     # ------------------------------------------------------------------
     # Data update
@@ -720,7 +720,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                     failures += failed_n
             return None
         except NikobusDataError as err:
-            _LOGGER.error("Error fetching Nikobus data: %s", err)
+            _LOGGER.error("Failed to fetch Nikobus data: %s", err)
             raise UpdateFailed(f"Data refresh failed: {err}") from err
         finally:
             if (
@@ -1268,7 +1268,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         while not self._stopping:
             attempt += 1
             self._reconnect_attempts += 1
-            _LOGGER.info("Nikobus reconnect attempt %d (delay %ds)…", attempt, delay)
+            _LOGGER.info("Nikobus reconnect attempt %d (delay %ds)", attempt, delay)
             self.async_update_listeners()
             try:
                 await self.nikobus_connection.connect()
@@ -1348,16 +1348,16 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             try:
                 await self.nikobus_listener.stop()
             except NikobusError as err:
-                _LOGGER.error("Error stopping listener: %s", err)
+                _LOGGER.error("Failed to stop listener: %s", err)
         if self.nikobus_command:
             try:
                 await self.nikobus_command.stop()
             except NikobusError as err:
-                _LOGGER.error("Error stopping command handler: %s", err)
+                _LOGGER.error("Failed to stop command handler: %s", err)
         try:
             await self.nikobus_connection.disconnect()
         except NikobusError as err:
-            _LOGGER.error("Error disconnecting: %s", err)
+            _LOGGER.error("Failed to disconnect: %s", err)
 
     # ------------------------------------------------------------------
     # Misc helpers
@@ -1800,7 +1800,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 outer_delay=_PROBE_OUTER_DELAY_S,
             )
         except Exception as err:  # pragma: no cover - defensive
-            _LOGGER.error("detect_stale_inventory failed: %s", err)
+            _LOGGER.error("Stale-inventory detection failed: %s", err)
             return
 
         absent = {str(a).upper() for a in (manifest.get("absent_modules") or [])}
@@ -2261,8 +2261,8 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 )
             except asyncio.TimeoutError:
                 _LOGGER.info(
-                    "Step 1: no PC-Link response within %.1fs — falling "
-                    "back to manual config files.",
+                    "No PC-Link response within %.1fs — falling back to "
+                    "manual config files",
                     self._PCLINK_PROBE_TIMEOUT,
                 )
                 # Library's inactivity timer will fire on_discovery_finished
@@ -2375,8 +2375,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                         str(addr).upper() for addr in modules.keys()
                     )
             _LOGGER.debug(
-                "start_module_scan ALL — dict_module_data buckets=%s, "
-                "queue=%s",
+                "Module scan (all) — buckets=%s, queue=%s",
                 {k: list(v.keys()) if isinstance(v, dict) else v
                  for k, v in self.dict_module_data.items()},
                 self._discovery_module_order,

--- a/custom_components/nikobus/cover.py
+++ b/custom_components/nikobus/cover.py
@@ -181,6 +181,12 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
         """Return if the cover is open (100)."""
         return self.current_cover_position == 100
 
+    def _render_state(self) -> Any:
+        """Diff on bus state + rounded position so an idle, unchanged poll
+        skips the write. Position updates during motion are written
+        directly by the motion loop and so bypass this entirely."""
+        return (self._state, self.current_cover_position)
+
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes, merging with parent attributes."""

--- a/custom_components/nikobus/cover.py
+++ b/custom_components/nikobus/cover.py
@@ -14,7 +14,8 @@ from homeassistant.components.cover import (
     CoverEntity,
     CoverEntityFeature,
 )
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
@@ -22,7 +23,7 @@ from .const import (
     DEFAULT_COVER_DEBOUNCE_DELAY,
     DEFAULT_COVER_MOVEMENT_BUFFER,
     DEFAULT_COVER_OPERATION_TIME,
-    EVENT_BUTTON_PRESSED,
+    press_signal,
 )
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity
@@ -200,8 +201,14 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
                 self._position = float(pos)
                 self._calculator.set_position(self._position)
 
+        # Per-address signal keyed by this cover's module address: only
+        # this module's covers are woken on a press, instead of a global
+        # EVENT_BUTTON_PRESSED listener every cover runs. Channel is still
+        # filtered below (one module carries several covers).
         self.async_on_remove(
-            self.hass.bus.async_listen(EVENT_BUTTON_PRESSED, self._handle_button_pressed)
+            async_dispatcher_connect(
+                self.hass, press_signal(self._address), self._handle_button_pressed
+            )
         )
 
         def _cancel_cover_tasks() -> None:
@@ -269,8 +276,8 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
 
         super()._handle_coordinator_update()
 
-    async def _handle_button_pressed(self, event: Event) -> None:
-        """Handle a physical Nikobus button press event.
+    async def _handle_button_pressed(self, data: dict) -> None:
+        """Handle a physical Nikobus button press event (routed by module).
 
         Records the press timestamp (for detection-latency calculation) only
         when the cover is currently stopped — meaning this press is starting a
@@ -280,12 +287,9 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
         Channel filtering prevents covers on the same roller module from
         sharing timestamps when unrelated buttons are pressed.
         """
-        if str(event.data.get("module_address", "")).upper() != str(self._address).upper():
-            return
-
         # Only process events for this specific channel to avoid cross-channel
         # timestamp pollution on multi-channel roller modules.
-        event_channel = event.data.get("channel")
+        event_channel = data.get("channel")
         if event_channel is not None and int(event_channel) != self._channel:
             return
 

--- a/custom_components/nikobus/cover.py
+++ b/custom_components/nikobus/cover.py
@@ -244,13 +244,13 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
         if new_bus_state == STATE_ERROR:
             if self._movement_source == "ha":
                 _LOGGER.debug(
-                    "Cover %s ch%d: motor-protection (0x03) after HA move — sending VALUE=0.",
+                    "Cover %s ch%d motor-protection (0x03) after HA move — writing 0 to clear",
                     self._address, self._channel,
                 )
                 self.hass.async_create_task(self._stop(send_stop=True, force_api=True))
             else:
                 _LOGGER.debug(
-                    "Cover %s ch%d: motor-protection (0x03) after Nikobus move — waiting for auto-clear.",
+                    "Cover %s ch%d motor-protection (0x03) after Nikobus move — waiting for auto-clear",
                     self._address, self._channel,
                 )
                 self.hass.async_create_task(self._stop(send_stop=False))
@@ -419,7 +419,7 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
             pass
         except Exception as err:
             _LOGGER.error(
-                "Cover %s ch%d: motion loop error — forcing stop: %s",
+                "Cover %s ch%d motion loop failed — forcing stop: %s",
                 self._address,
                 self._channel,
                 err,

--- a/custom_components/nikobus/entity.py
+++ b/custom_components/nikobus/entity.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -13,6 +14,10 @@ from .const import BRAND, DOMAIN, HUB_IDENTIFIER
 from .coordinator import NikobusDataCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+# Sentinel return for ``_render_state``: this entity opts out of
+# write-diffing and writes on every coordinator update (the default).
+_NO_DIFF = object()
 
 
 def hub_device_info() -> dr.DeviceInfo:
@@ -61,6 +66,41 @@ class NikobusEntity(CoordinatorEntity[NikobusDataCoordinator]):
         if via_device is not None:
             device_info["via_device"] = via_device
         self._attr_device_info = device_info
+
+        #: Last ``(available, render_state)`` actually written, for diffing.
+        self._last_render: tuple | None = None
+
+    def _invalidate_optimistic(self) -> None:
+        """Drop optimistic caches before the real state is read (override)."""
+
+    def _render_state(self) -> Any:
+        """Return the displayed state used to skip redundant writes.
+
+        Override to opt this entity into write-diffing (returning a
+        hashable that captures what the user sees). The default opts out
+        — the entity writes on every coordinator update.
+        """
+        return _NO_DIFF
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Write HA state on a coordinator update, skipping the write when
+        nothing the user sees has changed.
+
+        Each output module is polled every cycle and entities are woken
+        per module; without this, every channel re-rendered (and recom-
+        puted its attributes) every cycle even when its byte was
+        unchanged. Diffing on ``(available, render_state)`` collapses an
+        unchanged cycle to a cheap comparison.
+        """
+        self._invalidate_optimistic()
+        state = self._render_state()
+        if state is not _NO_DIFF:
+            signature = (self.available, state)
+            if signature == self._last_render:
+                return
+            self._last_render = signature
+        super()._handle_coordinator_update()
 
     @property
     def available(self) -> bool:

--- a/custom_components/nikobus/light.py
+++ b/custom_components/nikobus/light.py
@@ -110,11 +110,13 @@ class NikobusBaseLight(NikobusEntity, LightEntity, RestoreEntity):
             )
         )
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Invalidate optimistic cache when coordinator gets true hardware data."""
+    def _invalidate_optimistic(self) -> None:
+        """Drop the optimistic state so the real hardware state is read."""
         self._is_on = None
-        super()._handle_coordinator_update()
+
+    def _render_state(self) -> Any:
+        """Diff on the resolved on/off so an unchanged poll skips the write."""
+        return self.is_on
 
     @callback
     def _handle_button_operation(self) -> None:
@@ -154,11 +156,14 @@ class NikobusDimmerEntity(NikobusBaseLight):
             return self._optimistic_brightness
         return self.coordinator.get_light_brightness(self._address, self._channel)
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Invalidate optimistic caches when coordinator gets true hardware data."""
+    def _invalidate_optimistic(self) -> None:
+        """Also drop the optimistic brightness for this dimmer."""
+        super()._invalidate_optimistic()
         self._optimistic_brightness = None
-        super()._handle_coordinator_update()
+
+    def _render_state(self) -> Any:
+        """Diff on resolved on/off + brightness for the dimmer."""
+        return (self.is_on, self.brightness)
 
     @callback
     def _handle_button_operation(self) -> None:

--- a/custom_components/nikobus/light.py
+++ b/custom_components/nikobus/light.py
@@ -7,11 +7,12 @@ import logging
 from typing import Any
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .const import EVENT_BUTTON_OPERATION
+from .const import operation_signal
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity
 from .router import build_unique_id, get_routing, register_output_module_devices
@@ -98,22 +99,27 @@ class NikobusBaseLight(NikobusEntity, LightEntity, RestoreEntity):
         if last_state := await self.async_get_last_state():
             self._is_on = last_state.state == "on"
 
+        # Per-address signal: only this module's entities are woken on a
+        # press, instead of a global EVENT_BUTTON_OPERATION listener that
+        # every output entity runs and filters by address.
         self.async_on_remove(
-            self.hass.bus.async_listen(EVENT_BUTTON_OPERATION, self._handle_nikobus_event)
+            async_dispatcher_connect(
+                self.hass,
+                operation_signal(self._address),
+                self._handle_button_operation,
+            )
         )
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Invalidate optimistic cache when coordinator gets true hardware data."""
-        self._is_on = None  
+        self._is_on = None
         super()._handle_coordinator_update()
 
     @callback
-    def _handle_nikobus_event(self, event: Event) -> None:
-        """Handle physical button operation events."""
-        if str(event.data.get("impacted_module_address")) != str(self._address):
-            return
-        
+    def _handle_button_operation(self) -> None:
+        """A press impacted this module — drop optimistic state so the
+        next read reflects the new hardware state."""
         self._is_on = None
         self.async_write_ha_state()
 
@@ -155,11 +161,10 @@ class NikobusDimmerEntity(NikobusBaseLight):
         super()._handle_coordinator_update()
 
     @callback
-    def _handle_nikobus_event(self, event: Event) -> None:
-        """Handle physical button operation events."""
-        if str(event.data.get("impacted_module_address")) == str(self._address):
-            self._optimistic_brightness = None
-        super()._handle_nikobus_event(event)
+    def _handle_button_operation(self) -> None:
+        """Also drop the optimistic brightness for this dimmer's module."""
+        self._optimistic_brightness = None
+        super()._handle_button_operation()
 
     def _previous_brightness(self) -> int:
         """Best estimate of the wall LED's current "we last broadcast" state.

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -16,5 +16,5 @@
     "nikobus-connect>=0.24.0",
     "construct>=2.10"
   ],
-  "version": "3.7.0"
+  "version": "3.8.0"
 }

--- a/custom_components/nikobus/nkbactuator.py
+++ b/custom_components/nikobus/nkbactuator.py
@@ -30,6 +30,7 @@ from .const import (
     RELEASE_THRESHOLD_MS,
     SHORT_PRESS,
     operation_signal,
+    press_signal,
 )
 
 if TYPE_CHECKING:
@@ -311,11 +312,6 @@ class NikobusActuator:
                     "impacted_module_group": group,
                 }
             )
-            # Internal per-address wake for this module's output entities,
-            # alongside the public bus event above (which automations may
-            # consume). The targeted signal reaches only the impacted
-            # module's entities instead of every output entity on the bus.
-            async_dispatcher_send(self._hass, operation_signal(addr))
 
             # ==========================================
             # 2. Strict Module Debouncer (Prevents UI Jumps)
@@ -399,8 +395,24 @@ class NikobusActuator:
             
         # Log the event exactly as it is fired to the Home Assistant bus
         _LOGGER.debug("[%s] Firing HA Event: %s | Payload: %s", state.press_id, event_type, payload)
-        
+
         self._hass.bus.async_fire(event_type, payload)
+
+        # Internal per-address wake alongside the public bus event, so a
+        # notification reaches only the entities of the addresses it
+        # concerns rather than every output / button entity filtering a
+        # shared event (see operation_signal / press_signal). Automations
+        # still consume the bus events fired above.
+        if event_type == EVENT_BUTTON_OPERATION:
+            if module := payload.get("impacted_module_address"):
+                async_dispatcher_send(self._hass, operation_signal(module))
+        elif event_type == EVENT_BUTTON_PRESSED:
+            seen: set[str] = set()
+            for key in ("address", "module_address"):
+                addr = payload.get(key)
+                if addr and addr not in seen:
+                    seen.add(addr)
+                    async_dispatcher_send(self._hass, press_signal(addr), payload)
 
     def _derive_button_context(self, address: str) -> tuple[str | None, int | None]:
         """Determine the primary (module_address, channel) link from discovery."""

--- a/custom_components/nikobus/nkbactuator.py
+++ b/custom_components/nikobus/nkbactuator.py
@@ -283,7 +283,7 @@ class NikobusActuator:
         press_id = (press_context or {}).get("press_id") or f"{button_address}-{uuid.uuid4().hex[:8]}"
 
         impacted = self._derive_impacted_modules(op_point)
-        _LOGGER.debug("[%s] Processing button %s: %d modules impacted", press_id, button_address, len(impacted))
+        _LOGGER.debug("[%s] Button %s impacts %d module(s)", press_id, button_address, len(impacted))
 
         for addr, group in impacted:
 
@@ -294,7 +294,7 @@ class NikobusActuator:
             is_initial_press = press_context is not None and press_context.get("duration_s") == 0.0
 
             if requires_long_press and is_initial_press:
-                _LOGGER.debug("[%s] Ignoring initial press for Dimmer %s (Group %s). Waiting for release.", press_id, addr, group)
+                _LOGGER.debug("[%s] Dimmer %s group %s — ignoring initial press, waiting for release", press_id, addr, group)
                 continue
 
             # ==========================================
@@ -318,7 +318,7 @@ class NikobusActuator:
             # ==========================================
             cache_key = f"{addr}_{group}"
             if cache_key in self._module_refresh_tasks:
-                _LOGGER.debug("[%s] Canceling previous pending refresh for %s (Group %s)", press_id, addr, group)
+                _LOGGER.debug("[%s] Cancelling pending refresh for module %s group %s", press_id, addr, group)
                 self._module_refresh_tasks[cache_key].cancel()
 
             # ==========================================
@@ -328,46 +328,47 @@ class NikobusActuator:
                 try:
                     # STEP 1: Immediate UI Update (Skip for dimmers)
                     if not m_requires_long_press:
-                        _LOGGER.debug("[%s] Step 1: Immediate refresh for %s (Group %s)", m_press_id, m_addr, m_group)
+                        _LOGGER.debug("[%s] Immediate refresh of module %s group %s", m_press_id, m_addr, m_group)
                         await asyncio.sleep(0.3)
-                        
-                        # Bus Clearance Check
+
+                        # Skip while the button is still held — a read now
+                        # would collide on the bus; defer to the release.
                         if button_address.upper() in self._press_states:
-                            _LOGGER.debug("[%s] Button still held. Aborting Step 1 to prevent collision. Deferring to release event.", m_press_id)
+                            _LOGGER.debug("[%s] Button still held — deferring refresh to release", m_press_id)
                             return
-                        
+
                         try:
                             new_state = await self._coordinator.nikobus_command.get_output_state(m_addr, m_group)
                             if new_state:
-                                _LOGGER.debug("[%s] Step 1 Success for %s: %s", m_press_id, m_addr, new_state)
+                                _LOGGER.debug("[%s] Module %s read %s on immediate refresh", m_press_id, m_addr, new_state)
                                 self._coordinator.set_bytearray_group_state(m_addr, m_group, new_state)
                                 await self._coordinator.async_event_handler("nikobus_refreshed", {"impacted_module_address": m_addr})
                         except asyncio.CancelledError:
                             raise
                         except Exception as err:
-                            _LOGGER.debug("[%s] Step 1 Quick fetch failed for %s: %s", m_press_id, m_addr, err)
+                            _LOGGER.debug("[%s] Immediate refresh of module %s failed: %s", m_press_id, m_addr, err)
 
-                    # STEP 2: Delayed Check for Settled State
+                    # Read again once the outputs have settled.
                     delay = DIMMER_DELAY if m_requires_long_press else max(0, REFRESH_DELAY - 0.3)
-                    _LOGGER.debug("[%s] Step 2: Waiting %.1fs for settled state on %s", m_press_id, delay, m_addr)
-                    
+                    _LOGGER.debug("[%s] Waiting %.1fs for module %s to settle", m_press_id, delay, m_addr)
+
                     await asyncio.sleep(delay)
 
-                    _LOGGER.debug("[%s] Step 2: Requesting final state for %s (Group %s)", m_press_id, m_addr, m_group)
+                    _LOGGER.debug("[%s] Reading settled state of module %s group %s", m_press_id, m_addr, m_group)
                     new_state = await self._coordinator.nikobus_command.get_output_state(m_addr, m_group)
-                    
+
                     if new_state:
-                        _LOGGER.debug("[%s] Step 2 Success for %s: %s", m_press_id, m_addr, new_state)
+                        _LOGGER.debug("[%s] Module %s settled at %s", m_press_id, m_addr, new_state)
                         self._coordinator.set_bytearray_group_state(m_addr, m_group, new_state)
                         await self._coordinator.async_event_handler("nikobus_refreshed", {"impacted_module_address": m_addr})
                     else:
-                        _LOGGER.warning("[%s] Step 2: Module %s returned empty state", m_press_id, m_addr)
+                        _LOGGER.warning("[%s] Module %s returned an empty settled state", m_press_id, m_addr)
 
                 except asyncio.CancelledError:
-                    _LOGGER.debug("[%s] Refresh task for %s was cancelled by a newer press", m_press_id, m_addr)
-                    return 
+                    _LOGGER.debug("[%s] Refresh of module %s cancelled by a newer press", m_press_id, m_addr)
+                    return
                 except Exception as err:
-                    _LOGGER.error("[%s] Error refreshing module %s (Group %s): %s", m_press_id, m_addr, m_group, err)
+                    _LOGGER.error("[%s] Failed to refresh module %s group %s: %s", m_press_id, m_addr, m_group, err)
                 finally:
                     # Clean up the task reference when done
                     if self._module_refresh_tasks.get(cache_key) == asyncio.current_task():
@@ -394,7 +395,7 @@ class NikobusActuator:
             payload.update(extra)
             
         # Log the event exactly as it is fired to the Home Assistant bus
-        _LOGGER.debug("[%s] Firing HA Event: %s | Payload: %s", state.press_id, event_type, payload)
+        _LOGGER.debug("[%s] Fire %s — %s", state.press_id, event_type, payload)
 
         self._hass.bus.async_fire(event_type, payload)
 

--- a/custom_components/nikobus/nkbactuator.py
+++ b/custom_components/nikobus/nkbactuator.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from nikobus_connect.discovery import find_module, find_operation_point
 
 from .const import (
@@ -28,6 +29,7 @@ from .const import (
     REFRESH_DELAY,
     RELEASE_THRESHOLD_MS,
     SHORT_PRESS,
+    operation_signal,
 )
 
 if TYPE_CHECKING:
@@ -309,6 +311,11 @@ class NikobusActuator:
                     "impacted_module_group": group,
                 }
             )
+            # Internal per-address wake for this module's output entities,
+            # alongside the public bus event above (which automations may
+            # consume). The targeted signal reaches only the impacted
+            # module's entities instead of every output entity on the bus.
+            async_dispatcher_send(self._hass, operation_signal(addr))
 
             # ==========================================
             # 2. Strict Module Debouncer (Prevents UI Jumps)

--- a/custom_components/nikobus/nkbmanual.py
+++ b/custom_components/nikobus/nkbmanual.py
@@ -76,7 +76,7 @@ async def _read_json(
         return path, json.loads(raw)
     except (OSError, json.JSONDecodeError) as err:
         _LOGGER.warning(
-            "Manual-config: %s is unreadable (%s); skipping.", path, err
+            "Manual config: %s is unreadable (%s) — skipping", path, err
         )
         return None, None
 
@@ -647,8 +647,8 @@ def _consolidate_legacy_1a_only_buttons(
         out[addr] = entry
     out.update(new_entries)
     _LOGGER.info(
-        "Manual-config: consolidated %d 1A-only button faces into "
-        "%d canonical multi-key button(s).",
+        "Manual config: consolidated %d 1A-only button faces into "
+        "%d canonical multi-key button(s)",
         len(consumed), len(new_entries),
     )
     return out
@@ -677,7 +677,7 @@ async def async_apply_manual_config(
         raise
     except Exception:  # noqa: BLE001
         _LOGGER.exception(
-            "Manual-config: error applying %s; module store left unchanged",
+            "Manual config: failed to apply %s — module store left unchanged",
             MANUAL_MODULE_CONFIG_FILENAME,
         )
         modules_loaded = 0
@@ -691,7 +691,7 @@ async def async_apply_manual_config(
         raise
     except Exception:  # noqa: BLE001
         _LOGGER.exception(
-            "Manual-config: error applying %s; button store left unchanged",
+            "Manual config: failed to apply %s — button store left unchanged",
             MANUAL_BUTTON_CONFIG_FILENAME,
         )
         buttons_loaded = 0
@@ -705,7 +705,7 @@ async def async_apply_manual_config(
         # silently no-op here so PC-Link installs don't log noise on
         # every startup.
         _LOGGER.debug(
-            "Manual-config: neither %s nor %s present in %s; skipping import.",
+            "Manual config: neither %s nor %s found in %s — skipping import",
             MANUAL_MODULE_CONFIG_FILENAME,
             MANUAL_BUTTON_CONFIG_FILENAME,
             hass.config.path(""),
@@ -713,10 +713,9 @@ async def async_apply_manual_config(
         return False
 
     _LOGGER.info(
-        "Manual-config applied (declarative): modules=%d (source=%s) "
-        "buttons=%d physical / %d operation-points (source=%s). "
-        "Reload the integration after editing either file to apply "
-        "changes.",
+        "Manual config applied (declarative): modules=%d (source=%s), "
+        "buttons=%d physical / %d operation-points (source=%s) — reload "
+        "the integration after editing either file to apply changes",
         modules_loaded,
         module_path or "—",
         buttons_loaded,

--- a/custom_components/nikobus/scene.py
+++ b/custom_components/nikobus/scene.py
@@ -8,15 +8,16 @@ import uuid
 from typing import Any
 
 from homeassistant.components.scene import Scene
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .button import op_point_display_name
 from .const import (
     CATEGORY_SCENES,
     DOMAIN,
-    EVENT_BUTTON_PRESSED,
     EVENT_SCENE_ACTIVATED,
+    press_signal,
 )
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity
@@ -199,20 +200,23 @@ class NikobusCFSceneEntity(NikobusEntity, Scene):
         return out_list
 
     async def async_added_to_hass(self) -> None:
-        """Watch the bus so a physical scene activation fires an event."""
+        """Watch this scene's trigger addresses so a physical activation
+        fires an event. One per-address signal per trigger (one Central
+        Function, many triggers) wakes only this scene, not every scene."""
         await super().async_added_to_hass()
-        self.async_on_remove(
-            self.hass.bus.async_listen(EVENT_BUTTON_PRESSED, self._handle_trigger)
-        )
+        for addr in self._triggered_by:
+            self.async_on_remove(
+                async_dispatcher_connect(
+                    self.hass, press_signal(addr), self._handle_trigger
+                )
+            )
 
     @callback
-    def _handle_trigger(self, event: Event) -> None:
-        """Fire ``nikobus_scene_activated`` when any of this scene's trigger
+    def _handle_trigger(self, data: dict) -> None:
+        """Fire ``nikobus_scene_activated`` when one of this scene's trigger
         addresses is seen on the bus — physical press or HA-originated frame
-        alike (one Central Function, many triggers)."""
-        fired = str(event.data.get("address") or "").upper()
-        if fired not in self._triggered_by:
-            return
+        alike. Routed by address, so any delivery here is a match."""
+        fired = str(data.get("address") or "").upper()
         self.hass.bus.async_fire(
             EVENT_SCENE_ACTIVATED,
             {

--- a/custom_components/nikobus/scene.py
+++ b/custom_components/nikobus/scene.py
@@ -421,7 +421,7 @@ class NikobusSceneEntity(NikobusEntity, Scene):
     async def _process_feedback_leds(self) -> None:
         """Send feedback LED trigger commands."""
         for addr in self._feedback_leds:
-            _LOGGER.debug("Triggering feedback LED/Button: %s", addr)
+            _LOGGER.debug("Triggering feedback LED for %s", addr)
             # Standard Nikobus button trigger — sent as a repeated burst
             # (see coordinator.async_send_button_press) so it isn't
             # dropped under bus contention.

--- a/custom_components/nikobus/sensor.py
+++ b/custom_components/nikobus/sensor.py
@@ -91,20 +91,29 @@ class _DiscoverySignalEntity(SensorEntity):
 
 
 class NikobusDiscoveryStatusSensor(_DiscoverySignalEntity):
-    """Text sensor showing the current discovery status line.
+    """Discovery status sensor: coarse phase as the state, live detail as
+    attributes.
 
-    Reports ``discovery_status_message`` (e.g.
-    ``"Scanning module 0E6C (2/10) — register 0x87 of 0xFF (145 records)"``)
-    as the native value so the user sees per-register progress in real
-    time instead of a coarse enum that sits at ``"module_scan"`` for the
-    entire register-scan phase. The previous enum classification
-    (``idle|pc_link|module_scan|finished|error``) is still exposed as the
-    ``phase`` attribute for automations that grouped on it.
+    The **state** is the coarse phase (``idle|pc_link|module_scan|
+    finished|error``) — low cardinality, so the history is a handful of
+    clean transitions rather than hundreds of distinct per-register
+    strings. The live line (e.g. ``"Scanning module 0E6C (2/10) —
+    register 0x87 of 0xFF (145 records)"``) and the fine-grained detail
+    are attributes, all in ``_unrecorded_attributes`` so the per-register
+    churn during a scan never reaches the recorder.
     """
 
     _attr_has_entity_name = True
     _attr_translation_key = "discovery_status"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    # Transient progress detail — visible live, never worth recording.
+    _unrecorded_attributes = frozenset(
+        {
+            "message", "phase", "sub_phase", "current_module", "modules_done",
+            "modules_total", "register_current", "registers_done",
+            "registers_total", "decoded_records", "last_error",
+        }
+    )
 
     def __init__(self, coordinator: NikobusDataCoordinator) -> None:
         super().__init__(coordinator)
@@ -112,12 +121,13 @@ class NikobusDiscoveryStatusSensor(_DiscoverySignalEntity):
 
     @property
     def native_value(self) -> str:
-        return self._coordinator.discovery_status_message
+        return self._coordinator.discovery_phase
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         c = self._coordinator
         return {
+            "message": c.discovery_status_message,
             "phase": c.discovery_phase,
             "sub_phase": c.discovery_sub_phase,
             "current_module": c.discovery_current_module,

--- a/custom_components/nikobus/switch.py
+++ b/custom_components/nikobus/switch.py
@@ -7,12 +7,12 @@ import logging
 from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .const import EVENT_BUTTON_PRESSED, operation_signal
+from .const import operation_signal, press_signal
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity
 from .router import (
@@ -342,14 +342,19 @@ class NikobusInputLatchSwitch(NikobusEntity, SwitchEntity, RestoreEntity):
         last = await self.async_get_last_state()
         if last is not None and last.state in ("on", "off"):
             self._attr_is_on = last.state == "on"
-        self.async_on_remove(
-            self.hass.bus.async_listen(EVENT_BUTTON_PRESSED, self._handle_button_event)
-        )
+        # Per-address signals for this input's two bus addresses (1A / 1B),
+        # so only this latch is woken — not every entity on a press.
+        for addr in (self._addr_1a, self._addr_1b):
+            self.async_on_remove(
+                async_dispatcher_connect(
+                    self.hass, press_signal(addr), self._handle_button_event
+                )
+            )
 
     @callback
-    def _handle_button_event(self, event: Event) -> None:
+    def _handle_button_event(self, data: dict) -> None:
         """Latch on the 1A signal, clear on the 1B signal."""
-        addr = str(event.data.get("address") or "").upper()
+        addr = str(data.get("address") or "").upper()
         if addr == self._addr_1a:
             self._attr_is_on = True
             self.async_write_ha_state()

--- a/custom_components/nikobus/switch.py
+++ b/custom_components/nikobus/switch.py
@@ -8,10 +8,11 @@ from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .const import EVENT_BUTTON_OPERATION, EVENT_BUTTON_PRESSED
+from .const import EVENT_BUTTON_PRESSED, operation_signal
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity
 from .router import (
@@ -172,8 +173,15 @@ class NikobusBaseSwitch(NikobusEntity, SwitchEntity, RestoreEntity):
         if last_state := await self.async_get_last_state():
             self._is_on = last_state.state == "on"
 
+        # Per-address signal: only this module's entities are woken on a
+        # press, instead of a global EVENT_BUTTON_OPERATION listener that
+        # every output entity runs and filters by address.
         self.async_on_remove(
-            self.hass.bus.async_listen(EVENT_BUTTON_OPERATION, self._handle_nikobus_event)
+            async_dispatcher_connect(
+                self.hass,
+                operation_signal(self._address),
+                self._handle_button_operation,
+            )
         )
 
     @callback
@@ -183,11 +191,9 @@ class NikobusBaseSwitch(NikobusEntity, SwitchEntity, RestoreEntity):
         super()._handle_coordinator_update()
 
     @callback
-    def _handle_nikobus_event(self, event: Event) -> None:
-        """Handle physical button operation events."""
-        if str(event.data.get("impacted_module_address")) != str(self._address):
-            return
-        
+    def _handle_button_operation(self) -> None:
+        """A press impacted this module — drop optimistic state so the
+        next read reflects the new hardware state."""
         self._is_on = None
         self.async_write_ha_state()
 

--- a/custom_components/nikobus/switch.py
+++ b/custom_components/nikobus/switch.py
@@ -184,11 +184,13 @@ class NikobusBaseSwitch(NikobusEntity, SwitchEntity, RestoreEntity):
             )
         )
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Invalidate cache when hardware data is received."""
+    def _invalidate_optimistic(self) -> None:
+        """Drop the optimistic state so the real hardware state is read."""
         self._is_on = None
-        super()._handle_coordinator_update()
+
+    def _render_state(self) -> Any:
+        """Diff on the resolved on/off so an unchanged poll skips the write."""
+        return self.is_on
 
     @callback
     def _handle_button_operation(self) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,6 +193,8 @@ class _DataUpdateCoordinatorStub:
 class _CoordinatorEntityStub:
     """Minimal stub for CoordinatorEntity."""
 
+    available = True  # NikobusEntity.available reads super().available
+
     def __class_getitem__(cls, item):
         return cls
 
@@ -209,7 +211,8 @@ class _CoordinatorEntityStub:
         pass
 
     def _handle_coordinator_update(self):
-        pass
+        # Real CoordinatorEntity writes HA state on every update.
+        self.async_write_ha_state()
 
 
 _mod(

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -8,9 +8,10 @@ from __future__ import annotations
 
 import asyncio
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from custom_components.nikobus.binary_sensor import NikobusButtonBinarySensor
+from custom_components.nikobus.const import press_signal
 
 
 def _run(coro):
@@ -26,36 +27,36 @@ def _make():
     return e, coord
 
 
-def _press(address):
-    ev = MagicMock()
-    ev.data = {"address": address}
-    return ev
-
-
 class TestButtonBinarySensor(unittest.TestCase):
     def test_initial_state_idle(self):
         e, _ = _make()
         self.assertFalse(e._attr_is_on)
         self.assertEqual(e.state, "idle")
 
-    def test_press_match_sets_pressed_and_schedules_reset(self):
+    def test_press_sets_pressed_and_schedules_reset(self):
+        # The signal is per-address, so any delivery is this button's press.
         e, _ = _make()
-        e._handle_button_event(_press("081032"))
+        e._handle_button_event({"address": "081032"})
         self.assertTrue(e._attr_is_on)
         self.assertEqual(e.state, "pressed")
         # async_call_later (stubbed) returns a cancel handle
         self.assertIsNotNone(e._reset_timer_cancel)
 
-    def test_press_other_address_ignored(self):
+    def test_subscribes_to_its_own_press_signal(self):
         e, _ = _make()
-        e._handle_button_event(_press("FFFFFF"))
-        self.assertFalse(e._attr_is_on)
+        with patch(
+            "custom_components.nikobus.binary_sensor.async_dispatcher_connect",
+            return_value=lambda: None,
+        ) as conn:
+            _run(e.async_added_to_hass())
+        signals = [c.args[1] for c in conn.call_args_list]
+        self.assertIn(press_signal("081032"), signals)
 
     def test_second_press_cancels_prior_timer(self):
         e, _ = _make()
         cancel = MagicMock()
         e._reset_timer_cancel = cancel
-        e._handle_button_event(_press("081032"))
+        e._handle_button_event({"address": "081032"})
         cancel.assert_called_once()
 
     def test_reset_returns_to_idle(self):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -72,6 +72,7 @@ class _FakeCoord:
     set_bytearray_group_state = NikobusDataCoordinator.set_bytearray_group_state
     _feedback_callback = NikobusDataCoordinator._feedback_callback
     get_cover_operation_time = NikobusDataCoordinator.get_cover_operation_time
+    _refresh_module_type = NikobusDataCoordinator._refresh_module_type
 
 
 def _coord(states=None, module_data=None):
@@ -2026,6 +2027,46 @@ class TestCollectButtonLinkedModules(unittest.TestCase):
             }
         }
         self.assertEqual(self._collect(phys), {"AABB"})
+
+
+class TestRefreshModuleTypeDispatch(unittest.TestCase):
+    """The poll wakes a module's entities only when its bytes changed; the
+    coordinator's own post-poll global refresh covers the rest."""
+
+    def _run(self, coro):
+        return asyncio.new_event_loop().run_until_complete(coro)
+
+    def _setup(self, state_hex):
+        c = _coord(states={})
+        c.async_event_handler = AsyncMock()
+        c.nikobus_command.get_output_state = AsyncMock(return_value=state_hex)
+        return c
+
+    def test_dispatches_on_first_read_and_on_change_only(self):
+        c = self._setup("0102030405060708090A0B0C")
+        modules = {"C1C7": {"channels": [1, 2, 3, 4]}}
+
+        polled, failed = self._run(c._refresh_module_type(modules))
+        self.assertEqual((polled, failed), (1, 0))
+        self.assertEqual(c.async_event_handler.await_count, 1)  # empty -> real
+
+        self._run(c._refresh_module_type(modules))              # identical poll
+        self.assertEqual(c.async_event_handler.await_count, 1)  # no extra wake
+
+        c.nikobus_command.get_output_state = AsyncMock(
+            return_value="FF02030405060708090A0B0C"
+        )
+        self._run(c._refresh_module_type(modules))              # byte changed
+        self.assertEqual(c.async_event_handler.await_count, 2)
+
+    def test_unchanged_module_never_dispatches(self):
+        c = _coord(states={"C1C7": bytearray.fromhex("0102030405060708090A0B0C")})
+        c.async_event_handler = AsyncMock()
+        c.nikobus_command.get_output_state = AsyncMock(
+            return_value="0102030405060708090A0B0C"
+        )
+        self._run(c._refresh_module_type({"C1C7": {"channels": [1, 2, 3, 4]}}))
+        c.async_event_handler.assert_not_awaited()
 
 
 if __name__ == "__main__":

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -231,27 +231,31 @@ class TestStop(unittest.TestCase):
 
 
 class TestHandleButtonPressed(unittest.TestCase):
-    def _event(self, **data):
-        ev = MagicMock()
-        ev.data = data
-        return ev
+    # The signal is routed by module address, so the handler only filters
+    # by channel (one roller module carries several covers).
 
-    def test_ignores_other_module(self):
+    def test_subscribes_to_its_module_press_signal(self):
+        from custom_components.nikobus.const import press_signal
+
         ent, _ = _make_cover()
-        ent._state = STATE_STOPPED
-        _run(ent._handle_button_pressed(self._event(module_address="DEAD", channel=1)))
-        self.assertIsNone(ent._last_button_press_monotonic)
+        with patch(
+            "custom_components.nikobus.cover.async_dispatcher_connect",
+            return_value=lambda: None,
+        ) as conn:
+            _run(ent.async_added_to_hass())
+        signals = [c.args[1] for c in conn.call_args_list]
+        self.assertIn(press_signal("9105"), signals)
 
     def test_ignores_other_channel(self):
         ent, _ = _make_cover()
         ent._state = STATE_STOPPED
-        _run(ent._handle_button_pressed(self._event(module_address="9105", channel=2)))
+        _run(ent._handle_button_pressed({"channel": 2}))
         self.assertIsNone(ent._last_button_press_monotonic)
 
     def test_records_timestamp_when_stopped(self):
         ent, _ = _make_cover()
         ent._state = STATE_STOPPED
-        _run(ent._handle_button_pressed(self._event(module_address="9105", channel=1)))
+        _run(ent._handle_button_pressed({"channel": 1}))
         self.assertIsNotNone(ent._last_button_press_monotonic)
 
     def test_press_while_moving_is_a_stop(self):
@@ -259,7 +263,7 @@ class TestHandleButtonPressed(unittest.TestCase):
         ent._state = STATE_OPENING
         ent._movement_source = "ha"
         ent._stop = AsyncMock()
-        _run(ent._handle_button_pressed(self._event(module_address="9105", channel=1)))
+        _run(ent._handle_button_pressed({"channel": 1}))
         ent._stop.assert_awaited_once_with(send_stop=True)
 
 

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -307,6 +307,24 @@ class TestHandleCoordinatorUpdate(unittest.TestCase):
         self.assertEqual(ent._start_motion_logic.call_args.args[0], "opening")
         self.assertEqual(ent._movement_source, "nikobus")
 
+    def test_idle_unchanged_poll_skips_write(self):
+        # An idle cover polled with the same bus state writes once, then
+        # diffs out the redundant re-renders.
+        ent, _ = self._setup(STATE_STOPPED, state=STATE_STOPPED)
+        ent.async_write_ha_state = MagicMock()
+        ent._handle_coordinator_update()
+        ent._handle_coordinator_update()
+        ent._handle_coordinator_update()
+        self.assertEqual(ent.async_write_ha_state.call_count, 1)
+
+    def test_position_change_writes(self):
+        ent, _ = self._setup(STATE_STOPPED, state=STATE_STOPPED)
+        ent.async_write_ha_state = MagicMock()
+        ent._handle_coordinator_update()           # initial render
+        ent._position = ent._position + 25         # e.g. motion advanced it
+        ent._handle_coordinator_update()           # position changed -> writes
+        self.assertEqual(ent.async_write_ha_state.call_count, 2)
+
 
 class TestSetCoverPosition(unittest.TestCase):
     def test_noop_when_already_at_target(self):

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 
 import asyncio
 import unittest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from custom_components.nikobus.const import operation_signal
 from custom_components.nikobus.light import (
     NikobusDimmerEntity,
     NikobusRelayEntity,
@@ -34,12 +35,6 @@ def _coord():
     c.get_switch_state = MagicMock(return_value=False)
     c.get_cover_state = MagicMock(return_value=0x00)
     return c
-
-
-def _event(module_address):
-    ev = MagicMock()
-    ev.data = {"impacted_module_address": module_address}
-    return ev
 
 
 class TestDimmer(unittest.TestCase):
@@ -97,18 +92,26 @@ class TestDimmer(unittest.TestCase):
         self.assertIsNone(e._optimistic_brightness)
         c.api.turn_off_light.assert_awaited_once_with("0E6C", 1, current_brightness=90)
 
-    def test_nikobus_event_clears_optimistic_on_match(self):
+    def test_button_operation_clears_optimistic_state(self):
+        # The signal is per-module, so any delivery is for this dimmer.
         e, _ = self._make()
         e._optimistic_brightness = 100
         e._is_on = True
-        e._handle_nikobus_event(_event("0E6C"))
+        e.async_write_ha_state = MagicMock()
+        e._handle_button_operation()
         self.assertIsNone(e._optimistic_brightness)
+        self.assertIsNone(e._is_on)
 
-    def test_nikobus_event_ignores_other_module(self):
+    def test_subscribes_to_its_module_operation_signal(self):
         e, _ = self._make()
-        e._optimistic_brightness = 100
-        e._handle_nikobus_event(_event("DEAD"))
-        self.assertEqual(e._optimistic_brightness, 100)
+        e.hass = MagicMock()
+        with patch(
+            "custom_components.nikobus.light.async_dispatcher_connect",
+            return_value=lambda: None,
+        ) as conn:
+            _run(e.async_added_to_hass())
+        signals = [c.args[1] for c in conn.call_args_list]
+        self.assertIn(operation_signal("0E6C"), signals)
 
 
 class TestRelayLight(unittest.TestCase):

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -165,9 +165,8 @@ class TestCFSceneAttributes(unittest.TestCase):
         )
         e.hass = MagicMock()
         e.entity_id = "scene.x"
-        ev = MagicMock()
-        ev.data = {"address": "DE4E2C"}  # the non-canonical trigger
-        e._handle_trigger(ev)
+        # Routed by address, so any delivery is one of this scene's triggers.
+        e._handle_trigger({"address": "DE4E2C"})
         e.hass.bus.async_fire.assert_called_once()
         _, payload = e.hass.bus.async_fire.call_args.args
         self.assertEqual(payload["address"], "DE4E2C")
@@ -177,22 +176,35 @@ class TestCFSceneAttributes(unittest.TestCase):
                             "mode": "M04 (Light scene on)"}])
         e.hass = MagicMock()
         e.entity_id = "scene.nikobus_scene_de4e2c"
-        ev = MagicMock()
-        ev.data = {"address": "DE4E2C"}
-        e._handle_trigger(ev)
+        e._handle_trigger({"address": "DE4E2C"})
         e.hass.bus.async_fire.assert_called_once()
         name, payload = e.hass.bus.async_fire.call_args.args
         self.assertEqual(name, "nikobus_scene_activated")
         self.assertEqual(payload["address"], "DE4E2C")
         self.assertEqual(payload["member_count"], 1)
 
-    def test_handle_trigger_ignores_other_address(self):
-        e, _ = self._make([])
+    def test_subscribes_to_each_trigger_signal(self):
+        from unittest.mock import patch
+
+        from custom_components.nikobus.const import press_signal
+
+        coord = MagicMock()
+        coord.address_label = lambda a: a
+        coord.get_button_context = MagicMock(return_value=None)
+        e = NikobusCFSceneEntity(
+            coord, bus_address="8B7086",
+            cf_config={"pattern": "light_scene", "outputs": [],
+                       "triggered_by": ["8B7086", "DE4E2C"]},
+        )
         e.hass = MagicMock()
-        ev = MagicMock()
-        ev.data = {"address": "AAAAAA"}
-        e._handle_trigger(ev)
-        e.hass.bus.async_fire.assert_not_called()
+        with patch(
+            "custom_components.nikobus.scene.async_dispatcher_connect",
+            return_value=lambda: None,
+        ) as conn:
+            _run(e.async_added_to_hass())
+        signals = [c.args[1] for c in conn.call_args_list]
+        self.assertIn(press_signal("8B7086"), signals)
+        self.assertIn(press_signal("DE4E2C"), signals)
 
 
 class TestCoordinatorSceneHelpers(unittest.TestCase):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -6,7 +6,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from custom_components.nikobus.sensor import NikobusConnectionSensor
+from custom_components.nikobus.sensor import (
+    NikobusConnectionSensor,
+    NikobusDiscoveryStatusSensor,
+)
 from custom_components.nikobus.const import DOMAIN, HUB_IDENTIFIER
 
 _ICONS_JSON = (
@@ -170,6 +173,35 @@ class TestSensorMetadata(unittest.TestCase):
             identifiers={(DOMAIN, HUB_IDENTIFIER)},
         )
         self.assertIn((DOMAIN, HUB_IDENTIFIER), sensor._attr_device_info["identifiers"])
+
+
+class TestDiscoveryStatusSensor(unittest.TestCase):
+    """State is the coarse phase (clean, low-cardinality history); the
+    live per-register line and detail are unrecorded attributes."""
+
+    def _sensor(self, phase="module_scan", message="Scanning module 0E6C (2/10)"):
+        coord = MagicMock()
+        coord.discovery_phase = phase
+        coord.discovery_status_message = message
+        sensor = NikobusDiscoveryStatusSensor.__new__(NikobusDiscoveryStatusSensor)
+        sensor._coordinator = coord
+        return sensor
+
+    def test_state_is_the_coarse_phase(self):
+        self.assertEqual(self._sensor(phase="pc_link").native_value, "pc_link")
+
+    def test_live_message_is_an_attribute(self):
+        s = self._sensor(message="register 0x87 of 0xFF (145 records)")
+        self.assertEqual(
+            s.extra_state_attributes["message"],
+            "register 0x87 of 0xFF (145 records)",
+        )
+
+    def test_volatile_detail_is_unrecorded(self):
+        # The per-register churn (incl. the message) never reaches history.
+        unrecorded = NikobusDiscoveryStatusSensor._unrecorded_attributes
+        for key in self._sensor().extra_state_attributes:
+            self.assertIn(key, unrecorded)
 
 
 if __name__ == "__main__":

--- a/tests/test_state_diffing.py
+++ b/tests/test_state_diffing.py
@@ -1,0 +1,82 @@
+"""Coordinator updates skip the HA-state write when nothing visible changed.
+
+Each output module is polled every cycle and its channels are woken (via
+the coordinator listener *and* the per-module signal). Without diffing,
+every channel re-rendered and recomputed its attributes each cycle even
+when its byte was unchanged. ``NikobusEntity._handle_coordinator_update``
+now diffs on ``(available, render_state)`` and writes only on a real
+change — these pin that for switch (on/off) and dimmer (on/off + level).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.nikobus.light import NikobusDimmerEntity
+from custom_components.nikobus.switch import NikobusRelaySwitchEntity
+
+
+def _switch(state=False):
+    coord = MagicMock()
+    coord.get_switch_state = MagicMock(return_value=state)
+    coord.nikobus_connection.is_connected = True
+    e = NikobusRelaySwitchEntity(coord, "3851", 3, "Relay", "Switch", "05-002")
+    e.async_write_ha_state = MagicMock()
+    return e, coord
+
+
+def _dimmer(level=0):
+    coord = MagicMock()
+    coord.get_light_brightness = MagicMock(return_value=level)
+    coord.nikobus_connection.is_connected = True
+    e = NikobusDimmerEntity(coord, "0E6C", 1, "Lamp", "Dimmer", "05-007")
+    e.async_write_ha_state = MagicMock()
+    return e, coord
+
+
+def test_unchanged_updates_skip_the_write():
+    e, coord = _switch(state=False)
+    e._handle_coordinator_update()           # first render: None -> off, writes
+    e._handle_coordinator_update()           # identical: skipped
+    e._handle_coordinator_update()           # identical: skipped
+    assert e.async_write_ha_state.call_count == 1
+
+    coord.get_switch_state.return_value = True
+    e._handle_coordinator_update()           # off -> on: writes
+    assert e.async_write_ha_state.call_count == 2
+
+
+def test_availability_flip_writes_even_if_state_same():
+    e, coord = _switch(state=True)
+    e._handle_coordinator_update()           # writes (available, on)
+    coord.nikobus_connection.is_connected = False
+    e._handle_coordinator_update()           # now unavailable: writes
+    assert e.async_write_ha_state.call_count == 2
+
+
+def test_update_clears_optimistic_state_before_diffing():
+    e, coord = _switch(state=False)
+    e._is_on = True                          # stale optimistic 'on'
+    e._handle_coordinator_update()           # cleared, real state is off
+    assert e._is_on is None
+    assert e.is_on is False
+
+
+def test_dimmer_diffs_on_brightness():
+    e, coord = _dimmer(level=100)
+    e._handle_coordinator_update()           # writes
+    e._handle_coordinator_update()           # same level: skipped
+    assert e.async_write_ha_state.call_count == 1
+
+    coord.get_light_brightness.return_value = 200
+    e._handle_coordinator_update()           # brightness changed: writes
+    assert e.async_write_ha_state.call_count == 2
+
+
+def test_dimmer_update_clears_both_optimistic_caches():
+    e, coord = _dimmer(level=0)
+    e._is_on = True
+    e._optimistic_brightness = 180
+    e._handle_coordinator_update()
+    assert e._is_on is None
+    assert e._optimistic_brightness is None

--- a/tests/test_switch_dispatch.py
+++ b/tests/test_switch_dispatch.py
@@ -1,0 +1,115 @@
+"""The switch platform wakes only the impacted module's entities on a press.
+
+Before: every relay/cover switch subscribed to the shared
+``EVENT_BUTTON_OPERATION`` bus event, so one press invoked **all N**
+entity callbacks, each filtering itself out by address — O(N) per press,
+growing with the whole install.
+
+After: each switch connects to a per-address dispatcher signal
+(``operation_signal(address)``), so a press wakes only that module's
+channels — O(impacted), independent of N. These tests pin that routing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.nikobus.const import operation_signal
+from custom_components.nikobus.switch import NikobusRelaySwitchEntity
+
+
+class _Dispatcher:
+    """Faithful stand-in for HA's dispatcher: connections are keyed by the
+    exact signal string, and ``send`` invokes only that signal's callbacks
+    — the property that makes routing O(impacted) instead of O(N)."""
+
+    def __init__(self) -> None:
+        self.by_signal: dict[str, list] = {}
+
+    def connect(self, _hass, signal, cb):
+        self.by_signal.setdefault(signal, []).append(cb)
+        return lambda: self.by_signal[signal].remove(cb)
+
+    def send(self, _hass, signal, *args):
+        for cb in list(self.by_signal.get(signal, [])):
+            cb(*args)
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _make_switch(coord, hass, addr, channel):
+    e = NikobusRelaySwitchEntity(coord, addr, channel, f"ch{channel}", "Mod", "05-002")
+    e.hass = hass
+    e.async_write_ha_state = MagicMock()
+    return e
+
+
+def _wire(dispatcher, hass, addrs, channels=(1, 2, 3)):
+    """Build + register a switch per (module, channel); return the list."""
+    coord = MagicMock()
+    switches = []
+    with patch(
+        "custom_components.nikobus.switch.async_dispatcher_connect", dispatcher.connect
+    ):
+        for addr in addrs:
+            for ch in channels:
+                e = _make_switch(coord, hass, addr, ch)
+                _run(e.async_added_to_hass())
+                switches.append(e)
+    return switches
+
+
+@pytest.mark.parametrize("n_modules", [2, 5, 20], ids=lambda n: f"{n}modules")
+def test_operation_wakes_only_impacted_module(n_modules):
+    disp = _Dispatcher()
+    hass = MagicMock()
+    addrs = [f"{i:04X}" for i in range(1, n_modules + 1)]
+    switches = _wire(disp, hass, addrs)
+
+    # No switch registers a listener on the shared event bus anymore.
+    hass.bus.async_listen.assert_not_called()
+
+    # A press impacts one module — notify only that module's signal.
+    target = addrs[0]
+    disp.send(hass, operation_signal(target))
+
+    woken = [e for e in switches if e.async_write_ha_state.called]
+    assert {e._address for e in woken} == {target}
+    # Exactly the impacted module's channels woke — regardless of how many
+    # modules (N) exist on the bus.
+    assert len(woken) == 3
+    assert len(switches) == 3 * n_modules
+
+
+def test_connections_are_partitioned_by_address():
+    """Each switch registers exactly one per-address connection, and the
+    connections partition by signal — so no single ``send`` can reach all
+    of them (the structural guarantee a shared event_type lacks)."""
+    disp = _Dispatcher()
+    switches = _wire(disp, MagicMock(), ("AAAA", "BBBB"))
+
+    total = sum(len(cbs) for cbs in disp.by_signal.values())
+    assert total == len(switches) == 6
+    # Two distinct signals, 3 callbacks each — a send reaches at most 3.
+    assert sorted(len(cbs) for cbs in disp.by_signal.values()) == [3, 3]
+    assert set(disp.by_signal) == {
+        operation_signal("AAAA"),
+        operation_signal("BBBB"),
+    }
+
+
+def test_handler_drops_optimistic_state():
+    """The per-address handler clears optimistic state and writes once."""
+    disp = _Dispatcher()
+    switch = _wire(disp, MagicMock(), ("0E6C",), channels=(1,))[0]
+    switch._is_on = True
+
+    disp.send(MagicMock(), operation_signal("0E6C"))
+
+    assert switch._is_on is None
+    switch.async_write_ha_state.assert_called_once()


### PR DESCRIPTION
## What

A performance and logging pass over the integration. **No behaviour or configuration changes** — same entities, same protocol, same UX. Bumps to **3.8.0**.

## Why

On a large install the steady-state cost was dominated by redundant entity wakeups: a single button press woke *every* output/button entity on a shared bus event (each filtering itself out by address), and every poll re-rendered every entity twice regardless of whether anything changed.

## Changes

### Per-address wakeups (O(N) → O(impacted))
- Button presses and per-module poll refreshes are now routed through per-address dispatcher signals (`operation_signal` / `press_signal`, mirroring the existing `_update_{address}`) instead of shared `EVENT_BUTTON_OPERATION` / `EVENT_BUTTON_PRESSED` bus listeners. Only the impacted module's / button's entities are notified. The public bus events still fire for automations.
- Covers `cover`, lights `light`, switches `switch`, binary sensors, scenes, and the input-latch switch all converted; the in-handler address filters are gone (the dispatcher does the routing). Cover keeps only its channel filter.

### Skip redundant state writes
- `NikobusEntity` diffs `(available, render_state)` before writing; switch (`is_on`), dimmer (`is_on` + brightness) and cover (`bus_state` + position) opt in. An unchanged poll collapses to a comparison. Availability flips and real changes still write. Other platforms opt out via a sentinel and are unchanged.

### Quieter polling
- `_refresh_module_type` only re-broadcasts a module to its entities when its bytes actually changed; the coordinator's own post-poll `async_update_listeners` still covers everything.

### Discovery recorder hygiene
- The discovery-status sensor's **state** is now the coarse phase (`idle`/`pc_link`/`module_scan`/`finished`/`error`); the live per-register line moved to a `message` attribute, and all volatile detail is in `_unrecorded_attributes` — so a scan no longer floods history with per-register strings.

### Logging
- Standardized log messages to one style (sentence case, no trailing period, consistent identifiers and proper nouns). Levels unchanged. User-facing status strings left as-is.

## Tests

New: `test_switch_dispatch.py` (per-address fan-out, 3 vs 60 wakes at N=20), `test_state_diffing.py`, plus per-platform "subscribes to the right signal" routing tests and coordinator/sensor coverage. **Full suite 396 passing, ruff clean.** No test asserts on log text.

## Commits
Eight focused commits (per-address routing → all-platform rollout → state diffing → recorder hygiene → poll gating → cover diffing → log standardization → version/changelog).

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_