### PR TITLE
types: resolve the ~50 locally-fixable strict-typing diagnostics

### DIFF
--- a/custom_components/nikobus/__init__.py
+++ b/custom_components/nikobus/__init__.py
@@ -250,7 +250,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             outer_attempts,
             outer_delay,
         )
-        manifest: dict = await coordinator.nikobus_discovery.detect_stale_inventory(
+        manifest: dict[str, Any] = await coordinator.nikobus_discovery.detect_stale_inventory(
             outer_attempts=outer_attempts,
             outer_delay=outer_delay,
         )

--- a/custom_components/nikobus/binary_sensor.py
+++ b/custom_components/nikobus/binary_sensor.py
@@ -140,7 +140,7 @@ class NikobusButtonBinarySensor(NikobusEntity, BinarySensorEntity):
         self.async_on_remove(_cancel_reset_timer)
 
     @callback
-    def _handle_button_event(self, data: dict) -> None:
+    def _handle_button_event(self, data: dict[str, Any]) -> None:
         """This button was pressed (routed by address) — pulse to 'pressed'."""
         _LOGGER.debug("Button %s pressed", self._address)
 

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
 from typing import Any
 
 from homeassistant.components.button import ButtonEntity
@@ -72,7 +73,7 @@ async def async_setup_entry(
 def _iter_button_entities(
     coordinator: NikobusDataCoordinator,
     buttons: dict[str, Any],
-):
+) -> Iterator[NikobusButtonEntity]:
     """Yield one NikobusButtonEntity per discovered operation point."""
     for physical_addr, key_label, op_point, phys in iter_operation_points(buttons):
         yield NikobusButtonEntity(
@@ -297,7 +298,7 @@ def _ensure_pc_logic_parent_device(
 
 def _iter_module_records(
     dict_module_data: dict[str, Any], module_types: frozenset[str]
-):
+) -> Iterator[tuple[str, str, dict[str, Any]]]:
     """Yield ``(module_type, address, module_data)`` for the requested buckets."""
     for module_type in module_types:
         bucket = dict_module_data.get(module_type)

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -105,7 +105,7 @@ _PROBE_OUTER_DELAY_S = 3.0
 _REGISTRY_SOURCES = frozenset({"pc_link_registry", "pc_logic_registry"})
 
 
-def _member_set_from_outputs(outputs) -> frozenset:
+def _member_set_from_outputs(outputs: Any) -> frozenset[tuple[str, int, str]]:
     """Frozenset of ``(module_upper, channel, mode_code)`` for an output
     list — the canonical key for matching a scene/CF by its members,
     used identically on ``.nkb`` groups, CF entries and routing-graph
@@ -124,12 +124,12 @@ def _member_set_from_outputs(outputs) -> frozenset:
     return frozenset(out)
 
 
-def _cf_member_set(cf: dict) -> frozenset:
+def _cf_member_set(cf: dict[str, Any]) -> frozenset[tuple[str, int, str]]:
     """Member-set key for a stored ``nikobus_cf`` entry."""
     return _member_set_from_outputs((cf or {}).get("outputs"))
 
 
-def _output_entity_key(unique_id) -> tuple[str, int] | None:
+def _output_entity_key(unique_id: str | None) -> tuple[str, int] | None:
     """``(MODULE_ADDR_UPPER, channel)`` for a per-channel output entity's
     unique_id (``nikobus_{light|switch|cover}_{kind}_{addr}_{ch}``), else
     ``None`` — used to match ``.nkb`` output names to entities."""
@@ -146,7 +146,7 @@ def _output_entity_key(unique_id) -> tuple[str, int] | None:
     return (addr.upper(), int(ch))
 
 
-def _apply_entity_name(ent_reg, ent, name: str, overwrite: bool) -> bool:
+def _apply_entity_name(ent_reg: Any, ent: Any, name: str, overwrite: bool) -> bool:
     """Set an entity's name; return True if changed. Non-overwrite only
     fills a blank (no user name set); overwrite replaces any user name."""
     if overwrite:
@@ -868,8 +868,13 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         if self.nikobus_command:
             self.nikobus_command.set_bytearray_state(address, channel, value)
 
-    def set_bytearray_group_state(self, address: str, group: int, value: str) -> None:
+    def set_bytearray_group_state(
+        self, address: str, group: int | str, value: str
+    ) -> None:
         """Update a group in the state buffer from a hex string.
+
+        ``group`` accepts an int (1/2) or the string forms ("1"/"2") the
+        actuator routes by; it is normalised with ``int(group)`` below.
 
         Out-of-range group writes are silently ignored. Without this
         guard, a slice assignment like ``buf[6:12] = ...`` against a
@@ -1731,7 +1736,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
 
     async def _reconcile_post_discovery(
         self,
-        discovered_devices: dict | None = None,
+        discovered_devices: dict[str, Any] | None = None,
         inventory_query_type: InventoryQueryType | None = None,
     ) -> None:
         """Probe every output module + tag buttons by reachability.
@@ -1946,7 +1951,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
     async def _handle_discovery_finished(
         self,
         *,
-        discovered_devices: dict | None = None,
+        discovered_devices: dict[str, Any] | None = None,
         inventory_query_type: InventoryQueryType | None = None,
     ) -> None:
         """Signal discovery completion; optionally reload the config entry.
@@ -2476,7 +2481,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         scenes_created = 0
         if "scenes" in cats and self.cf_storage is not None:
             scene_by_members = {sc.members: sc.name for sc in data.scenes}
-            matched_scene_members: set = set()
+            matched_scene_members: set[frozenset[tuple[str, int, str]]] = set()
             for cf_addr, cf in self.cf_storage.data.get("nikobus_cf", {}).items():
                 hit = scene_by_members.get(_cf_member_set(cf))
                 if hit:
@@ -2484,7 +2489,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                     matched_scene_members.add(_cf_member_set(cf))
             graph = self._build_routing_graph()
             existing = self.cf_storage.data.setdefault("nikobus_cf", {})
-            new_entries: dict[str, dict] = {}
+            new_entries: dict[str, dict[str, Any]] = {}
             for sc in data.scenes:
                 if sc.members in matched_scene_members or not sc.members:
                     continue
@@ -2514,7 +2519,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         area_reg = ar.async_get(self.hass)
         entry_id = self.config_entry.entry_id
 
-        def _lookup(device) -> tuple[str, str] | None:
+        def _lookup(device: Any) -> tuple[str, str] | None:
             for domain, ident in device.identifiers:
                 if domain != DOMAIN:
                     continue
@@ -2562,7 +2567,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         # name, and their channels are named individually below.
         entities_named = 0
         if do_names:
-            by_device: dict[str, list] = {}
+            by_device: dict[str, list[Any]] = {}
             for ent in entities:
                 if ent.device_id:
                     by_device.setdefault(ent.device_id, []).append(ent)
@@ -2613,7 +2618,9 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             "scenes_created": scenes_created,
         }
 
-    def _build_routing_graph(self) -> dict:
+    def _build_routing_graph(
+        self,
+    ) -> dict[frozenset[tuple[str, int, str]], tuple[list[str], list[dict[str, Any]]]]:
         """Map every op-point's member set → ``(firing addresses, outputs)``.
 
         The routing graph is the full set of ``trigger → linked outputs``
@@ -2625,7 +2632,9 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         (one scene, several triggers) are grouped; the sorted-first is the
         canonical activation address.
         """
-        graph: dict[frozenset, tuple[list[str], list[dict]]] = {}
+        graph: dict[
+            frozenset[tuple[str, int, str]], tuple[list[str], list[dict[str, Any]]]
+        ] = {}
         buttons = (self.dict_button_data or {}).get("nikobus_button", {})
         if not isinstance(buttons, dict):
             return {}
@@ -2638,8 +2647,8 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 addr = op.get("bus_address")
                 if not isinstance(addr, str) or not addr:
                     continue
-                outputs: list[dict] = []
-                seen: set = set()
+                outputs: list[dict[str, Any]] = []
+                seen: set[tuple[str, int, str]] = set()
                 for link in op.get("linked_modules") or []:
                     if not isinstance(link, dict):
                         continue

--- a/custom_components/nikobus/cover.py
+++ b/custom_components/nikobus/cover.py
@@ -282,7 +282,7 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
 
         super()._handle_coordinator_update()
 
-    async def _handle_button_pressed(self, data: dict) -> None:
+    async def _handle_button_pressed(self, data: dict[str, Any]) -> None:
         """Handle a physical Nikobus button press event (routed by module).
 
         Records the press timestamp (for detection-latency calculation) only

--- a/custom_components/nikobus/entity.py
+++ b/custom_components/nikobus/entity.py
@@ -81,7 +81,7 @@ class NikobusEntity(CoordinatorEntity[NikobusDataCoordinator]):
         self._attr_device_info = device_info
 
         #: Last ``(available, render_state)`` actually written, for diffing.
-        self._last_render: tuple | None = None
+        self._last_render: tuple[bool, Any] | None = None
 
     def _invalidate_optimistic(self) -> None:
         """Drop optimistic caches before the real state is read (override)."""

--- a/custom_components/nikobus/nkbactuator.py
+++ b/custom_components/nikobus/nkbactuator.py
@@ -340,7 +340,12 @@ class NikobusActuator:
             # ==========================================
             # 3. Delayed State Fetch Task (UI Update Only)
             # ==========================================
-            async def _refresh_task(m_addr=addr, m_group=group, m_press_id=press_id, m_requires_long_press=requires_long_press):
+            async def _refresh_task(
+                m_addr: str = addr,
+                m_group: str = group,
+                m_press_id: str = press_id,
+                m_requires_long_press: bool = requires_long_press,
+            ) -> None:
                 try:
                     # STEP 1: Immediate UI Update (Skip for dimmers)
                     if not m_requires_long_press:
@@ -393,9 +398,9 @@ class NikobusActuator:
             # Schedule the newly requested refresh
             self._module_refresh_tasks[cache_key] = self._hass.async_create_task(_refresh_task())
 
-    def _fire_event(self, event_type: str, state: PressState, **kwargs) -> None:
+    def _fire_event(self, event_type: str, state: PressState, **kwargs: Any) -> None:
         """Helper to fire standardized Nikobus events and log them."""
-        payload = {
+        payload: dict[str, Any] = {
             "address": state.address,
             "module_address": state.module_address,
             "channel": state.channel,

--- a/custom_components/nikobus/nkbnames.py
+++ b/custom_components/nikobus/nkbnames.py
@@ -25,9 +25,12 @@ import re
 import tempfile
 import zipfile
 from pathlib import Path
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 _LOGGER = logging.getLogger(__name__)
+
+#: One parsed ``.mdb`` row: column name → value.
+_Row = dict[str, Any]
 
 CANONICAL_NKB_FILENAME = "nikobus.nkb"
 
@@ -174,7 +177,7 @@ def parse_nkb(nkb_path: str | Path) -> NkbData:
 
 
 def _extract_outputs(
-    comp_by_key: dict, objecten: list[dict], objectbase: dict
+    comp_by_key: dict[Any, _Row], objecten: list[_Row], objectbase: dict[Any, _Row]
 ) -> dict[tuple[str, int], str]:
     """``{(MODULE_ADDR, channel): name}`` for output channels with a real
     user name. Channel is the output's ``Prefix`` number (``O02`` → 2);
@@ -197,7 +200,7 @@ def _extract_outputs(
 
 
 def _extract_addresses(
-    components: list[dict], locations: dict
+    components: list[_Row], locations: dict[Any, Any]
 ) -> dict[str, tuple[str, str]]:
     """``{ADDRESS: (name, room)}`` for the physically-addressed components."""
     out: dict[str, tuple[str, str]] = {}
@@ -216,12 +219,12 @@ def _extract_addresses(
 
 
 def _extract_scenes(
-    components: list[dict],
-    comp_by_key: dict,
-    objecten: list[dict],
-    connections: list[dict],
-    linkmodes: dict,
-    objectbase: dict,
+    components: list[_Row],
+    comp_by_key: dict[Any, _Row],
+    objecten: list[_Row],
+    connections: list[_Row],
+    linkmodes: dict[Any, Any],
+    objectbase: dict[Any, _Row],
 ) -> list[SceneDef]:
     """Resolve each named CF group to its ``(module, channel, mode)`` members.
 
@@ -230,19 +233,19 @@ def _extract_scenes(
     carries only the trigger link; the membership lives on the trigger.
     """
     obj_by_key = {o["KeyObject"]: o for o in objecten}
-    objs_by_component: dict[object, set] = {}
+    objs_by_component: dict[Any, set[Any]] = {}
     for o in objecten:
         objs_by_component.setdefault(o.get("KeyComponent"), set()).add(o["KeyObject"])
-    conns_by_in: dict[object, list] = {}
+    conns_by_in: dict[Any, list[_Row]] = {}
     for cn in connections:
         conns_by_in.setdefault(cn["KeyObjectIn"], []).append(cn)
 
-    def module_addr(obj) -> str | None:
+    def module_addr(obj: _Row | None) -> str | None:
         comp = comp_by_key.get((obj or {}).get("KeyComponent"), {})
         pa = comp.get("PhysicalAddress")
         return _fmt_addr(pa) if isinstance(pa, int) and pa > 0 else None
 
-    def channel(obj) -> int | None:
+    def channel(obj: _Row | None) -> int | None:
         # Channel = the output's ``Prefix`` number (``O01`` -> 1), which
         # matches Home Assistant's per-channel numbering for EVERY module
         # type. (``ObjectAddress`` can't be used: roller outputs occupy
@@ -287,7 +290,7 @@ def _extract_scenes(
     return scenes
 
 
-def _rows(db, table: str) -> list[dict]:
+def _rows(db: Any, table: str) -> list[_Row]:
     """Row-dicts for ``table`` (access_parser returns column->list)."""
     parsed = db.parse_table(table)
     cols = list(parsed.keys())

--- a/custom_components/nikobus/repairs.py
+++ b/custom_components/nikobus/repairs.py
@@ -161,7 +161,7 @@ class LegacyUndecodedButtonsRepairFlow(RepairsFlow):
             phys = buttons.get(addr) or {}
             btype = phys.get("type") or "Unknown"
             model = phys.get("model") or "—"
-            reason = cls._REASON_LABELS.get(phys.get("status"), "—")
+            reason = cls._REASON_LABELS.get(phys.get("status") or "", "—")
             description = phys.get("description") or ""
             # Strip the auto-suffix and any pipe chars that would break
             # the table layout.

--- a/custom_components/nikobus/router.py
+++ b/custom_components/nikobus/router.py
@@ -145,7 +145,7 @@ def iter_input_module_children(
 
 def iter_operation_points(
     buttons: Mapping[str, Any] | None,
-) -> Iterator[tuple[str, str, Mapping[str, Any], Mapping[str, Any]]]:
+) -> Iterator[tuple[str, str, dict[str, Any], dict[str, Any]]]:
     """Yield ``(physical_addr, key_label, op_point, phys)`` for every
     button operation point carrying a ``bus_address``.
 

--- a/custom_components/nikobus/scene.py
+++ b/custom_components/nikobus/scene.py
@@ -212,7 +212,7 @@ class NikobusCFSceneEntity(NikobusEntity, Scene):
             )
 
     @callback
-    def _handle_trigger(self, data: dict) -> None:
+    def _handle_trigger(self, data: dict[str, Any]) -> None:
         """Fire ``nikobus_scene_activated`` when one of this scene's trigger
         addresses is seen on the bus — physical press or HA-originated frame
         alike. Routed by address, so any delivery here is a match."""

--- a/custom_components/nikobus/switch.py
+++ b/custom_components/nikobus/switch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Mapping
 from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
@@ -38,7 +39,7 @@ _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 0
 
 
-def input_ab_addresses(phys: dict[str, Any]) -> tuple[str, str] | None:
+def input_ab_addresses(phys: Mapping[str, Any]) -> tuple[str, str] | None:
     """Return ``(addr_1A, addr_1B)`` bus addresses for a synthesized
     PC-Logic / Modular-Interface input, or ``None``.
 
@@ -354,7 +355,7 @@ class NikobusInputLatchSwitch(NikobusEntity, SwitchEntity, RestoreEntity):
             )
 
     @callback
-    def _handle_button_event(self, data: dict) -> None:
+    def _handle_button_event(self, data: dict[str, Any]) -> None:
         """Latch on the 1A signal, clear on the 1B signal."""
         addr = str(data.get("address") or "").upper()
         if addr == self._addr_1a:


### PR DESCRIPTION
## What

Follow-up to the mypy-strict review (#439): knock out the **~50 locally-fixable** strict-typing diagnostics — the ones that **don't** need an installed HA package.

`mypy --strict` (vendor excluded) on our code: **151 → 101**. The residual **101 are all HA-stub-dependent** (subclassing `Any` base classes, the untyped `@callback` decorator, `Any` returns/attribute access from HA types) and clear in HA core's strict-typing CI — exactly the residue the quality_scale note describes.

| | count |
|---|---|
| before | 151 |
| `type-arg` / `no-untyped-def` / `arg-type` fixed | −50 |
| **after** | **101** (all HA-stub-dependent) |

## Changes (annotation-only, behaviour-neutral) — 12 files

- **Parameterise bare generics** across platforms/helpers/coordinator (`dict`/`set`/`list`/`frozenset`/`tuple` → concrete element types). `nkbnames` gets a `_Row = dict[str, Any]` alias for the parsed `.mdb` rows.
- **Add missing annotations** — the iterator helpers (`_iter_button_entities`, `_iter_module_records`), the actuator `_refresh_task` closure + `_fire_event(**kwargs: Any)`, and a few coordinator helpers.
- **`router.iter_operation_points`** yield narrowed to `dict[str, Any]` (it's `isinstance`-guarded) — fixes the entity-constructor `Mapping`-vs-`dict` arg-types centrally; **`switch.input_ab_addresses`** widened to `Mapping` (its source guards on `Mapping`).

## One real find

Typing the actuator's `group` exposed that **`set_bytearray_group_state` was declared `group: int`** but is called with the **string forms `"1"`/`"2"`** the actuator routes by (it does `int(group)` internally; the scene path passes a real `int`). Corrected the signature to `int | str` to match reality — **no behaviour change**, just an accurate type.

## Testing

Suite **402 passing**, ruff clean. (Depends on #439 for the `vendor/` exclusion in `mypy.ini`; the source changes here are independent.)

> Note: this completes the "~50 resolvable here … follow-up" item in #439's quality_scale note — once both merge, that line's count is 0 and the residue is the ~101 HA-stub set.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_