### PR TITLE
i18n: complete + correct the translations (fr/nl parity, stale/missing service strings)

### DIFF
--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -294,9 +294,13 @@
     "detect_stale_inventory": {
       "description": "Probes every known output module (switch, dimmer, roller) on the bus and reports which ones don't respond. Returns a manifest with checked / present / absent module lists plus orphaned button addresses. Does not modify configuration; pair with purge_stale_inventory after reviewing the results.",
       "fields": {
-        "timeout": {
-          "description": "Per-module probe timeout. Worst-case scan time is roughly N modules × timeout.",
-          "name": "Probe timeout (seconds)"
+        "outer_attempts": {
+          "name": "Sweep passes",
+          "description": "How many full detection passes to run (1–3). More passes improves reliability on a slow or busy bus."
+        },
+        "outer_delay": {
+          "name": "Delay between passes (seconds)",
+          "description": "Bus-quiet wait inserted between detection passes (0–10 s)."
         }
       },
       "name": "Detect stale inventory"
@@ -310,6 +314,16 @@
         }
       },
       "name": "Purge stale inventory"
+    },
+    "send_button_press": {
+      "name": "Send button press",
+      "description": "Simulate a Nikobus button press on the bus for the given address — fires the same telegram a physical press would.",
+      "fields": {
+        "address": {
+          "name": "Address",
+          "description": "Bus address of the button to simulate (e.g. 84DFFC)."
+        }
+      }
     }
   },
   "selector": {

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -304,9 +304,13 @@
       "name": "Détecter l'inventaire obsolète",
       "description": "Interroge chaque module de sortie connu (interrupteur, variateur, volet) sur le bus et signale ceux qui ne répondent pas. Renvoie un manifeste avec les listes de modules vérifiés / présents / absents ainsi que les adresses de boutons orphelines. Ne modifie pas la configuration ; à utiliser avec purge_stale_inventory après avoir examiné les résultats.",
       "fields": {
-        "timeout": {
-          "name": "Délai d'attente (secondes)",
-          "description": "Délai d'attente par module. Le temps d'analyse au pire cas est d'environ N modules × délai."
+        "outer_attempts": {
+          "name": "Passes de balayage",
+          "description": "Nombre de passes de détection complètes à exécuter (1–3). Davantage de passes améliore la fiabilité sur un bus lent ou chargé."
+        },
+        "outer_delay": {
+          "name": "Délai entre les passes (secondes)",
+          "description": "Temps d'attente (bus au repos) inséré entre les passes de détection (0–10 s)."
         }
       }
     },
@@ -339,6 +343,16 @@
         "sub_byte": {
           "name": "Sous-octet",
           "description": "Sélecteur de banque mémoire pour le mode forensic (par défaut 04 — table de liens de sortie). Autres banques observées : 00 (en-tête / identité du module), 01 (enregistrements BP-cell)."
+        }
+      }
+    },
+    "send_button_press": {
+      "name": "Envoyer un appui sur un bouton",
+      "description": "Simule l'appui sur un bouton Nikobus sur le bus pour l'adresse indiquée — émet le même télégramme qu'un appui physique.",
+      "fields": {
+        "address": {
+          "name": "Adresse",
+          "description": "Adresse de bus du bouton à simuler (par ex. 84DFFC)."
         }
       }
     }

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -43,6 +43,12 @@
           "has_feedbackmodule": "Module Feedback (05-207) installé et connecté via PC-Link",
           "prior_gen3": "PC-Link antérieur à la Gen 3",
           "refresh_interval": "Intervalle de scrutation (secondes)"
+        },
+        "data_description": {
+          "connection_string": "Chemin du périphérique série ou adresse TCP du pont PC-Link",
+          "has_feedbackmodule": "Lorsqu'il est activé, le module de retour (Feedback Module) transmet automatiquement les changements d'état — aucune interrogation nécessaire.",
+          "prior_gen3": "Active les ajustements de compatibilité pour le matériel PC-Link de première et deuxième génération.",
+          "refresh_interval": "Fréquence de lecture de l'état des modules sur le bus (60–3600 s). Des valeurs plus basses accélèrent les mises à jour mais augmentent le trafic du bus."
         }
       }
     },
@@ -138,14 +144,17 @@
       }
     },
     "abort": {
-      "not_loaded": "L'intégration Nikobus n'est pas chargée. Veuillez la recharger puis réessayer."
+      "not_loaded": "L'intégration Nikobus n'est pas chargée. Veuillez la recharger puis réessayer.",
+      "channel_not_found": "Le canal sélectionné est introuvable.",
+      "module_not_found": "Le module sélectionné est introuvable dans le stockage."
     },
     "error": {
       "invalid_nkb": "Ce fichier n'est pas un projet Nikobus .nkb lisible (il doit s'agir de l'export .nkb — une archive ZIP contenant la base de données du projet).",
       "upload_failed": "Impossible d'enregistrer le fichier téléversé. Consultez les journaux Home Assistant.",
       "nkb_nothing_selected": "Choisissez au moins un élément à importer.",
       "nkb_not_found": "Aucun fichier .nkb trouvé — téléversez-en un d'abord (Configurer → Téléverser le fichier projet .nkb).",
-      "nkb_parse_failed": "Impossible de lire le fichier .nkb. Consultez les journaux Home Assistant."
+      "nkb_parse_failed": "Impossible de lire le fichier .nkb. Consultez les journaux Home Assistant.",
+      "invalid_hex_address": "L'adresse de la LED doit comporter exactement 6 caractères hexadécimaux (ou être vide)."
     }
   },
   "entity": {
@@ -245,6 +254,18 @@
     },
     "setup_data_error": {
       "message": "Impossible de charger la configuration Nikobus : {error}"
+    },
+    "cf_no_address": {
+      "message": "Impossible d'activer une fonction centrale (CF) Nikobus sans adresse de bus."
+    },
+    "forensic_range_incomplete": {
+      "message": "Le mode forensic nécessite à la fois register_start et register_end. Fournissez les deux ou omettez les deux."
+    },
+    "forensic_requires_module_address": {
+      "message": "L'analyse forensic des registres nécessite un module_address. Spécifiez-en un (par ex. 940C) — la plage de registres ne peut pas être appliquée à tous les modules."
+    },
+    "not_connected": {
+      "message": "Le bus Nikobus n'est pas connecté — impossible d'envoyer une commande. Vérifiez la connexion et réessayez."
     }
   },
   "selector": {
@@ -275,6 +296,50 @@
         "switch": "Interrupteur",
         "light": "Lumière",
         "disabled": "Désactivé (masquer le canal)"
+      }
+    }
+  },
+  "services": {
+    "detect_stale_inventory": {
+      "name": "Détecter l'inventaire obsolète",
+      "description": "Interroge chaque module de sortie connu (interrupteur, variateur, volet) sur le bus et signale ceux qui ne répondent pas. Renvoie un manifeste avec les listes de modules vérifiés / présents / absents ainsi que les adresses de boutons orphelines. Ne modifie pas la configuration ; à utiliser avec purge_stale_inventory après avoir examiné les résultats.",
+      "fields": {
+        "timeout": {
+          "name": "Délai d'attente (secondes)",
+          "description": "Délai d'attente par module. Le temps d'analyse au pire cas est d'environ N modules × délai."
+        }
+      }
+    },
+    "purge_stale_inventory": {
+      "name": "Purger l'inventaire obsolète",
+      "description": "Supprime les adresses indiquées des stockages persistants de modules et de boutons, puis recharge l'intégration afin que les entités des adresses purgées soient supprimées. Exécutez d'abord detect_stale_inventory pour obtenir la liste des adresses pouvant être supprimées en toute sécurité.",
+      "fields": {
+        "addresses": {
+          "name": "Adresses",
+          "description": "Liste des adresses de modules / boutons à supprimer (comparées sans tenir compte de la casse dans les deux stockages)."
+        }
+      }
+    },
+    "query_module_inventory": {
+      "name": "Interroger l'inventaire des modules",
+      "description": "Déclenche une analyse d'inventaire des modules Nikobus. Sans paramètres, analyse tous les modules de sortie. Avec un module_address, analyse uniquement ce module en utilisant les plages adaptées à chaque type de module. Avec register_start + register_end (et éventuellement sub_byte), exécute une analyse en mode forensic exactement sur la plage demandée — utile pour rétro-concevoir l'agencement du stockage des modules PC-Logic, des modules d'interface ou des zones inconnues de n'importe quel module.",
+      "fields": {
+        "module_address": {
+          "name": "Adresse du module",
+          "description": "Adresse de module Nikobus facultative (par ex. 940C, F586). Sans celle-ci, analyse tous les modules de sortie connus."
+        },
+        "register_start": {
+          "name": "Début de registre",
+          "description": "Mode forensic — borne inférieure de la plage de registres à analyser, sous forme d'octet hexadécimal (par ex. 0x70 ou 70). Nécessite register_end et un module_address spécifique. Lorsqu'elle est fournie, l'analyse ne parcourt que cette plage et ignore la logique de passe supplémentaire de production."
+        },
+        "register_end": {
+          "name": "Fin de registre",
+          "description": "Mode forensic — borne supérieure de la plage de registres à analyser, sous forme d'octet hexadécimal (par ex. 0x83 ou 83). Doit être ≥ register_start."
+        },
+        "sub_byte": {
+          "name": "Sous-octet",
+          "description": "Sélecteur de banque mémoire pour le mode forensic (par défaut 04 — table de liens de sortie). Autres banques observées : 00 (en-tête / identité du module), 01 (enregistrements BP-cell)."
+        }
       }
     }
   }

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -43,6 +43,12 @@
           "has_feedbackmodule": "Feedbackmodule (05-207) geïnstalleerd en verbonden via PC-Link",
           "prior_gen3": "PC-Link is ouder dan Gen 3",
           "refresh_interval": "Polling-interval (seconden)"
+        },
+        "data_description": {
+          "connection_string": "Pad naar het seriële apparaat of TCP-adres van de PC-Link-brug",
+          "has_feedbackmodule": "Indien ingeschakeld pusht de Feedbackmodule statuswijzigingen automatisch — pollen is niet nodig.",
+          "prior_gen3": "Schakelt compatibiliteitsaanpassingen in voor PC-Link-hardware van de eerste en tweede generatie.",
+          "refresh_interval": "Hoe vaak de modulestatussen van de bus worden gelezen (60–3600 s). Lagere waarden betekenen snellere updates maar meer busverkeer."
         }
       }
     },
@@ -138,14 +144,17 @@
       }
     },
     "abort": {
-      "not_loaded": "De Nikobus-integratie is niet geladen. Herlaad de integratie en probeer het opnieuw."
+      "not_loaded": "De Nikobus-integratie is niet geladen. Herlaad de integratie en probeer het opnieuw.",
+      "channel_not_found": "Het geselecteerde kanaal is niet gevonden.",
+      "module_not_found": "De geselecteerde module is niet gevonden in de opslag."
     },
     "error": {
       "invalid_nkb": "Dit bestand is geen leesbaar Nikobus .nkb-project (het moet de .nkb-export zijn — een ZIP met de projectdatabase).",
       "upload_failed": "Kon het geüploade bestand niet opslaan. Controleer de Home Assistant-logboeken.",
       "nkb_nothing_selected": "Kies minstens één ding om te importeren.",
       "nkb_not_found": "Geen .nkb-bestand gevonden — upload er eerst een (Configureren → Projectbestand .nkb uploaden).",
-      "nkb_parse_failed": "Kon het .nkb-bestand niet lezen. Zie de Home Assistant-logboeken."
+      "nkb_parse_failed": "Kon het .nkb-bestand niet lezen. Zie de Home Assistant-logboeken.",
+      "invalid_hex_address": "Het LED-adres moet exact 6 hexadecimale tekens bevatten (of leeg zijn)."
     }
   },
   "entity": {
@@ -245,6 +254,18 @@
     },
     "setup_data_error": {
       "message": "Kon de Nikobus-configuratie niet laden: {error}"
+    },
+    "cf_no_address": {
+      "message": "Kan een Nikobus-CF niet activeren zonder busadres."
+    },
+    "forensic_range_incomplete": {
+      "message": "Forensische modus vereist zowel register_start als register_end. Geef beide op of laat beide weg."
+    },
+    "forensic_requires_module_address": {
+      "message": "Forensische registerscan vereist een module_address. Geef er een op (bijv. 940C) — het registerbereik kan niet op alle modules worden toegepast."
+    },
+    "not_connected": {
+      "message": "De Nikobus-bus is niet verbonden — kan geen commando verzenden. Controleer de verbinding en probeer opnieuw."
     }
   },
   "selector": {
@@ -275,6 +296,50 @@
         "switch": "Schakelaar",
         "light": "Lamp",
         "disabled": "Uitgeschakeld (kanaal verbergen)"
+      }
+    }
+  },
+  "services": {
+    "detect_stale_inventory": {
+      "name": "Verouderde inventaris detecteren",
+      "description": "Test elke bekende uitgangsmodule (schakelaar, dimmer, rolluik) op de bus en meldt welke niet reageren. Geeft een overzicht terug met lijsten van gecontroleerde / aanwezige / afwezige modules plus verweesde knopadressen. Wijzigt de configuratie niet; gebruik samen met purge_stale_inventory na het bekijken van de resultaten.",
+      "fields": {
+        "timeout": {
+          "name": "Time-out (seconden)",
+          "description": "Time-out per module. De scantijd in het slechtste geval is ongeveer N modules × time-out."
+        }
+      }
+    },
+    "purge_stale_inventory": {
+      "name": "Verouderde inventaris opschonen",
+      "description": "Verwijdert de opgegeven adressen uit de opgeslagen module- en knopopslag en herlaadt vervolgens de integratie zodat de entiteiten voor de verwijderde adressen verdwijnen. Voer eerst detect_stale_inventory uit om de lijst met veilig te verwijderen adressen te verkrijgen.",
+      "fields": {
+        "addresses": {
+          "name": "Adressen",
+          "description": "Lijst met module- / knopadressen om te verwijderen (hoofdletterongevoelig vergeleken met beide opslagplaatsen)."
+        }
+      }
+    },
+    "query_module_inventory": {
+      "name": "Module-inventaris opvragen",
+      "description": "Start een inventarisscan van Nikobus-modules. Zonder parameters worden alle uitgangsmodules gescand. Met een module_address wordt alleen die module gescand met de op het moduletype afgestemde bereiken. Met register_start + register_end (en optioneel sub_byte) wordt een forensische scan uitgevoerd van precies het gevraagde bereik — handig om de opslagindeling van PC-Logic, interfacemodules of onbekende delen van een module te reverse-engineeren.",
+      "fields": {
+        "module_address": {
+          "name": "Moduleadres",
+          "description": "Optioneel Nikobus-moduleadres (bijv. 940C, F586). Zonder dit wordt elke bekende uitgangsmodule gescand."
+        },
+        "register_start": {
+          "name": "Registerbegin",
+          "description": "Forensische modus — ondergrens van het te scannen registerbereik, als hex-byte (bijv. 0x70 of 70). Vereist register_end en een specifiek module_address. Indien opgegeven doorloopt de scan alleen dit bereik en slaat de extra-pass-logica van de productiescan over."
+        },
+        "register_end": {
+          "name": "Registereinde",
+          "description": "Forensische modus — bovengrens van het te scannen registerbereik, als hex-byte (bijv. 0x83 of 83). Moet ≥ register_start zijn."
+        },
+        "sub_byte": {
+          "name": "Sub-byte",
+          "description": "Geheugenbankselector voor forensische modus (standaard 04 — uitgangskoppelingstabel). Andere waargenomen banken: 00 (modulekop / identiteit), 01 (BP-cell-records)."
+        }
       }
     }
   }

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -304,9 +304,13 @@
       "name": "Verouderde inventaris detecteren",
       "description": "Test elke bekende uitgangsmodule (schakelaar, dimmer, rolluik) op de bus en meldt welke niet reageren. Geeft een overzicht terug met lijsten van gecontroleerde / aanwezige / afwezige modules plus verweesde knopadressen. Wijzigt de configuratie niet; gebruik samen met purge_stale_inventory na het bekijken van de resultaten.",
       "fields": {
-        "timeout": {
-          "name": "Time-out (seconden)",
-          "description": "Time-out per module. De scantijd in het slechtste geval is ongeveer N modules × time-out."
+        "outer_attempts": {
+          "name": "Detectiedoorgangen",
+          "description": "Aantal volledige detectiedoorgangen om uit te voeren (1–3). Meer doorgangen verbetert de betrouwbaarheid op een trage of drukke bus."
+        },
+        "outer_delay": {
+          "name": "Vertraging tussen doorgangen (seconden)",
+          "description": "Wachttijd (rustige bus) tussen detectiedoorgangen (0–10 s)."
         }
       }
     },
@@ -339,6 +343,16 @@
         "sub_byte": {
           "name": "Sub-byte",
           "description": "Geheugenbankselector voor forensische modus (standaard 04 — uitgangskoppelingstabel). Andere waargenomen banken: 00 (modulekop / identiteit), 01 (BP-cell-records)."
+        }
+      }
+    },
+    "send_button_press": {
+      "name": "Knopdruk verzenden",
+      "description": "Simuleert een Nikobus-knopdruk op de bus voor het opgegeven adres — verstuurt hetzelfde telegram als een fysieke druk.",
+      "fields": {
+        "address": {
+          "name": "Adres",
+          "description": "Busadres van de te simuleren knop (bijv. 84DFFC)."
         }
       }
     }


### PR DESCRIPTION
## What

Auditing the translations as part of the whole-repo double-check turned up **three** issues — a parity gap *and* two correctness bugs in `en` itself.

### 1. fr/nl were 29 keys behind en
`en.json` = 150 keys, `fr.json` / `nl.json` = 121 (same 29 missing in both). Backfilled all 29 in French and Dutch:
- **4 user-facing exception messages** — `not_connected`, `cf_no_address`, `forensic_range_incomplete`, `forensic_requires_module_address`
- **3 options-flow messages** — `module_not_found`, `channel_not_found`, `invalid_hex_address`
- **4 reconfigure field hints** — `data_description/*`
- **18 service strings** — the inventory services' names/descriptions/fields

### 2. `detect_stale_inventory` translation was stale (all languages)
It documented a **`timeout`** field that no longer exists — the schema (`services.yaml` + `__init__`) uses **`outer_attempts` / `outer_delay`** (the per-probe `timeout` kwarg was removed). Replaced the stale entry with the two real fields in en/fr/nl.

### 3. `send_button_press` had no translation block (all languages)
It's registered and in `services.yaml` but had **no** name/description/field labels anywhere — it rendered raw in Developer Tools → Actions. Added it in en/fr/nl.

## Verification

- en/fr/nl key sets now **identical (156 each)**, verified programmatically.
- **All four** `services.yaml` services have a complete translation block in all three languages.
- fr/nl backfill diff is additive; existing strings untouched. JSON re-emitted in the exact existing format (2-space, literal UTF-8; originals round-tripped byte-identical).
- Full suite **399 green**.

## One ask

French is solid. The **Dutch** forensic/register-bank service wording would benefit from a quick native pass.

No manifest bump — folds into the pending 3.8.2 release (#426).

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj