### PR TITLE
cleanup(nkbtravelcalculator): future-annotations + drop redundant else

### DIFF
--- a/custom_components/nikobus/nkbtravelcalculator.py
+++ b/custom_components/nikobus/nkbtravelcalculator.py
@@ -1,5 +1,7 @@
 """Position calculator for time-based Nikobus covers."""
 
+from __future__ import annotations
+
 import time
 
 
@@ -53,5 +55,4 @@ class NikobusTravelCalculator:
 
         if self._direction == 1:
             return min(100.0, self._start_pos + progress)
-        else:
-            return max(0.0, self._start_pos - progress)
+        return max(0.0, self._start_pos - progress)


### PR DESCRIPTION
## What

Review pass on `nkbtravelcalculator.py` — the time-based cover position dead-reckoning. **The math is sound** and well covered by `TestTravelCalculator` in `test_cover.py` (progress, 0/100 clamping, latency backdating, zero-active-time guard); the position convention (100=open, direction `1`=up increases toward 100) is consistent with `cover.py`.

## Changes (trivia only)

- Add `from __future__ import annotations` — this was the **only** integration module missing it.
- Drop the redundant `else` after a `return` in `current_position`.

No behaviour change. Cover tests green (39), ruff clean.

No manifest bump — parallel per-file review PRs; bump at release (this one's part of the outstanding-four sweep I missed before #426).

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_