### PR TITLE
refactor(sensor): public last_connected/reconnect_attempts accessors

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -316,6 +316,22 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             return "reconnecting"
         return "disconnected"
 
+    @property
+    def last_connected(self) -> datetime | None:
+        """Timestamp of the last successful connect (UTC), or ``None``.
+
+        Surfaced by the connection sensor's attributes and diagnostics.
+        """
+        return self._last_connected
+
+    @property
+    def reconnect_attempts(self) -> int:
+        """Consecutive reconnect attempts since the last successful connect.
+
+        Surfaced by the connection sensor's attributes and diagnostics.
+        """
+        return self._reconnect_attempts
+
     def _get_update_interval(self) -> timedelta | None:
         # No poll timer in push mode. A feedback module pushes state
         # unprompted; older PC-Links (prior_gen3) can't sustain the poll

--- a/custom_components/nikobus/diagnostics.py
+++ b/custom_components/nikobus/diagnostics.py
@@ -235,10 +235,10 @@ async def async_get_config_entry_diagnostics(
         },
         "coordinator": {
             "connection_status": coordinator.connection_status,
-            "reconnect_attempts": coordinator._reconnect_attempts,
+            "reconnect_attempts": coordinator.reconnect_attempts,
             "last_connected": (
-                coordinator._last_connected.isoformat()
-                if coordinator._last_connected
+                coordinator.last_connected.isoformat()
+                if coordinator.last_connected
                 else None
             ),
             "module_count": len(coordinator.dict_module_data),

--- a/custom_components/nikobus/sensor.py
+++ b/custom_components/nikobus/sensor.py
@@ -59,10 +59,10 @@ class NikobusConnectionSensor(CoordinatorEntity[NikobusDataCoordinator], SensorE
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return diagnostic attributes."""
-        last = self.coordinator._last_connected
+        last = self.coordinator.last_connected
         return {
             "last_connected": last.isoformat() if last else None,
-            "reconnect_attempts": self.coordinator._reconnect_attempts,
+            "reconnect_attempts": self.coordinator.reconnect_attempts,
             "connection_string": self.coordinator.connection_string,
         }
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -24,8 +24,8 @@ def _make_coordinator(is_connected=True, reconnect_task=None, reconnect_attempts
     coord = MagicMock()
     coord.nikobus_connection.is_connected = is_connected
     coord._reconnect_task = reconnect_task
-    coord._reconnect_attempts = reconnect_attempts
-    coord._last_connected = last_connected
+    coord.reconnect_attempts = reconnect_attempts
+    coord.last_connected = last_connected
     coord.connection_string = "192.168.1.1:8000"
 
     # Wire the real connection_status property
@@ -125,8 +125,8 @@ class TestSensorIcon(unittest.TestCase):
 class TestSensorAttributes(unittest.TestCase):
     def _sensor(self, last_connected=None, reconnect_attempts=0, connection_string="host:1234"):
         coord = MagicMock()
-        coord._last_connected = last_connected
-        coord._reconnect_attempts = reconnect_attempts
+        coord.last_connected = last_connected
+        coord.reconnect_attempts = reconnect_attempts
         coord.connection_string = connection_string
         sensor = NikobusConnectionSensor.__new__(NikobusConnectionSensor)
         sensor.coordinator = coord


### PR DESCRIPTION
## What

Review of `sensor.py` — one of the four files I missed in the first pass. It surfaced a real finding that **revises a call from #424**.

## The finding

`NikobusConnectionSensor.extra_state_attributes` reads the coordinator's **private** `_last_connected` / `_reconnect_attempts`. In #424 I dismissed adding public accessors for these as "ceremony for a debug dump" — but that reasoning was based only on the *diagnostics* reader. I hadn't reviewed `sensor.py` yet: these are exposed to **users** as entity attributes (`state_attr('sensor.nikobus_connection', 'reconnect_attempts')`), so they're a genuine observable surface and the accessor is warranted.

## Change

- **coordinator**: add `last_connected` and `reconnect_attempts` properties.
- **sensor** + **diagnostics**: read via the new properties — no more private cross-module access for these two anywhere.
- **test_sensor**: set the public names on the mock coordinator.

## Rest of sensor.py — good shape, no change

The discovery-status sensor's coarse-phase state + `_unrecorded_attributes` correctly keep per-register scan churn out of the recorder; the `SIGNAL_DISCOVERY_STATE` dispatcher push model is sound; types are complete.

**Noted (unchanged):** the connection sensor exposes `connection_string` as an attribute while diagnostics *redacts* it. Defensible — a local sensor attribute vs shareable diagnostics — but flagged for awareness.

## Testing

Full suite **399 passing**, ruff clean. No behaviour change.

No manifest bump — part of the outstanding-four sweep; folds into the pending 3.8.2 release (#426).

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_