### PR TITLE
cleanup(tests): drop dead DISCO_LIB + fix stale discovery comment

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,6 @@ from unittest.mock import AsyncMock
 
 ROOT = Path(__file__).parent.parent
 COMP = ROOT / "custom_components" / "nikobus"
-DISCO_LIB = ROOT / "nikobus-discovery"  # standalone PyPI library
 
 
 # ---------------------------------------------------------------------------
@@ -360,8 +359,9 @@ _niko.__path__ = [str(COMP)]
 _load("custom_components.nikobus.exceptions", COMP / "exceptions.py")
 _load("custom_components.nikobus.const", COMP / "const.py")
 
-# Discovery is now the standalone nikobus_discovery PyPI library.
-# It is installed via `pip install -e nikobus-discovery/` and imported directly.
+# Discovery lives in the standalone nikobus-connect PyPI package
+# (`pip install nikobus-connect`, imported as `nikobus_connect`); the
+# integration imports it directly, so there's nothing to load here.
 
 _load("custom_components.nikobus.nkbactuator", COMP / "nkbactuator.py")
 _load("custom_components.nikobus.nkbconfig", COMP / "nkbconfig.py")


### PR DESCRIPTION
## What

Review of the `tests/` suite, starting with the keystone `conftest.py`. It carried vestiges of an old layout where discovery was a local `nikobus-discovery` directory:

- `DISCO_LIB = ROOT / "nikobus-discovery"` was **defined but never used**, and no such directory exists.
- The module-load comment claimed discovery is "the `nikobus_discovery` PyPI library … `pip install -e nikobus-discovery/`". It's actually the **`nikobus-connect`** package (`pip install nikobus-connect`, imported as `nikobus_connect`) — what the code and CI actually use.

Both corrected. No test-behaviour change; suite **399 green**.

## Test-suite assessment (no further code change)

The suite is **substantial** — ~8,200 lines across 27 files, with deep coverage of the heavy logic: `test_coordinator` (2,073 lines), `test_manual_config` (1,294), `test_nkbnames`, `test_cover` (incl. the travel calculator), `test_actuator_burst` (the burst-release engine), reconnect, diagnostics, CF ingest/storage.

The **known limitation** is `conftest.py` itself: it's a hand-rolled ~300-line HA-framework stub rather than the official harness. That makes tests exercise pure logic with heavy mocking (and some `__new__`/private-attr reach-in) rather than real HA wiring. This is already tracked honestly in `quality_scale.yaml` — `test-coverage` and `config-flow-test-coverage` are marked **`todo`, pending a swap to `pytest-homeassistant-custom-component`**. That swap is the real improvement and a large, separate effort; the documented gaps (full config-flow step matrix, per-platform snapshot tests) sit behind it.

No manifest bump — bump at release.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_