### PR TITLE
chore: remove dead constants and a write-only attribute

### DIFF
--- a/custom_components/nikobus/const.py
+++ b/custom_components/nikobus/const.py
@@ -131,7 +131,6 @@ DISCOVERY_WEIGHT_FINALIZING: Final[int] = 5
 # Repair issues
 # =============================================================================
 ISSUE_NO_BUTTONS_CONFIGURED: Final[str] = "no_buttons_configured"
-ISSUE_STALE_INVENTORY_PRESENT: Final[str] = "stale_inventory_present"
 # Surfaced after Stage-2 scan-all when one or more buttons still have
 # no decoded ``linked_modules``. We can't programmatically distinguish
 # "intentionally unwired (HA automation trigger)" from "residue from a
@@ -246,12 +245,3 @@ DEVICE_INVENTORY_ANSWER: Final[tuple[str, str]] = ("$2E", "$1E")
 # =============================================================================
 RECONNECT_DELAY_INITIAL: Final[int] = 5   # First retry delay in seconds
 RECONNECT_DELAY_MAX: Final[int] = 60      # Cap on exponential-backoff delay
-
-# =============================================================================
-# Command Execution
-# =============================================================================
-COMMAND_EXECUTION_DELAY: Final[float] = 0.15  # Delay between command executions (OH1 uses 50 ms; 150 ms gives the bus a safe clearing window)
-COMMAND_ACK_WAIT_TIMEOUT: Final[int] = 15   # Outer deadline for the whole ACK+ANSWER wait
-COMMAND_ANSWER_WAIT_TIMEOUT: Final[int] = 5  # Pre-ACK: how long to wait for the ACK itself
-COMMAND_POST_ACK_ANSWER_TIMEOUT: Final[float] = 1.5  # Post-ACK: data should follow ACK quickly
-MAX_ATTEMPTS: Final[int] = 3  # Maximum retry attempts

--- a/custom_components/nikobus/scene.py
+++ b/custom_components/nikobus/scene.py
@@ -251,7 +251,6 @@ class NikobusSceneEntity(NikobusEntity, Scene):
             model="Software Scene",
             via_device=(DOMAIN, CATEGORY_SCENES),
         )
-        self._scene_id = scene_id
         self._attr_name = description
         self._attr_unique_id = f"nikobus_scene_{scene_id}"
 


### PR DESCRIPTION
## Summary

Dead-code audit of the integration (vulture + manual cross-checking against the HA framework conventions and the nikobus-connect cross-object contract).

**The honest finding: there is almost no dead code.** The only genuinely-unused symbols:

- **`const.py`** — the entire `Command Execution` block (`COMMAND_EXECUTION_DELAY`, `COMMAND_ACK_WAIT_TIMEOUT`, `COMMAND_ANSWER_WAIT_TIMEOUT`, `COMMAND_POST_ACK_ANSWER_TIMEOUT`, `MAX_ATTEMPTS`) — vestigial; nikobus-connect owns command timing now. Plus `ISSUE_STALE_INVENTORY_PRESENT`, an issue id that's never raised (and has no orphaned translation strings).
- **`scene.py`** — `self._scene_id`, assigned but never read.

## Why so little

Everything else vulture flagged is a **false positive**:
- HA framework entry points called by convention, not reference (`async_setup_entry`, `async_step_*`, entity service methods like `async_turn_on`/`async_press`, `_attr_*`, properties).
- The **library's cross-object contract** — nikobus-connect holds the coordinator as `self._coordinator` and reads `discovery_module` / `discovery_module_address` / `inventory_query_type` and calls `get_button_channels` via `getattr` (confirmed in `discovery/protocol.py`, `pc_record_parser.py`, `dimmer_decoder.py`).

vulture at 100% confidence reports **zero** unreachable code, and every module is imported.

`406 passed`, `ruff` clean.

## Takeaway on size

The codebase is large because it genuinely does a lot (discovery, 6 entity platforms, config/options flow, `.nkb` import, manual config, diagnostics, repairs) — not because of dead weight. Trimming dead code won't move the needle. The real levers remain structural: splitting the discovery subsystem out of `coordinator.py`, and/or moving domain logic (`nkbmanual`, `nkbreconcile`) down to the library.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_