### PR TITLE
fix(scene): translate software-scene activation errors

### DIFF
--- a/custom_components/nikobus/scene.py
+++ b/custom_components/nikobus/scene.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from homeassistant.components.scene import Scene
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -243,7 +244,7 @@ class NikobusSceneEntity(NikobusEntity, Scene):
         """Initialize the Nikobus scene."""
         scene_id = scene_config["id"]
         description = scene_config.get("description", f"Scene {scene_id}")
-        
+
         super().__init__(
             coordinator=coordinator,
             address=scene_id,
@@ -254,10 +255,10 @@ class NikobusSceneEntity(NikobusEntity, Scene):
         self._scene_id = scene_id
         self._attr_name = description
         self._attr_unique_id = f"nikobus_scene_{scene_id}"
-        
+
         self._channels = scene_config.get("channels", [])
         self._feedback_leds = self._normalize_feedback_leds(scene_config.get("feedback_led"))
-        
+
         # Guard against overlapping roller release tasks
         self._module_tokens: dict[str, str] = {}
         self._roller_stop_tasks: list[asyncio.Task[None]] = []
@@ -275,6 +276,19 @@ class NikobusSceneEntity(NikobusEntity, Scene):
         self.async_on_remove(_cancel_roller_tasks)
 
     async def async_activate(self, **kwargs: Any) -> None:
+        """Activate the scene, surfacing a bus failure as a clean error."""
+        try:
+            await self._activate()
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+                translation_placeholders={"error": str(err)},
+            ) from err
+
+    async def _activate(self) -> None:
         """Activate the scene by setting multiple module channels."""
         _LOGGER.info("Activating Nikobus scene: %s", self.name)
 
@@ -318,7 +332,7 @@ class NikobusSceneEntity(NikobusEntity, Scene):
                 # Determine direction based on the state being sent
                 direction = "up" if byte_val == STATE_OPEN else "down"
                 op_time = self.coordinator.get_cover_operation_time(module_id, chan_num, direction=direction)
-    
+
                 if op_time > 0:
                     module_task = roller_tasks.setdefault(module_id, {"indexes": set(), "delay": 0})
                     module_task["indexes"].add(idx)
@@ -362,16 +376,16 @@ class NikobusSceneEntity(NikobusEntity, Scene):
     async def _apply_module_state(self, module_id: str, state: bytearray) -> None:
         """Push the bytearray state to the Nikobus module via coordinator."""
         num_chans = self.coordinator.get_module_channel_count(module_id)
-        
+
         # Update Group 1 (1-6)
         self.coordinator.set_bytearray_group_state(module_id, 1, state[:6].hex())
-        
+
         # Update Group 2 (7-12) if applicable
         if num_chans > 6:
             self.coordinator.set_bytearray_group_state(module_id, 2, state[6:12].hex())
 
         await self.coordinator.api.set_output_states_for_module(address=module_id)
-        
+
         # Notify coordinator of manual refresh
         await self.coordinator.async_event_handler(
             "nikobus_refreshed", {"impacted_module_address": module_id}

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -81,6 +81,33 @@ class TestFeedbackLedDispatch(unittest.TestCase):
         )
 
 
+class TestSceneActivationErrors(unittest.TestCase):
+    """A bus failure during a software-scene activation surfaces as a
+    translated HomeAssistantError, not the raw library exception."""
+
+    def test_activate_translates_bus_error(self):
+        from homeassistant.exceptions import HomeAssistantError
+
+        coord = MagicMock()
+        coord.get_module_type.return_value = "switch_module"
+        coord.nikobus_module_states = {"C1C7": bytearray(12)}
+        coord.get_module_channel_count.return_value = 6
+        coord.async_event_handler = AsyncMock()
+        coord.api.set_output_states_for_module = AsyncMock(
+            side_effect=RuntimeError("bus down")
+        )
+        e = NikobusSceneEntity(coord, {
+            "id": "s1",
+            "channels": [{"module_id": "C1C7", "channel": 1, "state": "on"}],
+            "feedback_led": None,
+        })
+        e.name = "Test Scene"  # Entity.name isn't provided by the test stubs
+        with self.assertRaises(HomeAssistantError) as cm:
+            _run(e.async_activate())
+        self.assertEqual(cm.exception.translation_key, "communication_error")
+        self.assertIsInstance(cm.exception.__cause__, RuntimeError)
+
+
 class TestCFSceneActivation(unittest.TestCase):
     def test_activate_broadcasts_bus_address(self):
         coord = MagicMock()


### PR DESCRIPTION
## What

Review pass on `scene.py`. Fixes an **action-exceptions** gap I missed in #413, plus whitespace.

## The gap

There are two scene types:
- **`NikobusCFSceneEntity`** — `async_activate` → `async_activate_cf_broadcast`, already raises translated errors. ✅
- **`NikobusSceneEntity`** (software scenes from `nikobus_scene_config.json`) — `async_activate` commands the bus via `api.set_output_states_for_module` and let a failure propagate as the **raw library exception**. ❌

In #413 I wrote "scene has no commanding actions" — that was wrong for the software-scene path. This corrects it.

## Fix

Extract the activation body into `_activate`; `async_activate` wraps a failure as a translated `HomeAssistantError` (reusing `communication_error`), chained from the original — matching the switch/light/cover pattern. (Inlined the single wrap rather than adding a 4th `_command_error` copy, since scene has only this one untranslated action.)

Also stripped 7 trailing-whitespace lines.

## The rest (reviewed, no changes)

Solid: the CF-scene per-trigger `press_signal` wiring, the roller-stop token guard against overlapping activations, the global-delay rationale for shared roller stop deadlines, and the stateless `_handle_coordinator_update` are all sound.

## Testing

Added a test: a bus error during software-scene activation now raises `HomeAssistantError` with `communication_error` + the chained cause. Full suite **399 passing**, ruff clean.

## Follow-up noted

The 4 platforms (switch/light/cover/scene) now each have/inline the same translated-error mapping. A future small refactor could consolidate them into one shared helper (e.g. in `entity.py`). Left out here to keep this PR to `scene.py`.

No manifest bump — parallel per-file review PRs; bump at release.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_