### PR TITLE
cleanup(coordinator): drop dead input-button ids, unhide module-save hook

### DIFF
--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -669,7 +669,7 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
                 entry["channels"] = channels_list
 
             selected = user_input.get("channel")
-            await coordinator._async_on_module_save()
+            await coordinator.async_on_module_save()
 
             if selected and selected != "done":
                 try:
@@ -784,7 +784,7 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
                     _set_time_or_drop(channel, "operation_time_up", up)
                     _set_time_or_drop(channel, "operation_time_down", down)
 
-                await coordinator._async_on_module_save()
+                await coordinator.async_on_module_save()
                 # Return to the module step so the user can edit another
                 # channel or finish.
                 self._edit_channel_index = None

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -375,7 +375,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 button_data=self.dict_button_data,
                 on_button_save=self.button_storage.async_save,
                 module_data=self.module_storage.data,
-                on_module_save=self._async_on_module_save,
+                on_module_save=self.async_on_module_save,
                 on_progress=self._handle_discovery_progress,
             )
             self.nikobus_discovery.on_discovery_finished = self._handle_discovery_finished
@@ -1379,7 +1379,6 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             input_latch_switch_unique_id,
             iter_input_module_children,
             iter_operation_points,
-            INPUT_MODULE_TYPES,
         )
         known: set[str] = set()
         routing = build_routing(self.dict_module_data)
@@ -1397,37 +1396,6 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         # inputs — same enumerator the switch platform creates from.
         for in_addr, _phys in iter_input_module_children(buttons):
             known.add(input_latch_switch_unique_id(in_addr))
-        # Input-class modules (PC-Logic, Modular Interface) skip ``build_routing``
-        # because they don't drive output relays — emit their input-channel
-        # button unique IDs directly so orphan-cleanup doesn't remove them.
-        # PC-Logic (05-201) and Modular Interface (05-206) are excluded:
-        # their inputs surface through synthesised button-store entries
-        # (one ``LM-INPUT N`` device per input), not per-channel input
-        # entities. Both module types share the same synthesis path.
-        for module_type in INPUT_MODULE_TYPES:
-            if module_type in ("pc_logic", "interface_module"):
-                continue
-            bucket = self.dict_module_data.get(module_type) or {}
-            if not isinstance(bucket, dict):
-                continue
-            for address, module_data in bucket.items():
-                if not isinstance(module_data, dict):
-                    continue
-                channels = module_data.get("channels") or []
-                if not isinstance(channels, list):
-                    continue
-                addr_upper = str(address).upper()
-                for channel_index, channel_info in enumerate(channels, start=1):
-                    if not isinstance(channel_info, dict):
-                        continue
-                    if channel_info.get("entity_type") == "disabled":
-                        continue
-                    desc = channel_info.get("description") or ""
-                    if isinstance(desc, str) and desc.startswith("not_in_use"):
-                        continue
-                    known.add(
-                        f"{DOMAIN}_input_button_{addr_upper}_{channel_index}"
-                    )
         for scene in self.dict_scene_data.get("scene", []):
             if sid := scene.get("id"):
                 known.add(f"{DOMAIN}_scene_{sid}")
@@ -1501,8 +1469,12 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         entry_data = domain_data.get(self.config_entry.entry_id, {})
         entry_data.pop("routing", None)
 
-    async def _async_on_module_save(self) -> None:
-        """Persist the Store after discovery/user edits, then refresh derived views."""
+    async def async_on_module_save(self) -> None:
+        """Persist the Store after discovery/user edits, then refresh derived views.
+
+        Public hook: called by the library (registered as ``on_module_save``)
+        and by the options flow after a module/channel edit.
+        """
         await self.module_storage.async_save()
         self._rebuild_dict_module_data()
         # Clear the cached router spec so newly-discovered modules show up.


### PR DESCRIPTION
## What

Closes out the deferred coordinator items accumulated across the per-file review pass (#414, #417, #423).

## Changes

**1. Remove the dead `nikobus_input_button_*` block** in `get_known_entity_unique_ids`.
It loops `INPUT_MODULE_TYPES` (= `{pc_logic, interface_module}`) and `continue`s on both, so it never emitted an id — the exact mirror of the dead `NikobusInputEntity` path removed in #414. Also drops the now-unused `INPUT_MODULE_TYPES` from the method's local import. (The orphan-cleanup known-id set is unchanged in behaviour; the `get_known_entity_unique_ids` tests — `test_known_entity_cf_scenes`, `test_input_latch_switch` — still pass.)

**2. Rename `_async_on_module_save` → `async_on_module_save`.**
Despite the leading underscore it's a **public hook**: registered as the library's `on_module_save` callback *and* called cross-module from the options flow (`config_flow`). The underscore wrongly signalled "private" for something invoked across module boundaries (flagged in #417). Updated the callback wiring + both `config_flow` call sites; added a docstring note.

## Evaluated, left as-is

`diagnostics.py` reads the coordinator's `_reconnect_attempts` / `_last_connected` for its debug dump (noted in #423). I considered adding public properties but concluded it's **ceremony, not value** — exposing internal state as committed public API for a read-only diagnostics path isn't warranted; within-package access is fine there.

## Testing

Full suite **399 passing**, ruff clean. Net **−28** in the coordinator. No behaviour change.

No manifest bump — parallel per-file review PRs; bump at release.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_