### PR TITLE
perf/cleanup(coordinator): drop a redundant global wake + log/comment tidy

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -317,6 +317,10 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         return "disconnected"
 
     def _get_update_interval(self) -> timedelta | None:
+        # No poll timer in push mode. A feedback module pushes state
+        # unprompted; older PC-Links (prior_gen3) can't sustain the poll
+        # cadence, so they run push-only too (button presses + feedback
+        # frames drive refreshes). Everything else polls on the interval.
         if self._has_feedback_module or self._prior_gen3:
             return None
         return timedelta(seconds=self._refresh_interval)
@@ -537,7 +541,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             self._update_discovery_state(
                 phase=DISCOVERY_PHASE_PC_LINK,
                 message=(
-                    f"PC Link inventory: {self.discovery_registers_done}/"
+                    f"PC-Link inventory: {self.discovery_registers_done}/"
                     f"{self.discovery_registers_total} registers, "
                     f"{devices_found} device(s) found"
                 ),
@@ -633,7 +637,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 registers_done = 0
 
             if sub_phase == DISCOVERY_SUB_PHASE_INVENTORY:
-                message = "PC Link inventory: enumerating bus addresses…"
+                message = "PC-Link inventory: enumerating bus addresses…"
             elif sub_phase == DISCOVERY_SUB_PHASE_IDENTITY:
                 message = (
                     f"Identifying modules ({module_index}/{module_total})…"
@@ -1193,15 +1197,19 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 await asyncio.sleep(PRESS_REPEAT_DELAY)
 
     async def async_event_handler(self, event: str, data: dict[str, Any]) -> None:
-        """Dispatch events and trigger targeted entity updates."""
+        """Send an HA-originated press, or wake the impacted module's entities.
+
+        ``ha_button_pressed`` only queues the bus frame; the resulting bus
+        feedback dispatches the targeted update once the state actually
+        changes, so there's nothing to refresh here — returning avoids a
+        pointless wake of every entity.
+        """
         if event == "ha_button_pressed":
             await self.async_send_button_press(str(data.get("address") or ""))
+            return
 
         if address := data.get("impacted_module_address"):
             async_dispatcher_send(self.hass, f"{DOMAIN}_update_{address}")
-        else:
-            _LOGGER.debug("Global broadcast refresh triggered")
-            self.async_update_listeners()
 
     # ------------------------------------------------------------------
     # Connection lost / reconnect
@@ -1311,8 +1319,8 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 return
             except asyncio.CancelledError:
                 raise
-            except Exception as err:
-                _LOGGER.error("Subsystem restart failed after reconnect: %s — retrying", err)
+            except Exception:
+                _LOGGER.exception("Subsystem restart failed after reconnect — retrying")
                 await self.nikobus_connection.disconnect()
                 try:
                     await asyncio.sleep(delay)
@@ -1799,8 +1807,8 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 outer_attempts=_PROBE_OUTER_ATTEMPTS,
                 outer_delay=_PROBE_OUTER_DELAY_S,
             )
-        except Exception as err:  # pragma: no cover - defensive
-            _LOGGER.error("Stale-inventory detection failed: %s", err)
+        except Exception:  # pragma: no cover - defensive
+            _LOGGER.exception("Stale-inventory detection failed")
             return
 
         absent = {str(a).upper() for a in (manifest.get("absent_modules") or [])}
@@ -2009,8 +2017,8 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 await self.hass.config_entries.async_reload(self.config_entry.entry_id)
             except asyncio.CancelledError:
                 raise
-            except Exception as err:
-                _LOGGER.error("Failed to reload config entry after discovery: %s", err)
+            except Exception:
+                _LOGGER.exception("Failed to reload config entry after discovery")
 
         self._reload_task = self.hass.async_create_task(_reload())
 


### PR DESCRIPTION
## What

Deep-dive review of `coordinator.py`. **Behaviour-neutral** — a small perf fix, log/comment tidy. Code-only (see version note below).

The file is in good shape (earned comments, defensive `getattr` for the cross-library `DiscoveryProgress` dataclass, a cached `controlled_by` index, deliberate out-of-range buffer guards). Findings were modest.

## Changes

- **Drop a redundant global wake (the real find).** `async_event_handler`'s `else` branch called `async_update_listeners()` — waking *every* entity — and it was reachable **only** for `ha_button_pressed`, where the bus frame has just been *queued* and nothing has changed yet. The actual state update arrives later via that frame's per-address dispatch. So it was a pointless O(N) wake on every latch-switch toggle and `send_button_press`. Now `ha_button_pressed` sends and returns; refresh events keep their targeted dispatch. (The earlier per-address work missed this because it lives in the coordinator, not a platform.)
- **Three broad-except swallows → `_LOGGER.exception`** (reconnect subsystem-restart, stale-inventory detect, post-discovery reload) so a genuinely-unexpected failure keeps its traceback. Left the deliberate ones (`.debug` fire-and-forget progress, `.debug` per-poll-group noise per #337, `.warning` known reconnect-failure mode, per-frame feedback parse).
- **Documented `prior_gen3`.** `_get_update_interval()` disables the poll timer for `prior_gen3` as well as for a feedback module; that wasn't obvious from the code. Added a comment: older PC-Links can't sustain the poll cadence, so they run push-only. (Confirmed intended — no behaviour change.)
- **`PC Link` → `PC-Link`** in the two discovery status strings — finishing the consistency deferred from the logging pass.

## Testing

Full suite **396 passing**, ruff clean. The `async_event_handler` change is covered by the existing `test_event_handler_routes_through_burst` (asserts the press burst fires; no longer relies on a global wake).

## Version note

No manifest/CHANGELOG bump here: **#410 already owns 3.8.1 and is still open**, so a bump on this independent branch would collide on the manifest. Suggest bumping at release once both this and #410 land.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_