### PR TITLE
build(mypy): exclude vendored access_parser + honest strict-typing note

### DIFF
--- a/custom_components/nikobus/quality_scale.yaml
+++ b/custom_components/nikobus/quality_scale.yaml
@@ -88,11 +88,17 @@ rules:
     status: todo
     comment: |
       py.typed marker is in place and mypy.ini declares strict mode for
-      custom_components.nikobus.*. Code-side: PEP 585/604 forms used
-      throughout, asyncio.Task[None] generics declared, broad except
-      blocks re-raise CancelledError, ad-hoc Any removed in favour of
-      typed Event / NikobusDataCoordinator / CALLBACK_TYPE. The
-      remaining mypy diagnostics involve homeassistant.* generics that
-      mypy can only resolve when an installed HA package provides the
-      stubs; those will be cleared when the integration enters HA
-      core's strict-typing CI.
+      custom_components.nikobus.* (the vendored access_parser is excluded,
+      same as in ruff). Code-side: PEP 585/604 forms used throughout,
+      asyncio.Task[None] generics declared, broad except blocks re-raise
+      CancelledError, ad-hoc Any removed in favour of typed Event /
+      NikobusDataCoordinator / CALLBACK_TYPE.
+
+      `mypy --strict` over our code reports ~151 diagnostics. The majority
+      (~100: subclassing Any HA base classes, the untyped @callback
+      decorator, Any returns/attribute access from HA types) can only be
+      resolved with an installed HA package and clear in HA core's
+      strict-typing CI. The rest (~50: a handful of bare-generic
+      annotations — dict/set/list/frozenset/tuple without parameters —
+      and Mapping-vs-dict argument widening on the entity constructors)
+      are resolvable here and tracked as a follow-up typing pass.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,9 @@
 [mypy]
 python_version = 3.13
 strict = True
+# Vendored third-party Access reader (access_parser) — maintained
+# upstream, not type-checked here (ruff excludes it for the same reason).
+exclude = custom_components/nikobus/vendor/
 ignore_missing_imports = True
 follow_imports = silent
 warn_unused_ignores = True


### PR DESCRIPTION
## What

Ran `mypy --strict` (the Gold `strict-typing` todo) to turn it into a concrete number — and found the gap was **inflated by noise**.

### The finding

`mypy --strict` reported **450 diagnostics** — but **299 of them were in the vendored third-party `access_parser`** (including all 207 `name-defined`, from `construct`'s DSL). **ruff already excludes `vendor/`; mypy didn't.**

| | Before | After |
|---|---|---|
| mypy errors | 450 (20 files) | **151** (17 files) |
| of which vendor | 299 | 0 |

### Changes

- **`mypy.ini`** — exclude `custom_components/nikobus/vendor/` (path-regex `exclude`; the per-module `ignore_errors` form doesn't apply when the dir is passed on the CLI). Now matches ruff's scope.
- **`quality_scale.yaml`** — replaced the vague strict-typing note with the real breakdown.

### The honest gap (our 151)

- **~100 need an installed HA package** — subclassing `Any` base classes (`SensorEntity`/`LightEntity`/…), the untyped `@callback` decorator, `Any` returns/attribute access from HA types. These clear in HA core's strict-typing CI (the original note's claim — accurate for *these*).
- **~50 are resolvable here now** — a handful of bare-generic annotations (`dict`/`set`/`list`/`frozenset`/`tuple` without params) and `Mapping`-vs-`dict` widening on the entity constructors. Tracked as a follow-up typing pass.

So the todo is **closer than the old note implied**, once vendor noise is removed.

## Testing

No code/behaviour change (config + docs). Suite green, ruff clean.

No manifest bump.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_