### PR TITLE
types(diagnostics): annotate coordinator params + Counter

### DIFF
--- a/custom_components/nikobus/diagnostics.py
+++ b/custom_components/nikobus/diagnostics.py
@@ -16,13 +16,15 @@ from .const import (
     CONF_REFRESH_INTERVAL,
     DOMAIN,
 )
-from .coordinator import NikobusConfigEntry
+from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import device_entry_diagnostics
 
 TO_REDACT = {CONF_CONNECTION_STRING}
 
 
-def _per_module_decode_metrics(coordinator) -> dict[str, dict[str, Any]]:
+def _per_module_decode_metrics(
+    coordinator: NikobusDataCoordinator,
+) -> dict[str, dict[str, Any]]:
     """Build per-output-module decode-quality metrics.
 
     For each module address surface:
@@ -106,7 +108,7 @@ def _per_module_decode_metrics(coordinator) -> dict[str, dict[str, Any]]:
         ch_total = channel_counts.get(module_addr, 0)
         channels_seen: set[int] = {r["channel"] for r in recs}
         buttons_seen: set[str] = {r["button_phys"] for r in recs}
-        modes_seen: Counter = Counter(
+        modes_seen: Counter[str] = Counter(
             r["mode"] for r in recs if r["mode"] is not None
         )
         t1_values = sorted({r["t1"] for r in recs if r["t1"]})
@@ -144,7 +146,7 @@ def _per_module_decode_metrics(coordinator) -> dict[str, dict[str, Any]]:
     return out
 
 
-def _button_decode_metrics(coordinator) -> dict[str, Any]:
+def _button_decode_metrics(coordinator: NikobusDataCoordinator) -> dict[str, Any]:
     """Top-level button-store decode metrics.
 
     Surfaces aggregate counts useful for sanity-checking what came out


### PR DESCRIPTION
## What

Review pass on `diagnostics.py`. It's **solid** — redacts the connection string (`TO_REDACT`), the per-module / button decode-quality metrics are pure aggregation with careful guard ladders, and the raw-hex module-state dump is genuinely useful for debugging. Typing tidy only.

## Changes

- Annotate the `coordinator` parameter of `_per_module_decode_metrics` and `_button_decode_metrics` as `NikobusDataCoordinator` (was untyped).
- `modes_seen: Counter` → `Counter[str]`.

## Noted for a coordinator-side pass (not changed here)

`diagnostics.py` reads the coordinator's **private** `_reconnect_attempts` / `_last_connected`. Together with `config_flow`'s `_async_on_module_save()` call (flagged in #417), these would be cleaner as **public accessors** on the coordinator. Good candidate to fold into the pending coordinator cleanup (alongside the dead `get_known_entity_unique_ids` input-button block).

## Testing

Full suite **399 passing**, ruff clean. No behaviour change.

No manifest bump — parallel per-file review PRs; bump at release.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_