### PR TITLE
cleanup(entity): drop dead _LOGGER, tidy comment + whitespace

### DIFF
--- a/custom_components/nikobus/entity.py
+++ b/custom_components/nikobus/entity.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from homeassistant.core import callback
@@ -12,8 +11,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import BRAND, DOMAIN, HUB_IDENTIFIER
 from .coordinator import NikobusDataCoordinator
-
-_LOGGER = logging.getLogger(__name__)
 
 # Sentinel return for ``_render_state``: this entity opts out of
 # write-diffing and writes on every coordinator update (the default).
@@ -56,7 +53,7 @@ class NikobusEntity(CoordinatorEntity[NikobusDataCoordinator]):
         self._device_name = name
         self._device_model = model
 
-        # Platinum Architecture: Groups channels under a single physical device.
+        # Group every channel of a module under one physical device.
         device_info = dr.DeviceInfo(
             identifiers={(DOMAIN, self._address)},
             name=self._device_name,
@@ -118,7 +115,7 @@ class NikobusEntity(CoordinatorEntity[NikobusDataCoordinator]):
     async def async_added_to_hass(self) -> None:
         """Register targeted signal listener for this specific module address."""
         await super().async_added_to_hass()
-        
+
         signal = f"{DOMAIN}_update_{self._address}"
         self.async_on_remove(
             async_dispatcher_connect(self.hass, signal, self._handle_coordinator_update)


### PR DESCRIPTION
## What

Deep-dive review of `entity.py` (the shared entity base). It's small and in good shape — this PR is just trivial cleanup.

## Review notes

Solid, no behavioural findings:
- The write-diff hooks (`_render_state` / `_invalidate_optimistic` / `_NO_DIFF`) read cleanly.
- `available` correctly gates on **both** coordinator health (`super().available`) and live connection (`nikobus_connection.is_connected`); safe during teardown (connection object persists, just reports disconnected).
- `hub_device_info()` is a proper single source of truth for the bridge device.
- The CoordinatorEntity global listener + the per-address `_update_{address}` dispatcher both wake `_handle_coordinator_update`, but the diff makes that cheap — this is the known item #3 we chose not to pursue.

## Changes (cleanup only)

- **Remove the unused `_LOGGER`** and its `import logging` (defined, never referenced).
- **Reword the `Platinum Architecture:` comment** to plainly describe the device grouping.
- **Strip a trailing-whitespace line.**

`device_entry_diagnostics` is kept — it's imported and used by `diagnostics.py`.

## Testing

Full suite **396 passing**, ruff clean. Net diff: +2/−5.

## Version note

No manifest bump — parallel per-file review PRs (#410 owns 3.8.1); bump once at release.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_