### PR TITLE
fix(platforms): translate entity-action errors (action-exceptions rule)

### DIFF
--- a/custom_components/nikobus/cover.py
+++ b/custom_components/nikobus/cover.py
@@ -15,6 +15,7 @@ from homeassistant.components.cover import (
     CoverEntityFeature,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -23,6 +24,7 @@ from .const import (
     DEFAULT_COVER_DEBOUNCE_DELAY,
     DEFAULT_COVER_MOVEMENT_BUFFER,
     DEFAULT_COVER_OPERATION_TIME,
+    DOMAIN,
     press_signal,
 )
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
@@ -33,6 +35,16 @@ from .router import build_unique_id, get_routing, register_output_module_devices
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
+
+
+def _command_error(err: Exception) -> HomeAssistantError:
+    """A bus command failed — surface it as a translated HA error so the
+    user sees a clean message instead of the raw library exception."""
+    return HomeAssistantError(
+        translation_domain=DOMAIN,
+        translation_key="communication_error",
+        translation_placeholders={"error": str(err)},
+    )
 
 
 def _parse_operation_time(value: Any, fallback: float, label: str, address: str) -> float:
@@ -309,15 +321,30 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open cover command."""
-        await self._request_move("opening")
+        try:
+            await self._request_move("opening")
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            raise _command_error(err) from err
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover command."""
-        await self._request_move("closing")
+        try:
+            await self._request_move("closing")
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            raise _command_error(err) from err
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop cover command."""
-        await self._stop(send_stop=True)
+        try:
+            await self._stop(send_stop=True)
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            raise _command_error(err) from err
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move cover to a specific percentage."""

--- a/custom_components/nikobus/light.py
+++ b/custom_components/nikobus/light.py
@@ -8,11 +8,12 @@ from typing import Any
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .const import operation_signal
+from .const import DOMAIN, operation_signal
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity
 from .router import build_unique_id, get_routing, register_output_module_devices
@@ -20,6 +21,16 @@ from .router import build_unique_id, get_routing, register_output_module_devices
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
+
+
+def _command_error(err: Exception) -> HomeAssistantError:
+    """A bus command failed — surface it as a translated HA error so the
+    user sees a clean message instead of the raw library exception."""
+    return HomeAssistantError(
+        translation_domain=DOMAIN,
+        translation_key="communication_error",
+        translation_placeholders={"error": str(err)},
+    )
 
 
 async def async_setup_entry(
@@ -207,7 +218,7 @@ class NikobusDimmerEntity(NikobusBaseLight):
             self._is_on = None
             self._optimistic_brightness = None
             self.async_write_ha_state()
-            raise err
+            raise _command_error(err) from err
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the dimmer with optimistic UI update and error fallback."""
@@ -229,7 +240,7 @@ class NikobusDimmerEntity(NikobusBaseLight):
             self._is_on = None
             self._optimistic_brightness = None
             self.async_write_ha_state()
-            raise err
+            raise _command_error(err) from err
 
 
 class NikobusRelayEntity(NikobusBaseLight):
@@ -264,7 +275,7 @@ class NikobusRelayEntity(NikobusBaseLight):
         except Exception as err:
             self._is_on = None
             self.async_write_ha_state()
-            raise err
+            raise _command_error(err) from err
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Open relay with optimistic UI update and error fallback."""
@@ -278,7 +289,7 @@ class NikobusRelayEntity(NikobusBaseLight):
         except Exception as err:
             self._is_on = None
             self.async_write_ha_state()
-            raise err
+            raise _command_error(err) from err
 
 
 class NikobusCoverLightEntity(NikobusBaseLight):
@@ -313,7 +324,7 @@ class NikobusCoverLightEntity(NikobusBaseLight):
         except Exception as err:
             self._is_on = None
             self.async_write_ha_state()
-            raise err
+            raise _command_error(err) from err
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn light off via cover stop command with optimistic UI update and error fallback."""
@@ -327,4 +338,4 @@ class NikobusCoverLightEntity(NikobusBaseLight):
         except Exception as err:
             self._is_on = None
             self.async_write_ha_state()
-            raise err
+            raise _command_error(err) from err

--- a/custom_components/nikobus/switch.py
+++ b/custom_components/nikobus/switch.py
@@ -8,11 +8,12 @@ from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .const import operation_signal, press_signal
+from .const import DOMAIN, operation_signal, press_signal
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity
 from .router import (
@@ -36,6 +37,16 @@ except ImportError:  # pragma: no cover - defensive (older library)
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
+
+
+def _command_error(err: Exception) -> HomeAssistantError:
+    """A bus command failed — surface it as a translated HA error so the
+    user sees a clean message instead of the raw library exception."""
+    return HomeAssistantError(
+        translation_domain=DOMAIN,
+        translation_key="communication_error",
+        translation_placeholders={"error": str(err)},
+    )
 
 
 def input_ab_addresses(phys: dict[str, Any]) -> tuple[str, str] | None:
@@ -230,7 +241,7 @@ class NikobusRelaySwitchEntity(NikobusBaseSwitch):
         except Exception as err:
             self._is_on = None
             self.async_write_ha_state()
-            raise err
+            raise _command_error(err) from err
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Open relay with optimistic UI update and error fallback."""
@@ -244,7 +255,7 @@ class NikobusRelaySwitchEntity(NikobusBaseSwitch):
         except Exception as err:
             self._is_on = None
             self.async_write_ha_state()
-            raise err
+            raise _command_error(err) from err
 
 
 class NikobusCoverSwitchEntity(NikobusBaseSwitch):
@@ -277,7 +288,7 @@ class NikobusCoverSwitchEntity(NikobusBaseSwitch):
         except Exception as err:
             self._is_on = None
             self.async_write_ha_state()
-            raise err
+            raise _command_error(err) from err
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Trigger 'Stop/Close' on cover module with optimistic UI update and error fallback."""
@@ -291,7 +302,7 @@ class NikobusCoverSwitchEntity(NikobusBaseSwitch):
         except Exception as err:
             self._is_on = None
             self.async_write_ha_state()
-            raise err
+            raise _command_error(err) from err
 
 class NikobusInputLatchSwitch(NikobusEntity, SwitchEntity, RestoreEntity):
     """Stateful on/off latch for a PC-Logic / Modular-Interface input.

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -230,6 +230,31 @@ class TestStop(unittest.TestCase):
         coord.api.stop_cover.assert_awaited_once()
 
 
+class TestActionErrors(unittest.TestCase):
+    """A failed bus command surfaces as a translated HomeAssistantError."""
+
+    def test_open_translates_bus_error(self):
+        from homeassistant.exceptions import HomeAssistantError
+
+        ent, coord = _make_cover()
+        ent._state = STATE_STOPPED
+        coord.api.open_cover = AsyncMock(side_effect=RuntimeError("bus down"))
+        with self.assertRaises(HomeAssistantError) as cm:
+            _run(ent.async_open_cover())
+        self.assertEqual(cm.exception.translation_key, "communication_error")
+        self.assertIsInstance(cm.exception.__cause__, RuntimeError)
+
+    def test_stop_translates_bus_error(self):
+        from homeassistant.exceptions import HomeAssistantError
+
+        ent, coord = _make_cover()
+        ent._state = STATE_OPENING
+        coord.api.stop_cover = AsyncMock(side_effect=RuntimeError("bus down"))
+        with self.assertRaises(HomeAssistantError) as cm:
+            _run(ent.async_stop_cover())
+        self.assertEqual(cm.exception.translation_key, "communication_error")
+
+
 class TestHandleButtonPressed(unittest.TestCase):
     # The signal is routed by module address, so the handler only filters
     # by channel (one roller module carries several covers).

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -11,6 +11,8 @@ import asyncio
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from homeassistant.exceptions import HomeAssistantError
+
 from custom_components.nikobus.const import operation_signal
 from custom_components.nikobus.light import (
     NikobusDimmerEntity,
@@ -79,8 +81,10 @@ class TestDimmer(unittest.TestCase):
     def test_turn_on_reverts_on_error(self):
         e, c = self._make()
         c.api.turn_on_light.side_effect = RuntimeError("bus down")
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(HomeAssistantError) as cm:
             _run(e.async_turn_on())
+        self.assertEqual(cm.exception.translation_key, "communication_error")
+        self.assertIsInstance(cm.exception.__cause__, RuntimeError)
         self.assertIsNone(e._is_on)
         self.assertIsNone(e._optimistic_brightness)
 
@@ -139,8 +143,9 @@ class TestRelayLight(unittest.TestCase):
     def test_turn_on_reverts_on_error(self):
         e, c = self._make()
         c.api.turn_on_switch.side_effect = RuntimeError("x")
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(HomeAssistantError) as cm:
             _run(e.async_turn_on())
+        self.assertEqual(cm.exception.translation_key, "communication_error")
         self.assertIsNone(e._is_on)
 
 

--- a/tests/test_switch_entities.py
+++ b/tests/test_switch_entities.py
@@ -10,6 +10,8 @@ import asyncio
 import unittest
 from unittest.mock import AsyncMock, MagicMock
 
+from homeassistant.exceptions import HomeAssistantError
+
 from custom_components.nikobus.switch import (
     NikobusRelaySwitchEntity,
     NikobusCoverSwitchEntity,
@@ -58,8 +60,10 @@ class TestRelaySwitch(unittest.TestCase):
     def test_turn_on_reverts_on_error(self):
         e, c = self._make()
         c.api.turn_on_switch.side_effect = RuntimeError("x")
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(HomeAssistantError) as cm:
             _run(e.async_turn_on())
+        self.assertEqual(cm.exception.translation_key, "communication_error")
+        self.assertIsInstance(cm.exception.__cause__, RuntimeError)
         self.assertIsNone(e._is_on)
 
 
@@ -88,8 +92,9 @@ class TestCoverSwitch(unittest.TestCase):
     def test_turn_off_reverts_on_error(self):
         e, c = self._make()
         c.api.stop_cover.side_effect = RuntimeError("x")
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(HomeAssistantError) as cm:
             _run(e.async_turn_off())
+        self.assertEqual(cm.exception.translation_key, "communication_error")
         self.assertIsNone(e._is_on)
 
 


### PR DESCRIPTION
## What

Review pass on the output platforms (`switch` / `light` / `cover`), fixing the **action-exceptions** Silver rule: a failed bus command must surface as a translated `HomeAssistantError`, not a raw library exception.

## The problem

When a turn-on/off (or open/close/stop) failed — e.g. the bus dropped mid-command — the user got the raw `nikobus_connect` exception:
- `switch` / `light` caught the error, reverted optimistic state, then `raise err` (the raw error).
- `cover`'s actions let the library error propagate straight through.

Either way the frontend showed an ugly stack instead of a clean "Communication with Nikobus failed: …".

## Fix

Each output platform maps a command failure to a translated `HomeAssistantError` (reusing the existing `communication_error` key) via a small `_command_error` helper, chained from the original with `from err`:

- **switch** — the 4 relay / cover-switch `turn_on`/`turn_off` re-raises.
- **light** — the 6 dimmer / relay / cover-light re-raises.
- **cover** — wrap `async_open_cover` / `async_close_cover` / `async_stop_cover`. `async_set_cover_position` delegates to a debounced background task, so it never raises at the action boundary — left as-is.

Optimistic-state revert on switch/light is unchanged (broad catch preserved; only the raised type changed). `button` already raises translated errors; `binary_sensor` / `sensor` / `scene` have no such commanding actions.

## Tests

- The existing revert-on-error tests now assert `HomeAssistantError` + `translation_key == "communication_error"` + the chained `__cause__`.
- Added `cover` open/stop error-translation tests.
- Full suite **398 passing**, ruff clean.

## Scope / version

One PR for the three output platforms since the fix is a single cross-cutting concern (per the audit's exception-translation guidance). No manifest bump — parallel per-file review PRs; bump at release.

This clears the action re-raise half of the exception-translation blocker (the `ConfigEntryNotReady` half is in #410).

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_