### PR TITLE
refactor(coordinator): extract pure reconciliation helpers to nkbreconcile

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -65,6 +65,15 @@ from .const import (
 from .nkbactuator import NikobusActuator
 from .nkbconfig import NikobusConfig
 from .nkbmanual import legacy_config_files_present
+from .nkbreconcile import (
+    all_outputs_registry_sourced,
+    build_controlled_by_index,
+    cf_member_set,
+    collect_button_linked_modules,
+    collect_button_outputs,
+    has_pc_logic_module,
+    member_set_from_outputs,
+)
 from .nkbstorage import (
     NikobusButtonStorage,
     NikobusCFStorage,
@@ -101,32 +110,10 @@ _PROBE_OUTER_DELAY_S = 3.0
 # module currently knows about it — strong residue signal on installs
 # without PC-Logic. On installs WITH PC-Logic, a registry-only button
 # could be a legitimate PC-Logic scene trigger; the classifier gates the
-# residue verdict on ``_has_pc_logic_module`` to avoid that FP.
-_REGISTRY_SOURCES = frozenset({"pc_link_registry", "pc_logic_registry"})
-
-
-def _member_set_from_outputs(outputs: Any) -> frozenset[tuple[str, int, str]]:
-    """Frozenset of ``(module_upper, channel, mode_code)`` for an output
-    list — the canonical key for matching a scene/CF by its members,
-    used identically on ``.nkb`` groups, CF entries and routing-graph
-    op-points so the three are directly comparable."""
-    from .nkbnames import _mode_code
-
-    out = set()
-    for o in outputs or []:
-        if not isinstance(o, dict):
-            continue
-        mod = o.get("module_address")
-        ch = o.get("channel")
-        code = _mode_code(o.get("mode"))
-        if isinstance(mod, str) and isinstance(ch, int) and code:
-            out.add((mod.upper(), ch, code))
-    return frozenset(out)
-
-
-def _cf_member_set(cf: dict[str, Any]) -> frozenset[tuple[str, int, str]]:
-    """Member-set key for a stored ``nikobus_cf`` entry."""
-    return _member_set_from_outputs((cf or {}).get("outputs"))
+# residue verdict on ``nkbreconcile.has_pc_logic_module`` to avoid that FP.
+#
+# The member-set / controlled-by / registry-residue compute helpers are
+# pure (HA-free) and live in ``nkbreconcile`` — imported at the top.
 
 
 def _output_entity_key(unique_id: str | None) -> tuple[str, int] | None:
@@ -1048,49 +1035,10 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 return cf
         return None
 
-    def _build_controlled_by_index(self) -> dict[tuple[str, int], list[dict[str, Any]]]:
-        """Build a (module_address_upper, channel) -> list[button record] index."""
-        index: dict[tuple[str, int], list[dict[str, Any]]] = {}
-        buttons = (self.dict_button_data or {}).get("nikobus_button", {})
-        for physical_addr, phys in buttons.items():
-            if not isinstance(phys, dict):
-                continue
-            op_points = phys.get("operation_points") or {}
-            if not isinstance(op_points, dict):
-                continue
-            for key_label, op_point in op_points.items():
-                if not isinstance(op_point, dict):
-                    continue
-                bus_addr = op_point.get("bus_address") or ""
-                description = op_point.get("description") or f"Button {bus_addr}"
-                for link in op_point.get("linked_modules") or []:
-                    if not isinstance(link, dict):
-                        continue
-                    module_address = link.get("module_address")
-                    if not module_address:
-                        continue
-                    module_key = str(module_address).upper()
-                    for out in link.get("outputs") or []:
-                        if not isinstance(out, dict):
-                            continue
-                        channel = out.get("channel")
-                        if not isinstance(channel, int):
-                            continue
-                        index.setdefault((module_key, channel), []).append({
-                            "bus_address": bus_addr,
-                            "description": description,
-                            "mode": out.get("mode"),
-                            "t1": out.get("t1"),
-                            "t2": out.get("t2"),
-                            "wall_button_address": physical_addr,
-                            "wall_button_key": key_label,
-                        })
-        return index
-
     def get_controlled_by(self, module_address: str, channel: int) -> list[dict[str, Any]]:
         """Return the buttons that trigger a given ``(module_address, channel)``."""
         if self._controlled_by_index is None:
-            self._controlled_by_index = self._build_controlled_by_index()
+            self._controlled_by_index = build_controlled_by_index(self.dict_button_data)
         return self._controlled_by_index.get(
             (str(module_address).upper(), int(channel)), []
         )
@@ -1508,81 +1456,6 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         # Clear the cached router spec so newly-discovered modules show up.
         self._invalidate_routing_cache()
 
-    @staticmethod
-    def _collect_button_linked_modules(phys: dict[str, Any]) -> set[str]:
-        """Union of every module address referenced by any of a button's op-points."""
-        linked: set[str] = set()
-        op_points = phys.get("operation_points") or {}
-        if not isinstance(op_points, dict):
-            return linked
-        for op_point in op_points.values():
-            if not isinstance(op_point, dict):
-                continue
-            for link in op_point.get("linked_modules") or []:
-                if not isinstance(link, dict):
-                    continue
-                addr = link.get("module_address")
-                if addr:
-                    linked.add(str(addr).upper())
-        return linked
-
-    @staticmethod
-    def _collect_button_outputs(phys: dict[str, Any]) -> list[dict[str, Any]]:
-        """Flatten every output record under every op-point of a button.
-
-        Returned dicts are the decoder's per-output records (channel,
-        mode, payload, button_address, plus nikobus-connect 0.5.22+'s
-        ``record_source``). Used by the registry-only residue check.
-        """
-        outputs: list[dict[str, Any]] = []
-        op_points = phys.get("operation_points") or {}
-        if not isinstance(op_points, dict):
-            return outputs
-        for op_point in op_points.values():
-            if not isinstance(op_point, dict):
-                continue
-            for link in op_point.get("linked_modules") or []:
-                if not isinstance(link, dict):
-                    continue
-                for out in link.get("outputs") or []:
-                    if isinstance(out, dict):
-                        outputs.append(out)
-        return outputs
-
-    @staticmethod
-    def _all_outputs_registry_sourced(outputs: list[dict[str, Any]]) -> bool:
-        """True iff every output has ``record_source`` in the registry set.
-
-        Returns False if ``outputs`` is empty, or if any output is
-        missing the field. Pre-0.5.22 records (no ``record_source``)
-        are treated as source-unknown and fall through to the existing
-        classifier — backward compat without data migration.
-        """
-        if not outputs:
-            return False
-        return all(
-            out.get("record_source") in _REGISTRY_SOURCES
-            for out in outputs
-        )
-
-    def _has_pc_logic_module(self) -> bool:
-        """True if the install has at least one PC-Logic module in the store.
-
-        Gates the registry-only residue verdict: with PC-Logic absent,
-        a button whose every output is registry-sourced is unambiguous
-        residue (no real button-to-output link exists anywhere). With
-        PC-Logic present, the same shape could be a legitimate
-        PC-Logic-only scene trigger — fall through to the existing
-        classifier and let the user adjudicate.
-        """
-        modules = self.module_storage.data.get("nikobus_module", {})
-        if not isinstance(modules, dict):
-            return False
-        return any(
-            isinstance(m, dict) and m.get("module_type") == "pc_logic"
-            for m in modules.values()
-        )
-
     def _surface_legacy_undecoded_buttons(
         self, buttons: dict[str, Any]
     ) -> None:
@@ -1849,7 +1722,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
         # output module recording the link — strong residue signal.
         # With PC-Logic present, the same shape could be a legitimate
         # scene trigger; defer to the existing classifier.
-        has_pc_logic = self._has_pc_logic_module()
+        has_pc_logic = has_pc_logic_module(self.module_storage.data)
         for phys in buttons.values():
             if not isinstance(phys, dict):
                 continue
@@ -1878,15 +1751,15 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 phys["status"] = "input_only"
                 bucket_counts["input_only"] += 1
                 continue
-            linked = self._collect_button_linked_modules(phys)
-            outputs = self._collect_button_outputs(phys)
+            linked = collect_button_linked_modules(phys)
+            outputs = collect_button_outputs(phys)
             if not outputs:
                 # No decoded links anywhere — pre-Stage-2 default OR
                 # intentionally unwired button (HA-trigger pattern).
                 status = "legacy_undecoded"
             elif (
                 not has_pc_logic
-                and self._all_outputs_registry_sourced(outputs)
+                and all_outputs_registry_sourced(outputs)
             ):
                 # nikobus-connect 0.5.22 residue filter: every output
                 # comes from PC-Link / PC-Logic registry, and there's
@@ -2483,10 +2356,10 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             scene_by_members = {sc.members: sc.name for sc in data.scenes}
             matched_scene_members: set[frozenset[tuple[str, int, str]]] = set()
             for cf_addr, cf in self.cf_storage.data.get("nikobus_cf", {}).items():
-                hit = scene_by_members.get(_cf_member_set(cf))
+                hit = scene_by_members.get(cf_member_set(cf))
                 if hit:
                     cf_name_by_addr[str(cf_addr).upper()] = hit
-                    matched_scene_members.add(_cf_member_set(cf))
+                    matched_scene_members.add(cf_member_set(cf))
             graph = self._build_routing_graph()
             existing = self.cf_storage.data.setdefault("nikobus_cf", {})
             new_entries: dict[str, dict[str, Any]] = {}
@@ -2675,7 +2548,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                                 "t2": o.get("t2") if isinstance(o.get("t2"), str) else None,
                             }
                         )
-                members = _member_set_from_outputs(outputs)
+                members = member_set_from_outputs(outputs)
                 if not members:
                     continue
                 entry = graph.setdefault(members, ([], outputs))

--- a/custom_components/nikobus/nkbreconcile.py
+++ b/custom_components/nikobus/nkbreconcile.py
@@ -1,0 +1,165 @@
+"""Pure post-discovery reconciliation helpers.
+
+Stateless data-crunching extracted from ``coordinator.py``: member-set
+keys (used to match ``.nkb`` scene groups, classified CF entries and
+routing-graph op-points against each other), the ``controlled_by``
+index, and the registry-only-residue checks. None of these touch Home
+Assistant — they take the integration's button/module store dicts and
+return plain data — so they live here, away from the coordinator's HA
+lifecycle, and are unit-tested in isolation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# ``_mode_code`` extracts the leading ``M<n>`` from a mode label. It's
+# re-exported by the integration's ``nkbnames`` module (which since
+# nikobus-connect 0.26.0 is a thin shim over ``nikobus_connect.nkb``),
+# so this stays correct whether the parser is local or library-provided.
+from .nkbnames import _mode_code as mode_code
+
+# A button whose every output record is registry-sourced (read from a
+# PC-Link / PC-Logic register table rather than an output module's own
+# link table) is residue from a previous owner's programming — *unless*
+# the install has a PC-Logic, where it may be a legitimate scene trigger.
+REGISTRY_SOURCES = frozenset({"pc_link_registry", "pc_logic_registry"})
+
+
+def member_set_from_outputs(outputs: Any) -> frozenset[tuple[str, int, str]]:
+    """Frozenset of ``(module_upper, channel, mode_code)`` for an output
+    list — the canonical key for matching a scene/CF by its members, used
+    identically on ``.nkb`` groups, CF entries and routing-graph op-points
+    so the three are directly comparable."""
+    out: set[tuple[str, int, str]] = set()
+    for o in outputs or []:
+        if not isinstance(o, dict):
+            continue
+        mod = o.get("module_address")
+        ch = o.get("channel")
+        code = mode_code(o.get("mode"))
+        if isinstance(mod, str) and isinstance(ch, int) and code:
+            out.add((mod.upper(), ch, code))
+    return frozenset(out)
+
+
+def cf_member_set(cf: dict[str, Any]) -> frozenset[tuple[str, int, str]]:
+    """Member-set key for a stored ``nikobus_cf`` entry."""
+    return member_set_from_outputs((cf or {}).get("outputs"))
+
+
+def collect_button_linked_modules(phys: dict[str, Any]) -> set[str]:
+    """Union of every module address referenced by any of a button's op-points."""
+    linked: set[str] = set()
+    op_points = phys.get("operation_points") or {}
+    if not isinstance(op_points, dict):
+        return linked
+    for op_point in op_points.values():
+        if not isinstance(op_point, dict):
+            continue
+        for link in op_point.get("linked_modules") or []:
+            if not isinstance(link, dict):
+                continue
+            addr = link.get("module_address")
+            if addr:
+                linked.add(str(addr).upper())
+    return linked
+
+
+def collect_button_outputs(phys: dict[str, Any]) -> list[dict[str, Any]]:
+    """Flatten every output record under every op-point of a button.
+
+    Returned dicts are the decoder's per-output records (channel, mode,
+    payload, button_address, plus nikobus-connect 0.5.22+'s
+    ``record_source``). Used by the registry-only residue check.
+    """
+    outputs: list[dict[str, Any]] = []
+    op_points = phys.get("operation_points") or {}
+    if not isinstance(op_points, dict):
+        return outputs
+    for op_point in op_points.values():
+        if not isinstance(op_point, dict):
+            continue
+        for link in op_point.get("linked_modules") or []:
+            if not isinstance(link, dict):
+                continue
+            for out in link.get("outputs") or []:
+                if isinstance(out, dict):
+                    outputs.append(out)
+    return outputs
+
+
+def all_outputs_registry_sourced(outputs: list[dict[str, Any]]) -> bool:
+    """True iff every output has ``record_source`` in the registry set.
+
+    Returns False if ``outputs`` is empty, or if any output is missing
+    the field. Pre-0.5.22 records (no ``record_source``) are treated as
+    source-unknown and fall through to the existing classifier —
+    backward compat without data migration.
+    """
+    if not outputs:
+        return False
+    return all(out.get("record_source") in REGISTRY_SOURCES for out in outputs)
+
+
+def has_pc_logic_module(module_data: dict[str, Any] | None) -> bool:
+    """True if the install has at least one PC-Logic module in the store.
+
+    Gates the registry-only residue verdict: with PC-Logic absent, a
+    button whose every output is registry-sourced is unambiguous residue
+    (no real button-to-output link exists anywhere). With PC-Logic
+    present, the same shape could be a legitimate PC-Logic-only scene
+    trigger — fall through to the existing classifier and let the user
+    adjudicate.
+    """
+    modules = (module_data or {}).get("nikobus_module", {})
+    if not isinstance(modules, dict):
+        return False
+    return any(
+        isinstance(m, dict) and m.get("module_type") == "pc_logic"
+        for m in modules.values()
+    )
+
+
+def build_controlled_by_index(
+    button_data: dict[str, Any] | None,
+) -> dict[tuple[str, int], list[dict[str, Any]]]:
+    """Build a ``(module_address_upper, channel) -> [button record]`` index."""
+    index: dict[tuple[str, int], list[dict[str, Any]]] = {}
+    buttons = (button_data or {}).get("nikobus_button", {})
+    if not isinstance(buttons, dict):
+        return index
+    for physical_addr, phys in buttons.items():
+        if not isinstance(phys, dict):
+            continue
+        op_points = phys.get("operation_points") or {}
+        if not isinstance(op_points, dict):
+            continue
+        for key_label, op_point in op_points.items():
+            if not isinstance(op_point, dict):
+                continue
+            bus_addr = op_point.get("bus_address") or ""
+            description = op_point.get("description") or f"Button {bus_addr}"
+            for link in op_point.get("linked_modules") or []:
+                if not isinstance(link, dict):
+                    continue
+                module_address = link.get("module_address")
+                if not module_address:
+                    continue
+                module_key = str(module_address).upper()
+                for out in link.get("outputs") or []:
+                    if not isinstance(out, dict):
+                        continue
+                    channel = out.get("channel")
+                    if not isinstance(channel, int):
+                        continue
+                    index.setdefault((module_key, channel), []).append({
+                        "bus_address": bus_addr,
+                        "description": description,
+                        "mode": out.get("mode"),
+                        "t1": out.get("t1"),
+                        "t2": out.get("t2"),
+                        "wall_button_address": physical_addr,
+                        "wall_button_key": key_label,
+                    })
+    return index

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -674,21 +674,10 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
                 pass
             coord.nikobus_discovery = _OldDiscovery()
 
-        coord._collect_button_linked_modules = staticmethod(
-            NikobusDataCoordinator._collect_button_linked_modules
-        )
-        # Wire the 0.5.22 record_source helpers so the bucketing path
-        # uses real implementations instead of MagicMock returns (which
-        # would be truthy and skew the classifier).
-        coord._collect_button_outputs = staticmethod(
-            NikobusDataCoordinator._collect_button_outputs
-        )
-        coord._all_outputs_registry_sourced = staticmethod(
-            NikobusDataCoordinator._all_outputs_registry_sourced
-        )
-        coord._has_pc_logic_module = (
-            lambda self_=coord: NikobusDataCoordinator._has_pc_logic_module(self_)
-        )
+        # The record_source / linked-module helpers are now pure functions
+        # in nkbreconcile (imported into the coordinator module), so
+        # ``_reconcile_post_discovery`` uses the real implementations
+        # directly — no per-instance wiring needed.
         # Bind ``_reconcile_post_discovery`` to forward the sweep state
         # the way ``_handle_discovery_finished`` does in production:
         # via the kwargs that nikobus-connect 0.5.20 passes through
@@ -1493,7 +1482,9 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
         )
 
     async def test_has_pc_logic_module_helper(self):
-        # Direct unit test of the topology gate.
+        # Direct unit test of the topology gate (now a pure helper).
+        from custom_components.nikobus.nkbreconcile import has_pc_logic_module
+
         coord_no_pc_logic = self._make_coordinator_stub(
             modules={"8110": {"module_type": "switch_module"}},
         )
@@ -1504,8 +1495,8 @@ class TestReconcilePostDiscovery(unittest.IsolatedAsyncioTestCase):
             },
         )
 
-        self.assertFalse(coord_no_pc_logic._has_pc_logic_module())
-        self.assertTrue(coord_with_pc_logic._has_pc_logic_module())
+        self.assertFalse(has_pc_logic_module(coord_no_pc_logic.module_storage.data))
+        self.assertTrue(has_pc_logic_module(coord_with_pc_logic.module_storage.data))
 
 
 class TestHandleDiscoveryFinishedFinalizing(unittest.IsolatedAsyncioTestCase):
@@ -2010,7 +2001,9 @@ class TestHandleConnectionLostCoalescing(unittest.IsolatedAsyncioTestCase):
 class TestCollectButtonLinkedModules(unittest.TestCase):
     """Pure-function unit tests for the helper that drives bucket assignment."""
 
-    _collect = staticmethod(NikobusDataCoordinator._collect_button_linked_modules)
+    from custom_components.nikobus.nkbreconcile import collect_button_linked_modules
+
+    _collect = staticmethod(collect_button_linked_modules)
 
     def test_no_op_points_returns_empty_set(self):
         self.assertEqual(self._collect({}), set())

--- a/tests/test_nkbreconcile.py
+++ b/tests/test_nkbreconcile.py
@@ -1,0 +1,110 @@
+"""Unit tests for the pure reconciliation helpers (nkbreconcile)."""
+
+from __future__ import annotations
+
+from custom_components.nikobus.nkbreconcile import (
+    all_outputs_registry_sourced,
+    build_controlled_by_index,
+    cf_member_set,
+    collect_button_outputs,
+    has_pc_logic_module,
+    member_set_from_outputs,
+)
+
+
+def test_member_set_from_outputs_keys_on_module_channel_modecode():
+    outputs = [
+        {"module_address": "0e6c", "channel": 2, "mode": "M12 (Preset on)"},
+        {"module_address": "C9A5", "channel": 1, "mode": "M04"},
+        {"module_address": "0e6c", "channel": 3, "mode": "MCF"},  # no M-code -> dropped
+        {"channel": 1, "mode": "M01"},                            # no module -> dropped
+        "garbage",                                                # not a dict -> dropped
+    ]
+    assert member_set_from_outputs(outputs) == frozenset(
+        {("0E6C", 2, "M12"), ("C9A5", 1, "M04")}
+    )
+
+
+def test_member_set_from_outputs_empty():
+    assert member_set_from_outputs(None) == frozenset()
+    assert member_set_from_outputs([]) == frozenset()
+
+
+def test_cf_member_set_reads_outputs_field():
+    cf = {"outputs": [{"module_address": "8394", "channel": 1, "mode": "M02 (x)"}]}
+    assert cf_member_set(cf) == frozenset({("8394", 1, "M02")})
+    assert cf_member_set({}) == frozenset()
+
+
+def test_all_outputs_registry_sourced():
+    assert all_outputs_registry_sourced([]) is False  # empty -> not residue
+    assert all_outputs_registry_sourced(
+        [{"record_source": "pc_link_registry"}, {"record_source": "pc_logic_registry"}]
+    ) is True
+    # one output from a real output-module table -> not all registry-sourced
+    assert all_outputs_registry_sourced(
+        [{"record_source": "pc_link_registry"}, {"record_source": "output_module_table"}]
+    ) is False
+    # missing field (pre-0.5.22) -> source-unknown -> not all registry
+    assert all_outputs_registry_sourced([{"channel": 1}]) is False
+
+
+def test_has_pc_logic_module():
+    assert has_pc_logic_module(None) is False
+    assert has_pc_logic_module(
+        {"nikobus_module": {"8110": {"module_type": "switch_module"}}}
+    ) is False
+    assert has_pc_logic_module(
+        {"nikobus_module": {"940C": {"module_type": "pc_logic"}}}
+    ) is True
+
+
+def test_collect_button_outputs_flattens_op_points():
+    phys = {
+        "operation_points": {
+            "1A": {"linked_modules": [
+                {"module_address": "AABB", "outputs": [{"channel": 1}, {"channel": 2}]},
+            ]},
+            "1B": {"linked_modules": [
+                {"module_address": "CCDD", "outputs": [{"channel": 3}]},
+                "garbage",
+            ]},
+        }
+    }
+    assert collect_button_outputs(phys) == [
+        {"channel": 1}, {"channel": 2}, {"channel": 3}
+    ]
+    assert collect_button_outputs({}) == []
+
+
+def test_build_controlled_by_index():
+    button_data = {
+        "nikobus_button": {
+            "1843B4": {
+                "operation_points": {
+                    "1A": {
+                        "bus_address": "004E2C",
+                        "description": "Living switch",
+                        "linked_modules": [
+                            {"module_address": "0e6c", "outputs": [
+                                {"channel": 2, "mode": "M01"},
+                            ]},
+                        ],
+                    }
+                }
+            }
+        }
+    }
+    index = build_controlled_by_index(button_data)
+    assert list(index.keys()) == [("0E6C", 2)]
+    entry = index[("0E6C", 2)]
+    assert len(entry) == 1
+    assert entry[0]["bus_address"] == "004E2C"
+    assert entry[0]["wall_button_address"] == "1843B4"
+    assert entry[0]["wall_button_key"] == "1A"
+    assert entry[0]["mode"] == "M01"
+
+
+def test_build_controlled_by_index_empty_and_malformed():
+    assert build_controlled_by_index(None) == {}
+    assert build_controlled_by_index({"nikobus_button": "not-a-dict"}) == {}


### PR DESCRIPTION
## Summary

Phase 2 (first increment) — start decomposing `coordinator.py` (2,683 lines) by pulling the **stateless post-discovery compute** into a new HA-free module, `nkbreconcile.py`, per the "pure helper module" approach. The coordinator keeps the orchestration; the number-crunching moves out where it can be tested in isolation.

## What moved (now pure functions — take the store dicts, return plain data)

- `member_set_from_outputs` / `cf_member_set` — the `(module, channel, mode_code)` member-set keys used to match `.nkb` scene groups, classified CFs, and routing-graph op-points against each other
- `build_controlled_by_index` — `(module, channel) → [button record]`
- `collect_button_linked_modules` / `collect_button_outputs`
- `all_outputs_registry_sourced` / `has_pc_logic_module` — the registry-only-residue gate

The coordinator's `_reconcile_post_discovery`, `get_controlled_by`, and scene-matching now call these directly (no `self.` state needed — they were already reading data and returning data).

## Why this is safe

These were the lightest-coupled methods in the file (the ~625-line "Misc helpers" block had only 6 `self.hass` touches and one `self.*` write across it). None of the moved functions touch Home Assistant.

## Tests & size

- **`coordinator.py` −127 lines**; logic now in `nkbreconcile.py` (165 lines)
- New `test_nkbreconcile.py` (8 focused unit tests) replaces the awkward through-the-coordinator-stub tests
- `410 passed` (402 + 8 new), `ruff` clean, `mypy` unchanged (101 — the documented HA-stub set)

**No behaviour change.** Independent of the parser PRs (#115/#443) — `nkbreconcile` gets `_mode_code` via the integration's `nkbnames`, which works today and after the parser move.

## Next

This is the first, conservative extraction. The orchestration methods (`_reconcile_post_discovery`, `_ingest_cf_broadcasts`, `_handle_discovery_finished`) can be slimmed further in follow-ups now that the compute lives in `nkbreconcile`.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_