### PR TITLE
cleanup(const): future-annotations + regroup EVENT_SCENE_ACTIVATED

### DIFF
--- a/custom_components/nikobus/const.py
+++ b/custom_components/nikobus/const.py
@@ -1,5 +1,7 @@
 """Constants for the Nikobus integration."""
 
+from __future__ import annotations
+
 from typing import Final
 
 # =============================================================================
@@ -50,6 +52,10 @@ CATEGORY_DEVICES: Final[tuple[tuple[str, str, str], ...]] = (
 # =============================================================================
 EVENT_BUTTON_OPERATION: Final[str] = "nikobus_button_operation"
 EVENT_BUTTON_PRESSED: Final[str] = "nikobus_button_pressed"
+# Fired when a discovered CF/light scene is activated on the bus (its
+# trigger address is seen) — lets automations react to a scene firing,
+# whether triggered physically or from HA.
+EVENT_SCENE_ACTIVATED: Final[str] = "nikobus_scene_activated"
 
 
 def operation_signal(address: str) -> str:
@@ -75,10 +81,7 @@ def press_signal(address: str) -> str:
     filtering itself out. The payload mirrors the bus event's data dict.
     """
     return f"{DOMAIN}_press_{address.upper()}"
-# Fired when a discovered CF/light scene is activated on the bus (its
-# trigger address is seen) — lets automations react to a scene firing,
-# whether triggered physically or from HA.
-EVENT_SCENE_ACTIVATED: Final[str] = "nikobus_scene_activated"
+
 
 # =============================================================================
 # Discovery


### PR DESCRIPTION
## What

Review of `const.py` — one of the four files missed in the first sweep. It's well-organised (clear `===` section banners) and unusually well-commented for a constants module (the burst-detection, press-repeat, and category-device rationale all live here). Two tidy-ups only.

## Changes

- **`from __future__ import annotations`** — `const.py` was the other module missing it (alongside `nkbtravelcalculator`, #427).
- **Regroup `EVENT_SCENE_ACTIVATED`** — it was wedged directly after the `press_signal()` function body with no blank-line separation, despite being an event constant. Moved it up beside `EVENT_BUTTON_OPERATION` / `EVENT_BUTTON_PRESSED` in the Events section and restored the two blank lines after `press_signal`.

Same value, still exported from the same module — purely organisational.

## Testing

Full suite **399 passing**, ruff clean. No behaviour change.

No manifest bump — part of the outstanding-four sweep; folds into the pending 3.8.2 release (#426).

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_