### PR TITLE
cleanup(nkbconfig): drop vestigial no-op transform machinery

### DIFF
--- a/custom_components/nikobus/nkbconfig.py
+++ b/custom_components/nikobus/nkbconfig.py
@@ -18,7 +18,6 @@ from homeassistant.core import HomeAssistant
 from .exceptions import NikobusDataError
 
 _LOGGER = logging.getLogger(__name__)
-_LOAD_TRANSFORMS: dict[str, str] = {}
 
 
 class NikobusConfig:
@@ -29,14 +28,13 @@ class NikobusConfig:
         self._hass = hass
 
     async def load_json_data(self, file_name: str, data_type: str) -> dict[str, Any]:
-        """Load JSON data from a file and transform it based on the data type."""
+        """Load JSON data from a config file in the HA config directory."""
         file_path = self._hass.config.path(file_name)
         _LOGGER.info("Loading %s data from %s", data_type, file_path)
 
         try:
             async with aio_open(file_path, mode="r") as file:
-                data = json.loads(await file.read())
-            return self._transform_loaded_data(data, data_type)
+                return json.loads(await file.read())
 
         except FileNotFoundError:
             self._handle_file_not_found(file_path, data_type)
@@ -52,13 +50,6 @@ class NikobusConfig:
         except Exception as err:
             _LOGGER.error("Failed to load %s data: %s", data_type, err, exc_info=True)
             raise NikobusDataError(f"Failed to load {data_type} data: {err}") from err
-
-    def _transform_loaded_data(self, data: dict[str, Any], data_type: str) -> dict[str, Any]:
-        """Transform the loaded JSON data based on the data type."""
-        transform_name = _LOAD_TRANSFORMS.get(data_type)
-        if not transform_name:
-            return data
-        return getattr(self, transform_name)(data)
 
     def _handle_file_not_found(self, file_path: str, data_type: str) -> None:
         """Handle the case where the configuration file is not found."""


### PR DESCRIPTION
## What

Review pass on `nkbconfig.py` — a thin JSON config loader (only the scene file today; module/button config moved to the HA `Store` in 0.4.0).

## Change

`_LOAD_TRANSFORMS` was an **empty dict**, so `_transform_loaded_data` was a permanent no-op passthrough — its `getattr`-dispatch branch was unreachable. Leftover scaffolding from when module/button transforms existed. Both symbols are referenced only inside this file (no tests, no external callers), so:
- removed `_LOAD_TRANSFORMS` and `_transform_loaded_data`,
- `load_json_data` returns the parsed JSON directly.

## Reviewed, no change

Error handling is sound and untouched: `JSONDecodeError` / broad `Exception` → `NikobusDataError` (with `exc_info`), `FileNotFoundError` → log + write an empty skeleton so the library can populate it later.

## Testing

Full suite **399 passing**, ruff clean. Net **−9**, no behaviour change (the removed path was already a no-op).

No manifest bump — parallel per-file review PRs; bump at release.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_