### PR TITLE
icons: add missing import-button icon + complete service icons

### DIFF
--- a/custom_components/nikobus/icons.json
+++ b/custom_components/nikobus/icons.json
@@ -6,6 +6,9 @@
             },
             "scan_all_module_links": {
                 "default": "mdi:cog-sync"
+            },
+            "import_nkb_names": {
+                "default": "mdi:file-import"
             }
         },
         "sensor": {
@@ -35,6 +38,15 @@
     "services": {
         "query_module_inventory": {
             "service": "mdi:magnify-scan"
+        },
+        "send_button_press": {
+            "service": "mdi:gesture-tap-button"
+        },
+        "detect_stale_inventory": {
+            "service": "mdi:radar"
+        },
+        "purge_stale_inventory": {
+            "service": "mdi:delete-sweep"
         }
     }
 }


### PR DESCRIPTION
## What

Metadata sweep — `icons.json`, `quality_scale.yaml`, `hacs.json`.

## icons.json — two gaps closed

- **`import_nkb_names` button** had no icon, while its two sibling bridge buttons (`discover_modules_buttons`, `scan_all_module_links`) do — it fell back to the generic button glyph. Added `mdi:file-import`.
- Only **1 of 4 services** (`query_module_inventory`) had a service icon. Completed the set: `send_button_press`, `detect_stale_inventory`, `purge_stale_inventory`.

Verified: every button/sensor `translation_key` and every `services.yaml` service now has an icon. The specific glyphs are suggestions — swap freely.

## quality_scale.yaml — reviewed, accurate, no change

Cross-checked the claims against the code. They hold up — and a couple are *now* genuinely true thanks to this review batch: `action-exceptions` / `exception-translations` (the platform error-translation work in #413/#415 + the i18n completion in #430). The `todo`s (`config-flow-test-coverage`, `test-coverage`, `strict-typing`) are honestly marked.

## hacs.json — fine, no change

## Testing

Additions-only diff (+12), `icons.json` valid, full suite **399 green** (incl. the `test_sensor` icon-mapping tests).

No manifest bump — bump at release.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_