### PR TITLE
types: consume nikobus-connect's shipped types (drop ignore_missing_imports)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ Robustness, i18n & cleanup pass — a few user-facing fixes, otherwise internal.
   and helpers, refreshed stale in-code / README references, and tidied the
   test suite (closed leaked event loops, strengthened a few weak tests).
   The full test suite stays green.
+- **Type-checks against the `nikobus-connect` library directly.** The
+  library now ships a `py.typed` marker (0.25.0), so the integration's
+  use of its API is type-checked for real — the `ignore_missing_imports`
+  override for it has been dropped and the dependency pinned to
+  `nikobus-connect>=0.25.0`.
 
 ## 3.8.1
 

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -13,7 +13,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.24.0",
+    "nikobus-connect>=0.25.0",
     "construct>=2.10"
   ],
   "version": "3.8.2"

--- a/mypy.ini
+++ b/mypy.ini
@@ -24,8 +24,8 @@ strict = True
 [mypy-aiofiles.*]
 ignore_missing_imports = True
 
-[mypy-nikobus_connect.*]
-ignore_missing_imports = True
+# nikobus_connect ships a py.typed marker as of 0.25.0 (see the manifest
+# pin), so its types are consumed directly — no override needed.
 
 [mypy-serial_asyncio.*]
 ignore_missing_imports = True


### PR DESCRIPTION
## Summary

`nikobus-connect` 0.25.0 ships a `py.typed` marker (PEP 561), so the integration's use of its API is now type-checked against the **real signatures** instead of silently falling back to `Any`. This:

- drops the `[mypy-nikobus_connect.*] ignore_missing_imports = True` override in `mypy.ini`
- pins the dependency to `nikobus-connect>=0.25.0` in the manifest
- notes both in the (unreleased) 3.8.2 CHANGELOG entry, which already covers the typing-modernization theme

**No behaviour change** — config + manifest + changelog only.

## Validation

Verified locally against a fully-typed `nikobus_connect` build:

- Dropping the override added **zero** new errors — the integration's calls into `nikobus_connect` already match its real signatures (mypy error count unchanged, none attributable to `nikobus_connect`). The remaining sandbox mypy noise is the usual Home-Assistant-framework-as-`Any` artifact and is unrelated.
- `402 passed` — full test suite green.

## ⚠️ Merge ordering

This is **gated on `nikobus-connect` 0.25.0 being published to PyPI** (fdebrus/nikobus-connect#113). Because the manifest now requires `>=0.25.0`, HACS/pip installs will fail until that version is available. Publish the connect release first, then merge/ship this.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_