### PR TITLE
docs(binary_sensor): document pressed/idle state + fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Every physical button is one **device**. Each *operation point* on it — a key 
 | Entity | Direction | Use |
 |---|---|---|
 | **Button** | HA → bus | Press it to emit the same bus frame a physical press would (simulate the press). |
-| **Binary sensor** *(disabled by default)* | bus → HA | Turns `on` briefly when the real button is pressed; use it in state-based automations. |
+| **Binary sensor** *(disabled by default)* | bus → HA | Pulses to `pressed` (then back to `idle` after ~1 s) when the real button is pressed; use it in state-based automations. |
 
 > Binary sensors are **disabled by default** — enable them on the device page if you want to monitor presses.
 
@@ -225,7 +225,7 @@ Input addresses are computed by firmware from the module's own address (not stor
 trigger:
   - platform: state
     entity_id: binary_sensor.lm_input_1_key_a
-    to: "on"
+    to: "pressed"   # these sensors report "pressed" / "idle"
 ```
 
 ### What each button exposes

--- a/custom_components/nikobus/binary_sensor.py
+++ b/custom_components/nikobus/binary_sensor.py
@@ -109,13 +109,20 @@ class NikobusButtonBinarySensor(NikobusEntity, BinarySensorEntity):
 
     @property
     def state(self) -> str:
-        """Override to return 'pressed' if on, else 'idle'."""
+        """Report ``pressed`` / ``idle`` rather than the binary_sensor
+        default ``on`` / ``off``.
+
+        Deliberately non-standard: a Nikobus button is momentary, so
+        ``pressed`` / ``idle`` reads better in the UI and in automations
+        (``to: "pressed"``) than ``on`` / ``off``. ``is_on`` still tracks
+        the underlying boolean for anything that needs it.
+        """
         return "pressed" if self._attr_is_on else "idle"
 
     async def async_added_to_hass(self) -> None:
         """Register event listeners when added to Home Assistant."""
         await super().async_added_to_hass()
-        
+
         # Per-address signal: only this button's sensor is woken on its
         # own press, instead of a global EVENT_BUTTON_PRESSED listener
         # that every button sensor runs and filters by address.


### PR DESCRIPTION
## What

Review pass on `binary_sensor.py`. It's clean; the one real finding was a **doc/convention inconsistency**, which you opted to resolve by fixing the docs (keeping the custom state).

## The inconsistency

`NikobusButtonBinarySensor.state` deliberately returns **`pressed` / `idle`** instead of the binary_sensor default `on` / `off` (a Nikobus button is momentary — `pressed`/`idle` reads better). That's a reasonable UX choice, but:
- it was **undocumented in code** (a future reviewer could "fix" it back to on/off), and
- the **README's automation example used `to: "on"`**, which never fires against a `pressed`/`idle` state.

## Changes (no code behaviour change)

- **binary_sensor.py** — expanded the `state` docstring to call out the deliberate non-standard value and why; stripped trailing whitespace.
- **README.md** — the input automation example now uses `to: "pressed"`, and the entity-model table says the sensor *pulses to `pressed` (then `idle` after ~1 s)*.

## The rest (reviewed, no changes)

Solid: the per-address `press_signal` wiring, the reset-timer lifecycle (cancel-before-restart + cancel-on-remove), `_attr_entity_registry_enabled_default = False`, and the event-driven `_handle_coordinator_update` no-op are all correct.

## Testing

Existing tests already pin `pressed`/`idle` — unchanged, still green. Full suite **398 passing**, ruff clean.

No manifest bump — parallel per-file review PRs; bump at release.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_