### PR TITLE
refactor(coordinator): move button-bucketing + CF flatten into nkbreconcile

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -55,7 +55,6 @@ from .const import (
     DISCOVERY_WEIGHT_INVENTORY,
     DISCOVERY_WEIGHT_REGISTER_SCAN,
     DOMAIN,
-    INPUT_ONLY_BUTTON_TYPES,
     ISSUE_LEGACY_UNDECODED_BUTTONS,
     ISSUE_NO_BUTTONS_CONFIGURED,
     RECONNECT_DELAY_INITIAL,
@@ -66,11 +65,10 @@ from .nkbactuator import NikobusActuator
 from .nkbconfig import NikobusConfig
 from .nkbmanual import legacy_config_files_present
 from .nkbreconcile import (
-    all_outputs_registry_sourced,
     build_controlled_by_index,
     cf_member_set,
-    collect_button_linked_modules,
-    collect_button_outputs,
+    classify_button_status,
+    flatten_cf_broadcasts,
     has_pc_logic_module,
     member_set_from_outputs,
 )
@@ -1535,30 +1533,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             # that hits an empty bus shouldn't lose the user's scenes.)
             return
 
-        flat: dict[str, dict[str, Any]] = {}
-        for addr, cf in broadcasts.items():
-            outputs = [
-                {
-                    "module_address": str(m.module_address).upper(),
-                    "channel": int(m.channel),
-                    "mode": str(m.mode),
-                    "t1": getattr(m, "t1", None),
-                    "t2": getattr(m, "t2", None),
-                }
-                for m in getattr(cf, "outputs", [])
-            ]
-            bus_address = str(getattr(cf, "bus_address", addr)).upper()
-            triggered_by = [
-                str(t).upper()
-                for t in (getattr(cf, "triggered_by", None) or [bus_address])
-            ]
-            flat[str(addr).upper()] = {
-                "bus_address": bus_address,
-                "pattern": str(getattr(cf, "pattern", "unknown")),
-                "outputs": outputs,
-                # Every address that fires this CF (one CF, many triggers).
-                "triggered_by": triggered_by,
-            }
+        flat = flatten_cf_broadcasts(broadcasts)
 
         # Preserve any .nkb-sourced scenes (added by async_import_nkb_names);
         # discovery never produces them, so a re-scan must not wipe them.
@@ -1716,62 +1691,15 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             "input_only": 0,
         }
         buttons = self.dict_button_data.setdefault("nikobus_button", {})
-        # Topology gate for the registry-only residue check. With no
-        # PC-Logic in the install, a button whose every output record
-        # is sourced from PC-Link / PC-Logic registry memory has NO
-        # output module recording the link — strong residue signal.
-        # With PC-Logic present, the same shape could be a legitimate
-        # scene trigger; defer to the existing classifier.
+        # Topology gate for the registry-only residue check (see
+        # ``classify_button_status``): with no PC-Logic in the install, a
+        # button whose every output record is registry-sourced has no
+        # output module recording the link — a strong residue signal.
         has_pc_logic = has_pc_logic_module(self.module_storage.data)
         for phys in buttons.values():
             if not isinstance(phys, dict):
                 continue
-            # Library-synthesized PC-Logic (05-201) and Modular Interface
-            # (05-206) input children carry ``pc_logic_parent_address``
-            # set by the synthesizer in nikobus-connect
-            # ``_synthesize_pc_logic_inputs``. They model bus-event
-            # sources that the parent module listens to internally, not
-            # buttons that drive output modules — empty ``linked_modules``
-            # is the steady state, not a residue signal. Bucket them on
-            # their own status so the legacy-undecoded Repairs flow
-            # leaves them alone.
-            if phys.get("pc_logic_parent_address"):
-                phys["status"] = "synthesized_input"
-                bucket_counts["synthesized_input"] += 1
-                continue
-            # Universal Interface (Niko 05-058) in either mode is
-            # input-only — its 4/8 contacts emit press telegrams but
-            # don't write into output-module link tables (they're
-            # designed to feed PC-Logic conditions). Same shape as a
-            # synthesized PC-Logic input from the bucket-decision
-            # perspective: empty ``linked_modules`` is the steady state.
-            # Tag separately so the legacy-undecoded Repairs alert
-            # doesn't false-positive on them.
-            if phys.get("type") in INPUT_ONLY_BUTTON_TYPES:
-                phys["status"] = "input_only"
-                bucket_counts["input_only"] += 1
-                continue
-            linked = collect_button_linked_modules(phys)
-            outputs = collect_button_outputs(phys)
-            if not outputs:
-                # No decoded links anywhere — pre-Stage-2 default OR
-                # intentionally unwired button (HA-trigger pattern).
-                status = "legacy_undecoded"
-            elif (
-                not has_pc_logic
-                and all_outputs_registry_sourced(outputs)
-            ):
-                # nikobus-connect 0.5.22 residue filter: every output
-                # comes from PC-Link / PC-Logic registry, and there's
-                # no PC-Logic module to potentially justify a scene
-                # trigger. Unambiguous residue programming from a
-                # previous owner — surface for purge.
-                status = "legacy_orphan"
-            elif not (linked & remaining):
-                # All decoded-target modules were evicted by the probe.
-                status = "legacy_orphan"
-            else:
-                status = "active"
+            status = classify_button_status(phys, remaining, has_pc_logic)
             phys["status"] = status
             bucket_counts[status] += 1
 

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -66,11 +66,11 @@ from .nkbconfig import NikobusConfig
 from .nkbmanual import legacy_config_files_present
 from .nkbreconcile import (
     build_controlled_by_index,
+    build_routing_graph,
     cf_member_set,
     classify_button_status,
     flatten_cf_broadcasts,
     has_pc_logic_module,
-    member_set_from_outputs,
 )
 from .nkbstorage import (
     NikobusButtonStorage,
@@ -2288,7 +2288,7 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
                 if hit:
                     cf_name_by_addr[str(cf_addr).upper()] = hit
                     matched_scene_members.add(cf_member_set(cf))
-            graph = self._build_routing_graph()
+            graph = build_routing_graph(self.dict_button_data)
             existing = self.cf_storage.data.setdefault("nikobus_cf", {})
             new_entries: dict[str, dict[str, Any]] = {}
             for sc in data.scenes:
@@ -2419,66 +2419,3 @@ class NikobusDataCoordinator(DataUpdateCoordinator[None]):
             "scenes_created": scenes_created,
         }
 
-    def _build_routing_graph(
-        self,
-    ) -> dict[frozenset[tuple[str, int, str]], tuple[list[str], list[dict[str, Any]]]]:
-        """Map every op-point's member set → ``(firing addresses, outputs)``.
-
-        The routing graph is the full set of ``trigger → linked outputs``
-        relations from the button store — the same data discovery decodes.
-        Used to find the on-bus address that fires a named ``.nkb`` scene
-        group (matched by member set), including the shutter / master
-        groups that have no light-scene mode and so never become CF
-        entities on their own. Addresses driving an identical output set
-        (one scene, several triggers) are grouped; the sorted-first is the
-        canonical activation address.
-        """
-        graph: dict[
-            frozenset[tuple[str, int, str]], tuple[list[str], list[dict[str, Any]]]
-        ] = {}
-        buttons = (self.dict_button_data or {}).get("nikobus_button", {})
-        if not isinstance(buttons, dict):
-            return {}
-        for phys in buttons.values():
-            if not isinstance(phys, dict):
-                continue
-            for op in (phys.get("operation_points") or {}).values():
-                if not isinstance(op, dict):
-                    continue
-                addr = op.get("bus_address")
-                if not isinstance(addr, str) or not addr:
-                    continue
-                outputs: list[dict[str, Any]] = []
-                seen: set[tuple[str, int, str]] = set()
-                for link in op.get("linked_modules") or []:
-                    if not isinstance(link, dict):
-                        continue
-                    mod = link.get("module_address")
-                    if not isinstance(mod, str):
-                        continue
-                    for o in link.get("outputs") or []:
-                        if not isinstance(o, dict):
-                            continue
-                        ch = o.get("channel")
-                        mode = o.get("mode")
-                        if not (isinstance(ch, int) and isinstance(mode, str)):
-                            continue
-                        dedupe = (mod.upper(), ch, mode)
-                        if dedupe in seen:
-                            continue
-                        seen.add(dedupe)
-                        outputs.append(
-                            {
-                                "module_address": mod.upper(),
-                                "channel": ch,
-                                "mode": mode,
-                                "t1": o.get("t1") if isinstance(o.get("t1"), str) else None,
-                                "t2": o.get("t2") if isinstance(o.get("t2"), str) else None,
-                            }
-                        )
-                members = member_set_from_outputs(outputs)
-                if not members:
-                    continue
-                entry = graph.setdefault(members, ([], outputs))
-                entry[0].append(addr.upper())
-        return {m: (sorted(set(a)), o) for m, (a, o) in graph.items()}

--- a/custom_components/nikobus/nkbreconcile.py
+++ b/custom_components/nikobus/nkbreconcile.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from .const import INPUT_ONLY_BUTTON_TYPES
+
 # ``_mode_code`` extracts the leading ``M<n>`` from a mode label. It's
 # re-exported by the integration's ``nkbnames`` module (which since
 # nikobus-connect 0.26.0 is a thin shim over ``nikobus_connect.nkb``),
@@ -163,3 +165,77 @@ def build_controlled_by_index(
                         "wall_button_key": key_label,
                     })
     return index
+
+
+def classify_button_status(
+    phys: dict[str, Any],
+    remaining_modules: set[str],
+    has_pc_logic: bool,
+) -> str:
+    """Return the post-discovery reconciliation bucket for one button.
+
+    ``remaining_modules`` is the set of surviving (non-evicted) module
+    addresses (upper-case); ``has_pc_logic`` is the install's topology
+    gate. One of:
+
+      * ``synthesized_input`` — a library-synthesized PC-Logic (05-201) /
+        Modular-Interface (05-206) input child (``pc_logic_parent_address``
+        set). Models a bus-event source the parent listens to internally;
+        empty ``linked_modules`` is its steady state, not residue.
+      * ``input_only`` — a Universal Interface (05-058) and friends
+        (``type`` in ``INPUT_ONLY_BUTTON_TYPES``): emits press telegrams
+        but never writes output-module link tables. Empty links is normal.
+      * ``legacy_undecoded`` — no decoded outputs anywhere (pre-Stage-2
+        default, or an intentionally-unwired HA-trigger button).
+      * ``legacy_orphan`` — has decoded outputs but either every output is
+        registry-sourced with no PC-Logic to justify it (residue from a
+        previous owner), or every decoded-target module was evicted.
+      * ``active`` — at least one linked module survived the scan.
+    """
+    if phys.get("pc_logic_parent_address"):
+        return "synthesized_input"
+    if phys.get("type") in INPUT_ONLY_BUTTON_TYPES:
+        return "input_only"
+    linked = collect_button_linked_modules(phys)
+    outputs = collect_button_outputs(phys)
+    if not outputs:
+        return "legacy_undecoded"
+    if not has_pc_logic and all_outputs_registry_sourced(outputs):
+        return "legacy_orphan"
+    if not (linked & remaining_modules):
+        return "legacy_orphan"
+    return "active"
+
+
+def flatten_cf_broadcasts(broadcasts: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Convert the library's ``CFBroadcast`` objects to the JSON-safe
+    ``nikobus_cf`` store shape.
+
+    ``{addr: {bus_address, pattern, outputs, triggered_by}}`` — ``outputs``
+    is a list of ``{module_address, channel, mode, t1, t2}`` dicts, keyed
+    addresses upper-cased.
+    """
+    flat: dict[str, dict[str, Any]] = {}
+    for addr, cf in broadcasts.items():
+        outputs = [
+            {
+                "module_address": str(m.module_address).upper(),
+                "channel": int(m.channel),
+                "mode": str(m.mode),
+                "t1": getattr(m, "t1", None),
+                "t2": getattr(m, "t2", None),
+            }
+            for m in getattr(cf, "outputs", [])
+        ]
+        bus_address = str(getattr(cf, "bus_address", addr)).upper()
+        triggered_by = [
+            str(t).upper()
+            for t in (getattr(cf, "triggered_by", None) or [bus_address])
+        ]
+        flat[str(addr).upper()] = {
+            "bus_address": bus_address,
+            "pattern": str(getattr(cf, "pattern", "unknown")),
+            "outputs": outputs,
+            "triggered_by": triggered_by,
+        }
+    return flat

--- a/custom_components/nikobus/nkbreconcile.py
+++ b/custom_components/nikobus/nkbreconcile.py
@@ -239,3 +239,68 @@ def flatten_cf_broadcasts(broadcasts: dict[str, Any]) -> dict[str, dict[str, Any
             "triggered_by": triggered_by,
         }
     return flat
+
+
+def build_routing_graph(
+    button_data: dict[str, Any] | None,
+) -> dict[frozenset[tuple[str, int, str]], tuple[list[str], list[dict[str, Any]]]]:
+    """Map every op-point's member set -> ``(firing addresses, outputs)``.
+
+    The routing graph is the full set of ``trigger -> linked outputs``
+    relations from the button store — the same data discovery decodes.
+    Used to find the on-bus address that fires a named ``.nkb`` scene
+    group (matched by member set), including the shutter / master groups
+    that have no light-scene mode and so never become CF entities on
+    their own. Addresses driving an identical output set (one scene,
+    several triggers) are grouped; the sorted-first is the canonical
+    activation address.
+    """
+    graph: dict[
+        frozenset[tuple[str, int, str]], tuple[list[str], list[dict[str, Any]]]
+    ] = {}
+    buttons = (button_data or {}).get("nikobus_button", {})
+    if not isinstance(buttons, dict):
+        return {}
+    for phys in buttons.values():
+        if not isinstance(phys, dict):
+            continue
+        for op in (phys.get("operation_points") or {}).values():
+            if not isinstance(op, dict):
+                continue
+            addr = op.get("bus_address")
+            if not isinstance(addr, str) or not addr:
+                continue
+            outputs: list[dict[str, Any]] = []
+            seen: set[tuple[str, int, str]] = set()
+            for link in op.get("linked_modules") or []:
+                if not isinstance(link, dict):
+                    continue
+                mod = link.get("module_address")
+                if not isinstance(mod, str):
+                    continue
+                for o in link.get("outputs") or []:
+                    if not isinstance(o, dict):
+                        continue
+                    ch = o.get("channel")
+                    mode = o.get("mode")
+                    if not (isinstance(ch, int) and isinstance(mode, str)):
+                        continue
+                    dedupe = (mod.upper(), ch, mode)
+                    if dedupe in seen:
+                        continue
+                    seen.add(dedupe)
+                    outputs.append(
+                        {
+                            "module_address": mod.upper(),
+                            "channel": ch,
+                            "mode": mode,
+                            "t1": o.get("t1") if isinstance(o.get("t1"), str) else None,
+                            "t2": o.get("t2") if isinstance(o.get("t2"), str) else None,
+                        }
+                    )
+            members = member_set_from_outputs(outputs)
+            if not members:
+                continue
+            entry = graph.setdefault(members, ([], outputs))
+            entry[0].append(addr.upper())
+    return {m: (sorted(set(a)), o) for m, (a, o) in graph.items()}

--- a/tests/test_nkbreconcile.py
+++ b/tests/test_nkbreconcile.py
@@ -2,14 +2,100 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from custom_components.nikobus.nkbreconcile import (
     all_outputs_registry_sourced,
     build_controlled_by_index,
     cf_member_set,
+    classify_button_status,
     collect_button_outputs,
+    flatten_cf_broadcasts,
     has_pc_logic_module,
     member_set_from_outputs,
 )
+
+
+def _button(linked: list[tuple[str, int, str | None]], **extra):
+    """Build a minimal button record with one op-point driving ``linked``
+    outputs — each ``(module_address, channel, record_source)``."""
+    outputs = [
+        {"channel": ch, "mode": "M01", "record_source": src}
+        for _mod, ch, src in linked
+    ]
+    # Group outputs under their module address.
+    by_mod: dict[str, list[dict]] = {}
+    for (mod, ch, src), out in zip(linked, outputs):
+        by_mod.setdefault(mod, []).append(out)
+    return {
+        **extra,
+        "operation_points": {
+            "1A": {
+                "bus_address": "004E2C",
+                "linked_modules": [
+                    {"module_address": mod, "outputs": outs}
+                    for mod, outs in by_mod.items()
+                ],
+            }
+        },
+    }
+
+
+def test_classify_button_status_synthesized_input():
+    assert classify_button_status(
+        {"pc_logic_parent_address": "940C"}, set(), False
+    ) == "synthesized_input"
+
+
+def test_classify_button_status_input_only():
+    assert classify_button_status(
+        {"type": "Universal interface, switch mode"}, set(), False
+    ) == "input_only"
+
+
+def test_classify_button_status_legacy_undecoded_when_no_outputs():
+    assert classify_button_status({"operation_points": {}}, set(), False) == (
+        "legacy_undecoded"
+    )
+
+
+def test_classify_button_status_active_when_linked_module_survives():
+    phys = _button([("0E6C", 1, "output_module_table")])
+    assert classify_button_status(phys, {"0E6C"}, False) == "active"
+
+
+def test_classify_button_status_legacy_orphan_when_module_evicted():
+    phys = _button([("0E6C", 1, "output_module_table")])
+    assert classify_button_status(phys, {"C9A5"}, False) == "legacy_orphan"
+
+
+def test_classify_button_status_registry_residue_without_pc_logic():
+    phys = _button([("0E6C", 1, "pc_link_registry")])
+    # No PC-Logic → all-registry-sourced is residue, even if the module
+    # still exists.
+    assert classify_button_status(phys, {"0E6C"}, False) == "legacy_orphan"
+    # With PC-Logic present, defer to reachability (module survives → active).
+    assert classify_button_status(phys, {"0E6C"}, True) == "active"
+
+
+def test_flatten_cf_broadcasts():
+    cf = SimpleNamespace(
+        bus_address="384101",
+        pattern="switch_pair",
+        triggered_by=["384101", "004e2c"],
+        outputs=[SimpleNamespace(module_address="0e6c", channel=2, mode="M02", t1=None, t2=None)],
+    )
+    flat = flatten_cf_broadcasts({"384101": cf})
+    assert flat == {
+        "384101": {
+            "bus_address": "384101".upper(),
+            "pattern": "switch_pair",
+            "outputs": [
+                {"module_address": "0E6C", "channel": 2, "mode": "M02", "t1": None, "t2": None}
+            ],
+            "triggered_by": ["384101", "004E2C"],
+        }
+    }
 
 
 def test_member_set_from_outputs_keys_on_module_channel_modecode():

--- a/tests/test_nkbreconcile.py
+++ b/tests/test_nkbreconcile.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from custom_components.nikobus.nkbreconcile import (
     all_outputs_registry_sourced,
     build_controlled_by_index,
+    build_routing_graph,
     cf_member_set,
     classify_button_status,
     collect_button_outputs,
@@ -194,3 +195,40 @@ def test_build_controlled_by_index():
 def test_build_controlled_by_index_empty_and_malformed():
     assert build_controlled_by_index(None) == {}
     assert build_controlled_by_index({"nikobus_button": "not-a-dict"}) == {}
+
+
+def test_build_routing_graph_groups_triggers_by_member_set():
+    button_data = {
+        "nikobus_button": {
+            "AAAA": {"operation_points": {
+                "1A": {"bus_address": "004e2c", "linked_modules": [
+                    {"module_address": "0e6c", "outputs": [
+                        {"channel": 1, "mode": "M01"},
+                        {"channel": 1, "mode": "M01"},  # dupe -> deduped
+                    ]},
+                ]},
+            }},
+            # A second trigger driving the *same* member set -> grouped.
+            "BBBB": {"operation_points": {
+                "1A": {"bus_address": "1843B4", "linked_modules": [
+                    {"module_address": "0E6C", "outputs": [{"channel": 1, "mode": "M01"}]},
+                ]},
+            }},
+            # An op-point with no decodable members -> skipped.
+            "CCCC": {"operation_points": {
+                "1A": {"bus_address": "C0FFEE", "linked_modules": []},
+            }},
+        }
+    }
+    graph = build_routing_graph(button_data)
+    key = frozenset({("0E6C", 1, "M01")})
+    assert list(graph.keys()) == [key]
+    addrs, outputs = graph[key]
+    assert addrs == ["004E2C", "1843B4"]  # sorted, both triggers
+    assert outputs == [{"module_address": "0E6C", "channel": 1, "mode": "M01",
+                        "t1": None, "t2": None}]
+
+
+def test_build_routing_graph_empty_and_malformed():
+    assert build_routing_graph(None) == {}
+    assert build_routing_graph({"nikobus_button": "nope"}) == {}


### PR DESCRIPTION
## Summary

Coordinator decomposition (pure-helper approach) — moves the **pure-compute** out of the post-discovery orchestration into `nkbreconcile`, leaving the coordinator to orchestrate. Three extractions in this PR:

1. **`classify_button_status(phys, remaining_modules, has_pc_logic)`** — the reconciliation bucket ladder (`synthesized_input` / `input_only` / `legacy_undecoded` / `legacy_orphan` / `active`). A ~45-line `if/elif` block + rationale comments → one tested function.
2. **`flatten_cf_broadcasts(broadcasts)`** — the library's `CFBroadcast` objects → JSON-safe `nikobus_cf` store shape.
3. **`build_routing_graph(button_data)`** — map each op-point's member set → `(firing addresses, outputs)`, used to match named `.nkb` scene groups to on-bus trigger addresses.

## Size / coupling

- **`coordinator.py` 2,556 → 2,421 (−135 here; −262 from the pre-refactor 2,683).**
- `INPUT_ONLY_BUTTON_TYPES`, `member_set_from_outputs`, and the `collect_*` / registry-source helpers are now referenced only inside `nkbreconcile` (dropped from the coordinator imports).

## Tests

- **+9 unit tests** (17 total in `test_nkbreconcile.py`) covering every classifier branch (incl. the PC-Logic topology gate), the CF-flatten shape, and routing-graph grouping/dedup — replacing the awkward through-the-coordinator-stub tests.
- `406 passed`, `ruff` clean, `mypy` → 100 (no new errors).

**No behaviour change.** Builds on the merged #444; independent of the parser track.

## Where this lands

With this, `_reconcile_post_discovery` and `async_import_nkb_names` are down to orchestration (probe → evict → classify-loop → persist; gather → match → write registry). The remaining bulk of `coordinator.py` is legitimately HA lifecycle (connect/poll/reconnect, discovery progress, dispatcher, registry writes) — not extractable without the mixin pattern. This is the sensible stopping point for the pure-helper decomposition.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj