### PR TITLE
release: 3.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 3.8.2
+
+Robustness & cleanup pass — one user-facing fix, otherwise internal.
+
+- **Friendlier errors when a command can't reach the bus.** Turning a
+  switch / light / cover on or off — or activating a scene — now surfaces a
+  clean, translated "communication failed" message when the bus is
+  unreachable, instead of the raw library exception. The optimistic UI
+  state still rolls back on failure.
+- **Lighter button handling.** A latch-switch toggle or a simulated button
+  press no longer wakes *every* entity on the bus to filter itself out;
+  only the affected addresses are notified.
+- **Internal tidy — no behaviour or configuration changes.** Removed a
+  couple of unreachable code paths, de-duplicated the storage wrappers and
+  the command-error helper, modernised imports / typing across the
+  platforms and helpers, and refreshed stale in-code / README references.
+  The full test suite stays green.
+
 ## 3.8.1
 
 - **Fix: don't leak the bus connection when setup fails partway.** If the

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -16,5 +16,5 @@
     "nikobus-connect>=0.24.0",
     "construct>=2.10"
   ],
-  "version": "3.8.1"
+  "version": "3.8.2"
 }


### PR DESCRIPTION
## Release 3.8.2

Cuts a release for the review batch merged on top of 3.8.1 (#411–#425). `manifest.json` → **3.8.2**, plus a CHANGELOG entry.

### What's in it (user-facing)

- **Friendlier errors when a command can't reach the bus** — switch/light/cover on/off and scene activation now raise a clean, translated `communication_error` instead of the raw library exception; optimistic UI state still rolls back. (#413, #415)
- **Lighter button handling** — a latch toggle / simulated press no longer wakes every entity to self-filter; only affected addresses are notified. (#411)

### Internal (no behaviour change)

Unreachable-code removal (#414, #424, #421, #417), storage + `command_error` de-duplication (#420, #425), import/typing modernisation (#418, #419, #422, #423), doc/whitespace refresh (#412, #416). Full suite **399 green** throughout.

### Version note

I went with **3.8.2 (patch)** — no new features, one fix + internal cleanup, consistent with the 3.8.x pass-by-pass pattern. If you'd rather signal the error-handling/perf work as a minor, say so and I'll re-cut as **3.9.0**.

After merge, the usual release step is tagging `v3.8.2` / publishing the GitHub release (HACS picks up the manifest version) — let me know if you'd like me to draft that too.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_