### PR TITLE
types(nkbnames): precise SceneDef.members + extract-helper params

### DIFF
--- a/custom_components/nikobus/nkbnames.py
+++ b/custom_components/nikobus/nkbnames.py
@@ -68,7 +68,7 @@ class SceneDef(NamedTuple):
 
     name: str
     #: ``frozenset`` of ``(module_addr_upper, channel, mode_code)``.
-    members: frozenset
+    members: frozenset[tuple[str, int, str]]
 
 
 class NkbData(NamedTuple):
@@ -152,7 +152,7 @@ def parse_nkb(nkb_path: str | Path) -> NkbData:
 
 
 def _extract_outputs(
-    comp_by_key, objecten, objectbase
+    comp_by_key: dict, objecten: list[dict], objectbase: dict
 ) -> dict[tuple[str, int], str]:
     """``{(MODULE_ADDR, channel): name}`` for output channels with a real
     user name. Channel is the output's ``Prefix`` number (``O02`` → 2);
@@ -194,7 +194,12 @@ def _extract_addresses(
 
 
 def _extract_scenes(
-    components, comp_by_key, objecten, connections, linkmodes, objectbase
+    components: list[dict],
+    comp_by_key: dict,
+    objecten: list[dict],
+    connections: list[dict],
+    linkmodes: dict,
+    objectbase: dict,
 ) -> list[SceneDef]:
     """Resolve each named CF group to its ``(module, channel, mode)`` members.
 


### PR DESCRIPTION
## What

Review pass on `nkbnames.py` — the `.nkb` (zipped MS Access) parser that surfaces names, Areas, and scene member-sets for import. It's a **careful, well-tested module** (`test_nkbnames.py`, 22 cases): the natural-width address formatting (4-hex modules vs 6-hex buttons), the `Prefix`-based channel numbering (handling roller output pairs), and the group→MCF→trigger→output member-set resolution are all sound. Typing hygiene only.

## Changes (annotations only)

- `SceneDef.members`: `frozenset` → `frozenset[tuple[str, int, str]]`, matching the field's own comment.
- Added parameter types to `_extract_outputs` and `_extract_scenes` (matching the existing `_extract_addresses` style).

## Observed, not changed

`NkbData.outputs` uses a **mutable `{}` default** in a `NamedTuple` (shared across default-constructed instances). It's documented read-only and only ever *read* (coordinator `async_import_nkb_names`), and several tests construct `NkbData` without it — so the default has to stay. Flagged here for awareness; safe as-is.

## Testing

Full suite **399 passing** (incl. `test_nkbnames`), ruff clean. No behaviour change.

No manifest bump — parallel per-file review PRs; bump at release.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_