### PR TITLE
fix(coordinator): cancel actuator tasks on stop (concurrency audit)

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -1367,6 +1367,13 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                     await task
             setattr(self, task_attr, None)
 
+        # Cancel the actuator's in-flight press / refresh tasks too, so a
+        # button press being processed during unload can't touch the
+        # command handler / connection after we stop them below.
+        actuator = getattr(self, "nikobus_actuator", None)
+        if actuator:
+            actuator.stop()
+
         # 2. Then stop subsystems in reverse start order.
         if self.nikobus_listener:
             try:

--- a/custom_components/nikobus/nkbactuator.py
+++ b/custom_components/nikobus/nkbactuator.py
@@ -89,6 +89,23 @@ class NikobusActuator:
         self._press_states: dict[str, PressState] = {}
         self._module_refresh_tasks: dict[str, asyncio.Task[None]] = {}
 
+    def stop(self) -> None:
+        """Cancel all in-flight press-release and module-refresh tasks.
+
+        Called from ``NikobusDataCoordinator.stop()`` so a config-entry
+        unload/reload doesn't leave a button-press handler running against
+        a torn-down command handler / connection. Tasks self-terminate in
+        a few seconds anyway, but cancelling makes teardown deterministic.
+        """
+        for state in self._press_states.values():
+            if state.release_task and not state.release_task.done():
+                state.release_task.cancel()
+        self._press_states.clear()
+        for task in self._module_refresh_tasks.values():
+            if not task.done():
+                task.cancel()
+        self._module_refresh_tasks.clear()
+
     async def handle_button_press(self, address: str) -> None:
         """Handle incoming button frames with frame-count duration tracking.
 

--- a/tests/test_actuator_burst.py
+++ b/tests/test_actuator_burst.py
@@ -84,6 +84,28 @@ def _events_of(actuator: NikobusActuator, event_type: str) -> list[dict]:
     ]
 
 
+def test_stop_cancels_inflight_tasks():
+    """stop() cancels in-flight release + refresh tasks and clears the maps."""
+    actuator = _make_actuator()
+
+    release = MagicMock()
+    release.done.return_value = False
+    actuator._press_states["AA0000"] = PressState(
+        address="AA0000", press_start=0.0, last_press_time=0.0,
+        press_id="x", module_address=None, channel=None, release_task=release,
+    )
+    refresh = MagicMock()
+    refresh.done.return_value = False
+    actuator._module_refresh_tasks["BB00_1"] = refresh
+
+    actuator.stop()
+
+    release.cancel.assert_called_once()
+    refresh.cancel.assert_called_once()
+    assert actuator._press_states == {}
+    assert actuator._module_refresh_tasks == {}
+
+
 # ---------------------------------------------------------------------------
 # Frame-count duration
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Concurrency / async-lifecycle audit (end-to-end task review). `coordinator.stop()` cancels `_reconnect_task` and `_reload_task`, and its docstring promises it cancels background tasks "so no in-flight handler can touch the listener." But it had a gap: the **actuator's** in-flight tasks were never cancelled.

### Fixed: actuator task cancellation on stop

A button press being processed during a config-entry unload/reload — its release-watchdog task plus the per-module refresh tasks — kept running against the command handler / connection while `stop()` tore them down (surfacing as caught-but-noisy errors).

- **`NikobusActuator.stop()`** — cancel every `PressState.release_task` and every `_module_refresh_tasks` entry, then clear both maps.
- **`coordinator.stop()`** — call it, defensively via `getattr` (matching the existing `_reconnect_task`/`_reload_task` handling; the reconnect tests build a partial coordinator without `__init__`).
- **Test** — `actuator.stop()` cancels in-flight release + refresh tasks and clears the maps.

## Flagged, deliberately NOT fixed here

The **discovery** background tasks (`start_pc_link_inventory` / `start_module_scan`, launched fire-and-forget via `async_create_background_task` from `button.py`) are **also untracked and not cancelled on `stop()`**, and don't check `_stopping`. So a reload during an active 30-60s discovery runs it against a torn-down stack.

I left this alone because cancelling a mid-flight scan can leave the **vendored `NikobusDiscovery`'s internal state** (and its own timeout tasks) inconsistent — the safe fix is a cooperative `_stopping` check *inside* the discovery flow, best done alongside a library-side review rather than an external `.cancel()`.

### Audit — otherwise clean
Entity-owned tasks (cover motion/coalesce/error-recovery, scene roller-stops, binary-sensor reset timer) are all correctly cancelled via `async_on_remove`. Reconnect respects `_stopping`. The per-module refresh debouncer's `finally` ownership guard correctly avoids the cancel/replace race.

## Testing

Full suite **400 passing** (+1), ruff clean.

No manifest bump — bump at release.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_