### PR TITLE
fix(init): bus-connection leak on partial setup + cleaner unload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 3.8.1
+
+- **Fix: don't leak the bus connection when setup fails partway.** If the
+  connection opened but a later setup step failed, the bus was left open;
+  because only one client may hold the bus, every retry then failed. Setup
+  now tears the connection back down before retrying.
+- **Cleaner unload.** Platforms are unloaded before the connection stack is
+  stopped, and the coordinator is only stopped if the unload succeeded.
+- Setup failures now surface translated messages instead of raw text.
+
 ## 3.8.0
 
 Performance & logging pass — no behaviour or configuration changes.

--- a/custom_components/nikobus/__init__.py
+++ b/custom_components/nikobus/__init__.py
@@ -67,7 +67,7 @@ def _parse_register_byte(value: Any) -> int:
         try:
             n = int(text, 16)
         except ValueError:
-            raise vol.Invalid(f"Cannot parse '{value}' as a hex register byte")
+            raise vol.Invalid(f"Cannot parse '{value}' as a hex register byte") from None
     if not (0 <= n <= 0xFF):
         raise vol.Invalid(f"Register {n:#x} out of range 0x00..0xFF")
     return n
@@ -327,18 +327,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: NikobusConfigEntry) -> b
     entry.runtime_data = coordinator
 
     # 2. Connect and prepare internal buffers.
+    # ``connect`` opens the transport before initialising the listener /
+    # command stack, so a failure mid-setup can leave the bus open. Tear
+    # the coordinator back down before retrying — only one client may hold
+    # the bus, so a leaked connection would make every retry fail.
     try:
         await coordinator.connect()
     except NikobusConnectionError as err:
+        await coordinator.stop()
         raise ConfigEntryNotReady(
-            f"Cannot connect to Nikobus: {err}"
+            translation_domain=DOMAIN,
+            translation_key="communication_error",
+            translation_placeholders={"error": str(err)},
         ) from err
     except NikobusDataError as err:
+        await coordinator.stop()
         raise ConfigEntryNotReady(
-            f"Check your Nikobus config files — {err}"
+            translation_domain=DOMAIN,
+            translation_key="setup_data_error",
+            translation_placeholders={"error": str(err)},
         ) from err
     except NikobusError as err:
-        raise ConfigEntryNotReady(f"Nikobus setup error: {err}") from err
+        await coordinator.stop()
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="initialization_error",
+            translation_placeholders={"error": str(err)},
+        ) from err
 
     _register_hub_device(hass, entry)
 
@@ -414,6 +429,7 @@ def _register_category_devices(
             entry_type=dr.DeviceEntryType.SERVICE,
         )
 
+
 async def _async_cleanup_orphan_entities(
     hass: HomeAssistant, entry: NikobusConfigEntry, coordinator: NikobusDataCoordinator
 ) -> None:
@@ -422,7 +438,7 @@ async def _async_cleanup_orphan_entities(
     dev_reg = dr.async_get(hass)
 
     valid_entity_ids = coordinator.get_known_entity_unique_ids()
-    
+
     # Remove orphan entities
     entities = [
         entity for entity in ent_reg.entities.values()
@@ -454,9 +470,14 @@ async def _async_cleanup_orphan_entities(
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: NikobusConfigEntry) -> bool:
-    """Unload the integration and stop background tasks."""
-    coordinator = entry.runtime_data
-    if coordinator:
-        await coordinator.stop()
+    """Unload the integration and stop background tasks.
 
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    Unload the platforms first so entities are gone before the protocol
+    stack is torn down, and only stop the coordinator if that succeeded —
+    a refused unload must not leave a stopped coordinator behind a still
+    loaded entry.
+    """
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok and (coordinator := entry.runtime_data):
+        await coordinator.stop()
+    return unload_ok

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -16,5 +16,5 @@
     "nikobus-connect>=0.24.0",
     "construct>=2.10"
   ],
-  "version": "3.8.0"
+  "version": "3.8.1"
 }

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -166,6 +166,9 @@
     },
     "not_connected": {
       "message": "Nikobus bus is not connected — cannot send a command. Check the connection and retry."
+    },
+    "setup_data_error": {
+      "message": "Could not load Nikobus configuration: {error}"
     }
   },
   "options": {

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -242,6 +242,9 @@
     },
     "no_inventory_source": {
       "message": "Aucun PC-Link détecté sur le bus et aucun fichier de configuration manuelle trouvé. Installez un PC-Link ou créez nikobus_module_config.json (et éventuellement nikobus_button_config.json) dans votre répertoire de configuration Home Assistant, puis réessayez."
+    },
+    "setup_data_error": {
+      "message": "Impossible de charger la configuration Nikobus : {error}"
     }
   },
   "selector": {

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -242,6 +242,9 @@
     },
     "no_inventory_source": {
       "message": "Geen PC-Link gedetecteerd op de bus en geen handmatige configuratiebestanden gevonden. Installeer een PC-Link of maak nikobus_module_config.json (en eventueel nikobus_button_config.json) aan in uw Home Assistant-configuratiemap en probeer het opnieuw."
+    },
+    "setup_data_error": {
+      "message": "Kon de Nikobus-configuratie niet laden: {error}"
     }
   },
   "selector": {


### PR DESCRIPTION
## What

File-by-file review hardening, starting with `__init__.py`. Fixes a real bus-connection leak, makes unload safer, and clears the untranslated-exception blocker for this file. Bumps to **3.8.1**.

## The bug (why this matters)

`coordinator.connect()` opens the transport **first**, then loads storage and starts the listener/command stack in a second phase. If that second phase fails, the transport was left **open** — and `async_setup_entry` raised `ConfigEntryNotReady` **without** tearing it down. Since Nikobus allows **only one client on the bus**, the retry then opened a *second* connection and failed indefinitely.

**Fix:** each `connect()` failure now calls `await coordinator.stop()` before raising. `stop()` is safe to call after a partial connect (it null-checks the listener/command and wraps disconnect).

## Other fixes in this file

- **`async_unload_entry`** — unload platforms *first*, then stop the coordinator only if the unload succeeded (was: stop unconditionally, before unload — which could strand a stopped coordinator behind a still-loaded entry).
- **Translated the three `ConfigEntryNotReady` raises** — reuse `communication_error` / `initialization_error`, add a new `setup_data_error` key (en/fr/nl). Clears pylint `W7417`.
- **Exception chaining** in `_parse_register_byte` (`raise … from None`, `B904`).
- Trailing whitespace + a missing blank line.

## Deliberately left as-is

The two-pass entity scan in `_async_cleanup_orphan_entities` looks redundant but is **intentional**: the second pass must read the registry *after* orphan entities are removed, so a device whose only entity was just removed becomes removable. Merging the passes would be a bug.

## Testing

`__init__.py` isn't importable in the current test harness (it needs real HA `ServiceResponse`/`SupportsResponse`, which the manual stubs don't provide), so no unit tests exercise it — consistent with its existing state. Full suite still **396 passing**, ruff clean. Translation files validated, no reformatting noise (3 lines each).

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_