### PR TITLE
security(nkbnames): harden .nkb extraction (path-traversal + zip bomb)

### DIFF
--- a/custom_components/nikobus/nkbnames.py
+++ b/custom_components/nikobus/nkbnames.py
@@ -31,6 +31,11 @@ _LOGGER = logging.getLogger(__name__)
 
 CANONICAL_NKB_FILENAME = "nikobus.nkb"
 
+# Hard ceiling on the decompressed ``.mdb`` we'll read from a ``.nkb``.
+# A real Nikobus project DB is a few MB; this only exists to bound a
+# crafted (decompression-bomb) archive. Generous on purpose.
+_MAX_MDB_BYTES = 64 * 1024 * 1024  # 64 MiB
+
 # Location bucket the software uses for virtual groups (scenes), not a room.
 _GROUP_LOCATION_SENTINEL = "S_DB_GROUPS"
 
@@ -128,8 +133,25 @@ def parse_nkb(nkb_path: str | Path) -> NkbData:
             )
             if mdb_name is None:
                 raise ValueError("no .mdb inside the .nkb archive")
-            zf.extract(mdb_name, tmp)
-        db = AccessParser(str(Path(tmp) / mdb_name))
+            # Read the .mdb through a hard byte cap and write it under a
+            # FIXED local name. Two reasons, both defending against a
+            # crafted .nkb:
+            #   * the byte cap stops a decompression-bomb member from
+            #     exhausting memory/disk (``read`` decompresses lazily, so
+            #     a 10 GB member only ever yields ``_MAX_MDB_BYTES`` here);
+            #   * the fixed output name means an attacker-controlled member
+            #     path (``/etc/x.mdb``, ``../../x.mdb``) can't redirect the
+            #     AccessParser read outside ``tmp`` — unlike ``Path(tmp) /
+            #     mdb_name``, which an absolute or ``..`` name escapes.
+            with zf.open(mdb_name) as member:
+                data = member.read(_MAX_MDB_BYTES + 1)
+            if len(data) > _MAX_MDB_BYTES:
+                raise ValueError(
+                    f".mdb exceeds the {_MAX_MDB_BYTES}-byte safety limit"
+                )
+            mdb_path = Path(tmp) / "project.mdb"
+            mdb_path.write_bytes(data)
+        db = AccessParser(str(mdb_path))
         components = _rows(db, "Component")
         locations = {
             r["KeyLocation"]: r["StrUserName"] for r in _rows(db, "Location")

--- a/tests/test_nkb_upload.py
+++ b/tests/test_nkb_upload.py
@@ -74,3 +74,52 @@ def test_save_uploaded_nkb_invalid_rejected_and_not_saved(tmp_path):
     assert ei.value.key == "invalid_nkb"
     # the canonical file must NOT be written when validation fails
     assert not (tmp_path / "nikobus.nkb").exists()
+
+
+# ---------------------------------------------------------------------------
+# parse_nkb extraction hardening (crafted-.nkb defences)
+# ---------------------------------------------------------------------------
+
+def test_parse_nkb_rejects_oversized_mdb(tmp_path, monkeypatch):
+    """A decompression-bomb .mdb is rejected by the byte cap, not extracted."""
+    import zipfile
+    from custom_components.nikobus import nkbnames
+
+    monkeypatch.setattr(nkbnames, "_MAX_MDB_BYTES", 16)
+    bomb = tmp_path / "bomb.nkb"
+    with zipfile.ZipFile(bomb, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("__niko__.mdb", b"A" * 64)  # 64 decompressed > 16 cap
+
+    with pytest.raises(ValueError, match="safety limit"):
+        nkbnames.parse_nkb(str(bomb))
+
+
+def test_parse_nkb_traversal_member_name_stays_in_tmp(tmp_path):
+    """An absolute / `..` .mdb member name cannot redirect the parser read
+    outside the temp dir — it's written under a fixed local name."""
+    import zipfile
+    from custom_components.nikobus import nkbnames
+
+    evil = tmp_path / "evil.nkb"
+    with zipfile.ZipFile(evil, "w") as zf:
+        zf.writestr("../../../../etc/passwd.mdb", b"not-a-real-mdb")
+
+    captured = {}
+
+    class _Sentinel(Exception):
+        pass
+
+    def _fake_parser(path):
+        captured["path"] = path
+        raise _Sentinel()
+
+    with patch(
+        "custom_components.nikobus.vendor.access_parser.AccessParser", _fake_parser
+    ):
+        with pytest.raises(_Sentinel):
+            nkbnames.parse_nkb(str(evil))
+
+    p = captured["path"]
+    assert p.endswith("project.mdb")
+    assert "etc/passwd" not in p
+    assert ".." not in p


### PR DESCRIPTION
## What

Security review of the **untrusted `.nkb` import path**. `parse_nkb` extracted the `.mdb` from the uploaded ZIP and then read it via `Path(tmp) / mdb_name`, where `mdb_name` comes straight from the archive's member list — two issues:

### 1. Path traversal → arbitrary file read
`Path(tmp) / mdb_name` doesn't sanitize the member name (which `ZipFile.extract` *does*):
- `/etc/x.mdb` → `Path(tmp) / "/etc/x.mdb"` = `/etc/x.mdb` (absolute **discards tmp**)
- `../../x.mdb` → walks out of tmp

So `AccessParser` could be pointed at a `.mdb`-parseable file **outside the temp dir**.

### 2. Decompression bomb
`zf.extract` fully decompresses the member with **no size limit** — a tiny crafted `.nkb` could exhaust memory/disk.

## Fix (one change, both defences)

Read the member through a **hard byte cap** (`_MAX_MDB_BYTES` = 64 MiB; `read()` decompresses lazily, so a giant member only ever yields the cap), and write it under a **fixed local name** (`project.mdb`) — so the attacker-controlled member path never touches the filesystem path handed to `AccessParser`.

## Scope / threat model

Bounded — the `.nkb` is **user-supplied to their own HA** (upload or `/config`), so severity is **low** (no remote/unauth vector). But the fixes are cheap and correct. Also reviewed and found **safe**:
- **Upload side** (`_save_uploaded_nkb`) — fixed destination (`nikobus.nkb`), HA-validated upload temp, dest not written on parse failure.
- **Data flow** — parsed `.mdb` values become device/entity names + Areas, applied as **plain strings** (no injection; HA slugifies entity_ids).
- `find_nkb_file` — globs the trusted config dir only.
- Vendored `access_parser` internals are third-party (out of scope), but the byte cap now bounds its memory exposure too.

## Testing

Two new tests: oversized-member rejection (byte cap), and a `../../../../etc/passwd.mdb` member name that must resolve to the in-tmp `project.mdb` (verified `AccessParser` receives the safe path, never the escaped one). Suite **402 passing**, ruff clean.

No manifest bump — bump at release.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_