### PR TITLE
test: close leaked event loops + timeout coroutines (zero warnings)

### DIFF
--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -15,7 +15,11 @@ from custom_components.nikobus.const import press_signal
 
 
 def _run(coro):
-    return asyncio.new_event_loop().run_until_complete(coro)
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 def _make():

--- a/tests/test_button_press_repeat.py
+++ b/tests/test_button_press_repeat.py
@@ -23,7 +23,11 @@ def _coord(press_repeat=DEFAULT_PRESS_REPEAT):
 
 
 def _run(coro):
-    return asyncio.new_event_loop().run_until_complete(coro)
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 class TestButtonPressRepeat(unittest.TestCase):

--- a/tests/test_cf_ingest.py
+++ b/tests/test_cf_ingest.py
@@ -17,7 +17,11 @@ from custom_components.nikobus.coordinator import NikobusDataCoordinator
 
 
 def _run(coro):
-    return asyncio.new_event_loop().run_until_complete(coro)
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 def _stub_cf_member(module_address, channel, mode, t1=None, t2=None):

--- a/tests/test_cf_storage.py
+++ b/tests/test_cf_storage.py
@@ -18,7 +18,11 @@ from custom_components.nikobus.nkbstorage import NikobusCFStorage
 
 
 def _run(coro):
-    return asyncio.new_event_loop().run_until_complete(coro)
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 class TestNikobusCFStorage(unittest.TestCase):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2034,7 +2034,11 @@ class TestRefreshModuleTypeDispatch(unittest.TestCase):
     coordinator's own post-poll global refresh covers the rest."""
 
     def _run(self, coro):
-        return asyncio.new_event_loop().run_until_complete(coro)
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
 
     def _setup(self, state_hex):
         c = _coord(states={})

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -29,7 +29,11 @@ _MONO = "custom_components.nikobus.nkbtravelcalculator.time.monotonic"
 
 
 def _run(coro):
-    return asyncio.new_event_loop().run_until_complete(coro)
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_inventory_parsing.py
+++ b/tests/test_inventory_parsing.py
@@ -1,3 +1,5 @@
+import asyncio
+import shutil
 import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
@@ -36,11 +38,23 @@ class TestInventoryParsing(unittest.IsolatedAsyncioTestCase):
 
         self.coordinator = FakeCoordinator()
         self._tmp_dir = tempfile.mkdtemp()
+
+        # Close any coroutine handed to create_task — the discovery's
+        # internal timeout watchdogs — so they aren't reported as
+        # "never awaited". We mock scheduling rather than run it.
+        def _fake_create_task(arg, *a, **kw):
+            if asyncio.iscoroutine(arg):
+                arg.close()
+            return MagicMock()
+
         self.discovery = NikobusDiscovery(
             self.coordinator,
             config_dir=self._tmp_dir,
-            create_task=MagicMock(return_value=MagicMock()),
+            create_task=_fake_create_task,
         )
+
+    async def asyncTearDown(self) -> None:
+        shutil.rmtree(self._tmp_dir, ignore_errors=True)
 
     async def test_parse_pclink_inventory_response_populates_modules_and_buttons(self):
         module_payload = _build_inventory_payload(0x01, b"\x12\x34")

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -22,7 +22,11 @@ from custom_components.nikobus.light import (
 
 
 def _run(coro):
-    return asyncio.new_event_loop().run_until_complete(coro)
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 def _coord():

--- a/tests/test_manual_config.py
+++ b/tests/test_manual_config.py
@@ -123,7 +123,11 @@ nkbmanual = _load(
 
 
 def _run(coro):
-    return asyncio.new_event_loop().run_until_complete(coro)
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 class TestApplyManualConfig(unittest.TestCase):

--- a/tests/test_nkb_upload.py
+++ b/tests/test_nkb_upload.py
@@ -24,7 +24,11 @@ def _flow(tmp_path):
 
 
 def _run(coro):
-    return asyncio.new_event_loop().run_until_complete(coro)
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 def _uploaded(src_path):

--- a/tests/test_nkbnames.py
+++ b/tests/test_nkbnames.py
@@ -249,7 +249,11 @@ def _entity(eid, device_id, name=None, original_name=None, unique_id=None):
 
 
 def _run(coro):
-    return asyncio.new_event_loop().run_until_complete(coro)
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 def _patches(data, devices, entities, dev_reg, ent_reg, area_reg):

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -19,7 +19,11 @@ from custom_components.nikobus.scene import (
 
 
 def _run(coro):
-    return asyncio.new_event_loop().run_until_complete(coro)
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 def _scene(**cfg):

--- a/tests/test_switch_dispatch.py
+++ b/tests/test_switch_dispatch.py
@@ -39,7 +39,11 @@ class _Dispatcher:
 
 
 def _run(coro):
-    return asyncio.new_event_loop().run_until_complete(coro)
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 def _make_switch(coord, hass, addr, channel):

--- a/tests/test_switch_entities.py
+++ b/tests/test_switch_entities.py
@@ -19,7 +19,11 @@ from custom_components.nikobus.switch import (
 
 
 def _run(coro):
-    return asyncio.new_event_loop().run_until_complete(coro)
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 def _coord():


### PR DESCRIPTION
## What

Reviewing the test suite (the per-file pass you asked for), the headline finding is hygiene the `-q` output was hiding: the suite reported **"3 warnings"**, but that's pytest deduplicating — `pytest -W default` reveals **60+ `ResourceWarning: unclosed event loop`** plus **3 `RuntimeWarning: coroutine never awaited`**.

## Fixes (test-only, no production code)

**1. Leaked event loops (13 files).** The `_run(coro)` helper did `asyncio.new_event_loop().run_until_complete(coro)` and never closed the loop — one leaked loop per call. Wrapped each in:
```python
loop = asyncio.new_event_loop()
try:
    return loop.run_until_complete(coro)
finally:
    loop.close()
```

**2. Unawaited timeout coroutines (`test_inventory_parsing.py`).** It builds a **real** `NikobusDiscovery` with `create_task=MagicMock(...)`, so the library's `_timeout_after` / `_inventory_timeout_after` watchdog coroutines were created and dropped unawaited. Switched to a fake `create_task` that closes any coroutine it's handed (the same pattern `test_cover.py` already uses), and added `asyncTearDown` to remove the per-test temp dir (a separate small leak).

## Result

```
399 passed in 21.5s      # was: 399 passed, 3 warnings  (hiding 60+)
```

Clean run, ruff clean, no production code touched.

No manifest bump — test-only.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_