### PR TITLE
test: strengthen 3 no-assertion smoke tests + fix misleading names

### DIFF
--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -173,9 +173,12 @@ class TestSetByteArrayState(unittest.TestCase):
         c.set_bytearray_state("C1C7", 1, 0xFF)
         self.assertEqual(c.nikobus_module_states["C1C7"][0], 0xFF)
 
-    def test_unknown_address_does_not_raise(self):
+    def test_unknown_address_autovivifies_buffer(self):
+        # A single-channel write to an unknown address allocates a fresh
+        # 12-byte buffer (optimistic write) — it is NOT a silent no-op.
         c = _coord()
-        c.set_bytearray_state("FFFF", 1, 0xFF)  # silent no-op
+        c.set_bytearray_state("FFFF", 1, 0xFF)
+        self.assertEqual(c.nikobus_module_states["FFFF"][0], 0xFF)
 
     def test_channel_0_does_not_write(self):
         c = _coord(states={"C1C7": bytearray([0x11])})
@@ -226,9 +229,12 @@ class TestSetByteArrayGroupState(unittest.TestCase):
         c.set_bytearray_group_state("C1C7", 1, "GGGGGGGGGGGG")
         self.assertEqual(bytes(c.nikobus_module_states["C1C7"]), original)
 
-    def test_unknown_address_does_not_raise(self):
+    def test_unknown_address_is_a_no_op(self):
+        # Unlike set_bytearray_state, the group write does NOT allocate a
+        # buffer for an unknown module — it leaves the store untouched.
         c = _coord()
         c.set_bytearray_group_state("UNKNOWN", 1, "AABBCCDDEEFF")
+        self.assertNotIn("UNKNOWN", c.nikobus_module_states)
 
 
 # ---------------------------------------------------------------------------
@@ -272,10 +278,17 @@ class TestFeedbackCallback(unittest.IsolatedAsyncioTestCase):
         await c._feedback_callback(1, "$1CC7C1")  # too short
         self.assertEqual(c.nikobus_module_states["C1C7"], bytearray(12))
 
-    async def test_unknown_module_ignored(self):
+    async def test_unknown_module_auto_allocated(self):
+        # Feedback is authoritative: a frame from a not-yet-known module
+        # auto-allocates its buffer and records the state (the callback's
+        # "Auto-allocate if module wasn't pre-registered" path) — it is
+        # not ignored.
         c = _coord(states={})
         frame = _feedback_frame("C7C1", "AABBCCDDEEFF")
-        await c._feedback_callback(1, frame)  # should not raise
+        await c._feedback_callback(1, frame)
+        self.assertEqual(
+            c.nikobus_module_states["C1C7"][:6], bytearray.fromhex("AABBCCDDEEFF")
+        )
 
     async def test_resolve_pending_get_called_when_command_set(self):
         c = _coord(states={"C1C7": bytearray(12)})


### PR DESCRIPTION
## What

Continuing the test-suite review: the suite had **three `test` methods with no assertion** — they only verified a call didn't raise. Adding the obvious behavioural assertion **exposed that their names/comments described the opposite of what the code does**:

| Test | Claimed | Actual behaviour | Fix |
|---|---|---|---|
| `set_bytearray_state("FFFF", …)` | `# silent no-op` | **auto-allocates** a 12-byte buffer (optimistic write) | renamed `…_autovivifies_buffer`; assert the byte |
| `set_bytearray_group_state("UNKNOWN", …)` | `…_does_not_raise` | genuinely a **no-op** (no buffer) | renamed `…_is_a_no_op`; assert store untouched |
| `_feedback_callback` unknown module | `…_ignored` | **auto-allocates + records** state | renamed `…_auto_allocated`; assert recorded bytes |

All three behaviours are **intentional** — the feedback path even carries an explicit `# Auto-allocate if module wasn't pre-registered` comment — so the tests now *document* them instead of masking them with no-op smoke checks. No production code changed.

## For your judgement (flagged, not changed)

`set_bytearray_state` auto-allocates a buffer for an unknown address, but `set_bytearray_group_state` does **not** — the two write paths handle unknown addresses asymmetrically. Both are defensible (single-channel optimistic write vs group write requiring a known module), so I left it as-is, but flagging in case the asymmetry is unintended.

## Testing

Full suite green, ruff clean, and **zero assertion-less tests remain** in the suite (verified by AST scan).

> Note: the "3 warnings" on this branch are the event-loop leaks fixed separately in #433 (this branch predates it); they're unrelated to this change.

No manifest bump — test-only.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_