### PR TITLE
refactor(platforms): consolidate the 4 command_error copies into entity

### DIFF
--- a/custom_components/nikobus/cover.py
+++ b/custom_components/nikobus/cover.py
@@ -15,7 +15,6 @@ from homeassistant.components.cover import (
     CoverEntityFeature,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -24,27 +23,16 @@ from .const import (
     DEFAULT_COVER_DEBOUNCE_DELAY,
     DEFAULT_COVER_MOVEMENT_BUFFER,
     DEFAULT_COVER_OPERATION_TIME,
-    DOMAIN,
     press_signal,
 )
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
-from .entity import NikobusEntity
+from .entity import NikobusEntity, command_error
 from .nkbtravelcalculator import NikobusTravelCalculator
 from .router import build_unique_id, get_routing, register_output_module_devices
 
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
-
-
-def _command_error(err: Exception) -> HomeAssistantError:
-    """A bus command failed — surface it as a translated HA error so the
-    user sees a clean message instead of the raw library exception."""
-    return HomeAssistantError(
-        translation_domain=DOMAIN,
-        translation_key="communication_error",
-        translation_placeholders={"error": str(err)},
-    )
 
 
 def _parse_operation_time(value: Any, fallback: float, label: str, address: str) -> float:
@@ -326,7 +314,7 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
         except asyncio.CancelledError:
             raise
         except Exception as err:
-            raise _command_error(err) from err
+            raise command_error(err) from err
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover command."""
@@ -335,7 +323,7 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
         except asyncio.CancelledError:
             raise
         except Exception as err:
-            raise _command_error(err) from err
+            raise command_error(err) from err
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop cover command."""
@@ -344,7 +332,7 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
         except asyncio.CancelledError:
             raise
         except Exception as err:
-            raise _command_error(err) from err
+            raise command_error(err) from err
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move cover to a specific percentage."""

--- a/custom_components/nikobus/entity.py
+++ b/custom_components/nikobus/entity.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -15,6 +16,21 @@ from .coordinator import NikobusDataCoordinator
 # Sentinel return for ``_render_state``: this entity opts out of
 # write-diffing and writes on every coordinator update (the default).
 _NO_DIFF = object()
+
+
+def command_error(err: Exception) -> HomeAssistantError:
+    """A failed bus command as a translated HA error.
+
+    Shared by the output platforms (switch / light / cover / scene): each
+    entity action wraps a failed bus command with
+    ``raise command_error(err) from err`` so the user sees a clean message
+    instead of the raw library exception.
+    """
+    return HomeAssistantError(
+        translation_domain=DOMAIN,
+        translation_key="communication_error",
+        translation_placeholders={"error": str(err)},
+    )
 
 
 def hub_device_info() -> dr.DeviceInfo:

--- a/custom_components/nikobus/light.py
+++ b/custom_components/nikobus/light.py
@@ -8,29 +8,18 @@ from typing import Any
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .const import DOMAIN, operation_signal
+from .const import operation_signal
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
-from .entity import NikobusEntity
+from .entity import NikobusEntity, command_error
 from .router import build_unique_id, get_routing, register_output_module_devices
 
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
-
-
-def _command_error(err: Exception) -> HomeAssistantError:
-    """A bus command failed — surface it as a translated HA error so the
-    user sees a clean message instead of the raw library exception."""
-    return HomeAssistantError(
-        translation_domain=DOMAIN,
-        translation_key="communication_error",
-        translation_placeholders={"error": str(err)},
-    )
 
 
 async def async_setup_entry(
@@ -218,7 +207,7 @@ class NikobusDimmerEntity(NikobusBaseLight):
             self._is_on = None
             self._optimistic_brightness = None
             self.async_write_ha_state()
-            raise _command_error(err) from err
+            raise command_error(err) from err
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the dimmer with optimistic UI update and error fallback."""
@@ -240,7 +229,7 @@ class NikobusDimmerEntity(NikobusBaseLight):
             self._is_on = None
             self._optimistic_brightness = None
             self.async_write_ha_state()
-            raise _command_error(err) from err
+            raise command_error(err) from err
 
 
 class NikobusRelayEntity(NikobusBaseLight):
@@ -275,7 +264,7 @@ class NikobusRelayEntity(NikobusBaseLight):
         except Exception as err:
             self._is_on = None
             self.async_write_ha_state()
-            raise _command_error(err) from err
+            raise command_error(err) from err
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Open relay with optimistic UI update and error fallback."""
@@ -289,7 +278,7 @@ class NikobusRelayEntity(NikobusBaseLight):
         except Exception as err:
             self._is_on = None
             self.async_write_ha_state()
-            raise _command_error(err) from err
+            raise command_error(err) from err
 
 
 class NikobusCoverLightEntity(NikobusBaseLight):
@@ -324,7 +313,7 @@ class NikobusCoverLightEntity(NikobusBaseLight):
         except Exception as err:
             self._is_on = None
             self.async_write_ha_state()
-            raise _command_error(err) from err
+            raise command_error(err) from err
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn light off via cover stop command with optimistic UI update and error fallback."""
@@ -338,4 +327,4 @@ class NikobusCoverLightEntity(NikobusBaseLight):
         except Exception as err:
             self._is_on = None
             self.async_write_ha_state()
-            raise _command_error(err) from err
+            raise command_error(err) from err

--- a/custom_components/nikobus/scene.py
+++ b/custom_components/nikobus/scene.py
@@ -9,7 +9,6 @@ from typing import Any
 
 from homeassistant.components.scene import Scene
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -21,7 +20,7 @@ from .const import (
     press_signal,
 )
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
-from .entity import NikobusEntity
+from .entity import NikobusEntity, command_error
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -282,11 +281,7 @@ class NikobusSceneEntity(NikobusEntity, Scene):
         except asyncio.CancelledError:
             raise
         except Exception as err:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key="communication_error",
-                translation_placeholders={"error": str(err)},
-            ) from err
+            raise command_error(err) from err
 
     async def _activate(self) -> None:
         """Activate the scene by setting multiple module channels."""

--- a/custom_components/nikobus/switch.py
+++ b/custom_components/nikobus/switch.py
@@ -8,14 +8,13 @@ from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .const import DOMAIN, operation_signal, press_signal
+from .const import operation_signal, press_signal
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
-from .entity import NikobusEntity
+from .entity import NikobusEntity, command_error
 from .router import (
     build_unique_id,
     get_routing,
@@ -37,16 +36,6 @@ except ImportError:  # pragma: no cover - defensive (older library)
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
-
-
-def _command_error(err: Exception) -> HomeAssistantError:
-    """A bus command failed — surface it as a translated HA error so the
-    user sees a clean message instead of the raw library exception."""
-    return HomeAssistantError(
-        translation_domain=DOMAIN,
-        translation_key="communication_error",
-        translation_placeholders={"error": str(err)},
-    )
 
 
 def input_ab_addresses(phys: dict[str, Any]) -> tuple[str, str] | None:
@@ -241,7 +230,7 @@ class NikobusRelaySwitchEntity(NikobusBaseSwitch):
         except Exception as err:
             self._is_on = None
             self.async_write_ha_state()
-            raise _command_error(err) from err
+            raise command_error(err) from err
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Open relay with optimistic UI update and error fallback."""
@@ -255,7 +244,7 @@ class NikobusRelaySwitchEntity(NikobusBaseSwitch):
         except Exception as err:
             self._is_on = None
             self.async_write_ha_state()
-            raise _command_error(err) from err
+            raise command_error(err) from err
 
 
 class NikobusCoverSwitchEntity(NikobusBaseSwitch):
@@ -288,7 +277,7 @@ class NikobusCoverSwitchEntity(NikobusBaseSwitch):
         except Exception as err:
             self._is_on = None
             self.async_write_ha_state()
-            raise _command_error(err) from err
+            raise command_error(err) from err
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Trigger 'Stop/Close' on cover module with optimistic UI update and error fallback."""
@@ -302,7 +291,7 @@ class NikobusCoverSwitchEntity(NikobusBaseSwitch):
         except Exception as err:
             self._is_on = None
             self.async_write_ha_state()
-            raise _command_error(err) from err
+            raise command_error(err) from err
 
 class NikobusInputLatchSwitch(NikobusEntity, SwitchEntity, RestoreEntity):
     """Stateful on/off latch for a PC-Logic / Modular-Interface input.


### PR DESCRIPTION
## What

Closes out the one cross-cutting cleanup flagged during the review (in #415): the action-exceptions work left **four copies** of the same "wrap a failed bus command as a translated `HomeAssistantError(communication_error)`" logic — an identical `_command_error` helper in `switch` / `light` / `cover`, plus an inline copy of the raise in `scene`.

## Change

- Promote it to a single public **`entity.command_error(err)`** (the shared base all four already import from).
- `switch` / `light` / `cover` / `scene` import and use it.
- Drop the now-unused `HomeAssistantError` / `DOMAIN` imports each local copy required (ruff-verified — `All checks passed`).

Behaviour is **identical**: same `communication_error` translation key, same `{"error": str(err)}` placeholder, same chained `raise … from err`. The revert-on-error tests (switch/light) and the scene/cover error-translation tests are unchanged and still green.

## Testing

Full suite **399 passing**, ruff clean. Net **−23 lines** across 5 files (+16 in `entity`, −39 in the platforms).

No manifest bump — parallel per-file review PRs; bump at release.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_