### PR TITLE
docs(changelog): refresh 3.8.2 entry to cover #427–#434

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,28 @@
 
 ## 3.8.2
 
-Robustness & cleanup pass — one user-facing fix, otherwise internal.
+Robustness, i18n & cleanup pass — a few user-facing fixes, otherwise internal.
 
 - **Friendlier errors when a command can't reach the bus.** Turning a
   switch / light / cover on or off — or activating a scene — now surfaces a
   clean, translated "communication failed" message when the bus is
   unreachable, instead of the raw library exception. The optimistic UI
   state still rolls back on failure.
+- **Complete French & Dutch translations.** Filled in 29 strings that were
+  English-only (error messages, the reconfigure form, and the diagnostic
+  service descriptions), corrected a stale service field, and added the
+  missing translations for the *Send button press* action.
+- **Icons for the last bridge button and the services.** The *Import Names
+  from .nkb* button and the three inventory services now show their own
+  icons instead of the generic fallback glyph.
 - **Lighter button handling.** A latch-switch toggle or a simulated button
   press no longer wakes *every* entity on the bus to filter itself out;
   only the affected addresses are notified.
-- **Internal tidy — no behaviour or configuration changes.** Removed a
-  couple of unreachable code paths, de-duplicated the storage wrappers and
-  the command-error helper, modernised imports / typing across the
-  platforms and helpers, and refreshed stale in-code / README references.
+- **Internal tidy — no behaviour or configuration changes.** Removed a few
+  unreachable code paths, de-duplicated the storage wrappers and the
+  command-error helper, modernised imports / typing across the platforms
+  and helpers, refreshed stale in-code / README references, and tidied the
+  test suite (closed leaked event loops, strengthened a few weak tests).
   The full test suite stays green.
 
 ## 3.8.1


### PR DESCRIPTION
## What

Double-checking what's landed: #426 cut the `3.8.2` CHANGELOG, but **#427–#434 merged after it** (and 3.8.2 isn't tagged yet), so the entry was out of date. Refreshed it to reflect everything in the release.

**Added to the entry (user-facing):**
- Complete **French & Dutch translations** — 29 backfilled strings + the two service-translation fixes (#430)
- **Icons** for the *Import Names from .nkb* button and the three inventory services (#431)

**Folded into the internal line:**
- test-suite tidy — closed leaked event loops, strengthened weak tests (#432–#434)

Docs only; version stays `3.8.2`.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_