### PR TITLE
cleanup(nkbactuator): tidy datetime import + whitespace

### DIFF
--- a/custom_components/nikobus/nkbactuator.py
+++ b/custom_components/nikobus/nkbactuator.py
@@ -8,8 +8,7 @@ import time
 import uuid
 from collections import deque
 from dataclasses import dataclass, field
-from datetime import timezone as _tz
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.core import HomeAssistant
@@ -223,7 +222,7 @@ class NikobusActuator:
     async def _handle_release(self, state: PressState, press_duration: float) -> None:
         """Cleanup and process module updates upon button release."""
         bucket = self._get_bucket(press_duration)
-        
+
         # 1. Base Release Event
         self._fire_event("nikobus_button_released", state, state_value="released", duration=press_duration, bucket=bucket)
 
@@ -383,7 +382,7 @@ class NikobusActuator:
             "address": state.address,
             "module_address": state.module_address,
             "channel": state.channel,
-            "ts": datetime.now(_tz.utc).isoformat(),
+            "ts": datetime.now(timezone.utc).isoformat(),
             "press_id": state.press_id,
             "state": kwargs.get("state_value"),
             "duration_s": kwargs.get("duration"),
@@ -393,7 +392,7 @@ class NikobusActuator:
         }
         if extra := kwargs.get("extra"):
             payload.update(extra)
-            
+
         # Log the event exactly as it is fired to the Home Assistant bus
         _LOGGER.debug("[%s] Fire %s — %s", state.press_id, event_type, payload)
 


### PR DESCRIPTION
## What

Review pass on `nkbactuator.py` — the button press-lifecycle engine. **It's the most sophisticated helper and it holds up well**, so this PR is just trivia.

## Reviewed, no behavioural findings

The hard parts are careful and well-documented:
- **Frame-count duration anchoring** — press duration tracked as `frame_count * FRAME_CADENCE_S` rather than wall-clock, the only quantity that survives upstream bridge buffering.
- **Burst-aware adaptive release threshold** — detects a drained bridge stall (clustered sub-threshold gaps) and extends release patience, then relaxes back when the gap window is clean again.
- **Per-module cancel-and-replace refresh debouncing** with a `finally` guard that only pops the task slot if it still owns it.
- Covered by `test_actuator_burst.py` (12 cases).

## Changes (cosmetic only)

- Collapse the split `from datetime import timezone as _tz` / `from datetime import datetime` into one import; use `timezone.utc`.
- Strip two trailing-whitespace lines.

## Noted for later (not changed)

- The ~50-line `_refresh_task` closure in `process_button_modules` (with loop-var default-arg binding) could be extracted to a method for readability.
- In-flight release/refresh tasks aren't explicitly cancelled on config-entry unload — they self-terminate (release detects silence; refresh is short), so low risk, but a tracked-task cleanup would be tidier.

## Testing

Full suite **399 passing**, ruff clean. Net −1.

No manifest bump — parallel per-file review PRs; bump at release.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_