### PR TITLE
Land phase 1 on main (stacked-merge catch-up)

### DIFF
--- a/custom_components/nikobus/quality_scale.yaml
+++ b/custom_components/nikobus/quality_scale.yaml
@@ -8,12 +8,13 @@ rules:
   common-modules: done
   config-flow: done
   config-flow-test-coverage:
-    status: todo
+    status: done
     comment: |
-      Existing tests cover protocol/listener/command/coordinator/sensor.
-      A dedicated test_config_flow.py with the full success / cannot_connect /
-      unknown / already_configured / hardware-branch / reconfigure matrix is
-      pending the test-infrastructure swap to pytest-homeassistant-custom-component.
+      tests/test_config_flow.py covers the full matrix — success,
+      cannot_connect, unknown, already_configured (duplicate unique_id),
+      the hardware branch (feedback module vs polling step), reconfigure
+      (success + failure keeps the entry untouched) and the options menu —
+      against stub flow handlers returning HA-shaped FlowResult dicts.
   dependency-transparency: done
   docs-actions: done
   docs-high-level-description: done
@@ -44,11 +45,14 @@ rules:
       The Nikobus PC-Link bridge has no authentication; the integration
       only opens a serial or raw TCP socket.
   test-coverage:
-    status: todo
+    status: done
     comment: |
-      Core flows have tests but per-platform tests with snapshots and the
-      diagnostics test require the test-infrastructure swap to
-      pytest-homeassistant-custom-component (planned, separate PR).
+      Core flows, the config/options/reconfigure flow matrix
+      (test_config_flow.py), per-platform entity creation through the
+      real router (test_platform_setup.py), diagnostics
+      (test_diagnostics_quality.py), config-entry migration
+      (test_migration.py) and storage failure handling are all covered —
+      420+ tests against the stub-based harness in tests/conftest.py.
 
   # Gold
   devices: done

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,14 +68,72 @@ class _ConfigEntry:
         return cls
 
 
-class _ConfigFlow:
+class _AbortFlow(Exception):
+    """Stub of homeassistant.data_entry_flow.AbortFlow."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+class _FlowHandlerBase:
+    """Shared flow-result helpers mirroring HA's FlowHandler surface.
+
+    Steps return plain dicts shaped like HA's FlowResult so tests can
+    assert on ``type`` / ``step_id`` / ``errors`` without the real flow
+    framework.
+    """
+
+    hass = None
+
+    def async_show_form(self, *, step_id, data_schema=None, errors=None, **kw):
+        return {
+            "type": "form",
+            "step_id": step_id,
+            "data_schema": data_schema,
+            "errors": errors or {},
+        }
+
+    def async_show_menu(self, *, step_id, menu_options, **kw):
+        return {"type": "menu", "step_id": step_id, "menu_options": menu_options}
+
+    def async_create_entry(self, *, title=None, data=None, **kw):
+        return {"type": "create_entry", "title": title, "data": data}
+
+    def async_abort(self, *, reason):
+        return {"type": "abort", "reason": reason}
+
+
+class _ConfigFlow(_FlowHandlerBase):
     # Allow ``class X(ConfigFlow, domain="nikobus")`` subclassing.
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__()
 
+    #: Test hook — set to a set of unique_ids considered "already configured".
+    _configured_unique_ids: set | None = None
+    _unique_id = None
 
-class _OptionsFlow:
-    pass
+    async def async_set_unique_id(self, unique_id):
+        self._unique_id = unique_id
+
+    def _abort_if_unique_id_configured(self):
+        if self._configured_unique_ids and self._unique_id in self._configured_unique_ids:
+            raise _AbortFlow("already_configured")
+
+    #: Test hook — the entry returned by ``_get_reconfigure_entry``.
+    _reconfigure_entry = None
+
+    def _get_reconfigure_entry(self):
+        return self._reconfigure_entry
+
+    def async_update_reload_and_abort(self, entry, *, data=None, **kw):
+        entry.data = data
+        return {"type": "abort", "reason": "reconfigure_successful"}
+
+
+class _OptionsFlow(_FlowHandlerBase):
+    #: Test hook — assigned directly by tests (HA wires it via handler).
+    config_entry = None
 
 
 class _ConfigEntryState:
@@ -331,7 +389,7 @@ _mod(
     FileSelector=lambda *a, **k: None,
     FileSelectorConfig=lambda *a, **k: None,
 )
-_mod("homeassistant.data_entry_flow", FlowResult=dict)
+_mod("homeassistant.data_entry_flow", FlowResult=dict, AbortFlow=_AbortFlow)
 # homeassistant.components.file_upload — process_uploaded_file is patched
 # per-test; stub the module so config_flow's lazy import resolves.
 _mod("homeassistant.components.file_upload", process_uploaded_file=None)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,213 @@
+"""Config / reconfigure / options flow step tests.
+
+Phase-1 gold matrix: success path, connection errors, the hardware
+branch (feedback module present vs polling needed), reconfigure, and
+the options menu. The conftest flow stubs return HA-shaped FlowResult
+dicts, so each step is exercised as a plain coroutine.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.data_entry_flow import AbortFlow
+
+from custom_components.nikobus.config_flow import (
+    NikobusConfigFlow,
+    NikobusOptionsFlow,
+)
+from custom_components.nikobus.const import (
+    CONF_CONNECTION_STRING,
+    CONF_HAS_FEEDBACK_MODULE,
+    CONF_PRIOR_GEN3,
+    CONF_REFRESH_INTERVAL,
+)
+
+_TEST_CONN = "custom_components.nikobus.config_flow._test_connection"
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _flow() -> NikobusConfigFlow:
+    flow = NikobusConfigFlow()
+    flow.hass = MagicMock()
+    flow._configured_unique_ids = set()
+    return flow
+
+
+class TestConfigFlowUser(unittest.TestCase):
+    def test_shows_form_without_input(self):
+        result = _run(_flow().async_step_user(None))
+        self.assertEqual(result["type"], "form")
+        self.assertEqual(result["step_id"], "user")
+        self.assertEqual(result["errors"], {})
+
+    def test_success_advances_to_hardware(self):
+        flow = _flow()
+        with patch(_TEST_CONN, new=AsyncMock()) as conn:
+            result = _run(
+                flow.async_step_user({CONF_CONNECTION_STRING: " 192.168.2.50:9999 "})
+            )
+        # Connection string is stripped before testing + storing.
+        conn.assert_awaited_once_with(flow.hass, "192.168.2.50:9999")
+        self.assertEqual(result["type"], "form")
+        self.assertEqual(result["step_id"], "hardware")
+        self.assertEqual(flow._data[CONF_CONNECTION_STRING], "192.168.2.50:9999")
+
+    def test_cannot_connect_shows_error(self):
+        flow = _flow()
+        with patch(_TEST_CONN, new=AsyncMock(side_effect=ValueError("nope"))):
+            result = _run(
+                flow.async_step_user({CONF_CONNECTION_STRING: "/dev/ttyUSB0"})
+            )
+        self.assertEqual(result["type"], "form")
+        self.assertEqual(result["step_id"], "user")
+        self.assertEqual(result["errors"], {"base": "cannot_connect"})
+
+    def test_unexpected_error_shows_unknown(self):
+        flow = _flow()
+        with patch(_TEST_CONN, new=AsyncMock(side_effect=RuntimeError("boom"))):
+            result = _run(
+                flow.async_step_user({CONF_CONNECTION_STRING: "/dev/ttyUSB0"})
+            )
+        self.assertEqual(result["errors"], {"base": "unknown"})
+
+    def test_duplicate_connection_aborts(self):
+        flow = _flow()
+        # unique_id is the lower-cased connection string.
+        flow._configured_unique_ids = {"192.168.2.50:9999"}
+        with patch(_TEST_CONN, new=AsyncMock()):
+            with self.assertRaises(AbortFlow) as ctx:
+                _run(
+                    flow.async_step_user(
+                        {CONF_CONNECTION_STRING: "192.168.2.50:9999"}
+                    )
+                )
+        self.assertEqual(ctx.exception.reason, "already_configured")
+
+
+class TestConfigFlowHardwareBranch(unittest.TestCase):
+    def _flow_with_connection(self) -> NikobusConfigFlow:
+        flow = _flow()
+        flow._data[CONF_CONNECTION_STRING] = "host:1234"
+        return flow
+
+    def test_feedback_module_skips_polling(self):
+        # With a feedback module the bus pushes state — no polling step,
+        # the entry is created immediately with the default interval.
+        flow = self._flow_with_connection()
+        result = _run(
+            flow.async_step_hardware(
+                {CONF_HAS_FEEDBACK_MODULE: True, CONF_PRIOR_GEN3: False}
+            )
+        )
+        self.assertEqual(result["type"], "create_entry")
+        self.assertEqual(result["title"], "Nikobus (host:1234)")
+        self.assertTrue(result["data"][CONF_HAS_FEEDBACK_MODULE])
+        self.assertEqual(result["data"][CONF_REFRESH_INTERVAL], 120)
+
+    def test_no_feedback_module_requires_polling_step(self):
+        flow = self._flow_with_connection()
+        result = _run(
+            flow.async_step_hardware(
+                {CONF_HAS_FEEDBACK_MODULE: False, CONF_PRIOR_GEN3: False}
+            )
+        )
+        self.assertEqual(result["type"], "form")
+        self.assertEqual(result["step_id"], "polling")
+
+        result = _run(flow.async_step_polling({CONF_REFRESH_INTERVAL: 300}))
+        self.assertEqual(result["type"], "create_entry")
+        self.assertEqual(result["data"][CONF_REFRESH_INTERVAL], 300)
+        self.assertFalse(result["data"][CONF_HAS_FEEDBACK_MODULE])
+
+
+class TestReconfigureFlow(unittest.TestCase):
+    def _flow_with_entry(self) -> tuple[NikobusConfigFlow, MagicMock]:
+        flow = _flow()
+        entry = MagicMock()
+        entry.data = {CONF_CONNECTION_STRING: "old:1234"}
+        entry.options = {}
+        flow._reconfigure_entry = entry
+        return flow, entry
+
+    def test_success_updates_entry_and_aborts(self):
+        flow, entry = self._flow_with_entry()
+        new_input = {
+            CONF_CONNECTION_STRING: "new:5678",
+            CONF_HAS_FEEDBACK_MODULE: True,
+            CONF_PRIOR_GEN3: False,
+            CONF_REFRESH_INTERVAL: 120,
+        }
+        with patch(_TEST_CONN, new=AsyncMock()):
+            result = _run(flow.async_step_reconfigure(new_input))
+        self.assertEqual(result["type"], "abort")
+        self.assertEqual(result["reason"], "reconfigure_successful")
+        self.assertEqual(entry.data, new_input)
+
+    def test_cannot_connect_keeps_form(self):
+        flow, entry = self._flow_with_entry()
+        with patch(_TEST_CONN, new=AsyncMock(side_effect=ValueError("nope"))):
+            result = _run(
+                flow.async_step_reconfigure(
+                    {CONF_CONNECTION_STRING: "bad:0"}
+                )
+            )
+        self.assertEqual(result["type"], "form")
+        self.assertEqual(result["step_id"], "reconfigure")
+        self.assertEqual(result["errors"], {"base": "cannot_connect"})
+        # Entry untouched on failure.
+        self.assertEqual(entry.data, {CONF_CONNECTION_STRING: "old:1234"})
+
+
+class TestOptionsFlow(unittest.TestCase):
+    def _options_flow(self) -> NikobusOptionsFlow:
+        flow = NikobusOptionsFlow()
+        entry = MagicMock()
+        entry.data = {
+            CONF_CONNECTION_STRING: "host:1234",
+            CONF_HAS_FEEDBACK_MODULE: False,
+            CONF_REFRESH_INTERVAL: 120,
+        }
+        entry.options = {}
+        flow.config_entry = entry
+        return flow
+
+    def test_init_shows_menu(self):
+        result = _run(self._options_flow().async_step_init(None))
+        self.assertEqual(result["type"], "menu")
+        self.assertEqual(
+            result["menu_options"],
+            ["hardware", "configure_modules", "upload_nkb", "import_nkb"],
+        )
+
+    def test_hardware_with_feedback_creates_entry(self):
+        flow = self._options_flow()
+        result = _run(
+            flow.async_step_hardware(
+                {CONF_HAS_FEEDBACK_MODULE: True, CONF_PRIOR_GEN3: False}
+            )
+        )
+        self.assertEqual(result["type"], "create_entry")
+        self.assertTrue(result["data"][CONF_HAS_FEEDBACK_MODULE])
+
+    def test_hardware_without_feedback_goes_to_polling(self):
+        flow = self._options_flow()
+        result = _run(
+            flow.async_step_hardware(
+                {CONF_HAS_FEEDBACK_MODULE: False, CONF_PRIOR_GEN3: False}
+            )
+        )
+        self.assertEqual(result["type"], "form")
+        self.assertEqual(result["step_id"], "polling")
+        result = _run(flow.async_step_polling({CONF_REFRESH_INTERVAL: 600}))
+        self.assertEqual(result["type"], "create_entry")
+        self.assertEqual(result["data"][CONF_REFRESH_INTERVAL], 600)

--- a/tests/test_platform_setup.py
+++ b/tests/test_platform_setup.py
@@ -1,0 +1,175 @@
+"""Entity-creation tests for the output platforms' ``async_setup_entry``.
+
+Phase-1 gold matrix: feed a realistic ``dict_module_data`` through the
+real router (``get_routing``/``build_routing``) and assert each
+platform materialises the right entities — count, class, address,
+channel and unique_id uniqueness. Device-registry writes are patched
+out (``register_output_module_devices``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest.mock import MagicMock, patch
+
+import importlib
+
+# ``from custom_components.nikobus import light`` would resolve to the
+# *homeassistant.components.light* stub: the package __init__ imports the
+# HA platform modules under the same names, shadowing the submodules.
+# ``import_module`` returns the real submodule regardless.
+cover_platform = importlib.import_module("custom_components.nikobus.cover")
+light_platform = importlib.import_module("custom_components.nikobus.light")
+scene_platform = importlib.import_module("custom_components.nikobus.scene")
+switch_platform = importlib.import_module("custom_components.nikobus.switch")
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+_MODULE_DATA = {
+    "dimmer_module": {
+        "D1A2": {
+            "description": "Dimmer salon",
+            "model": "05-007-02",
+            "channels": [
+                {"description": "Spots salon"},
+                {"description": "Suspension"},
+            ],
+        }
+    },
+    "switch_module": {
+        "8110": {
+            "description": "Relais RDC",
+            "model": "05-000-02",
+            "channels": [
+                {"description": "Prise TV"},
+                {"description": "not_in_use 2"},  # legacy skip convention
+                {"description": "Cuisine", "entity_type": "disabled"},  # UI skip
+            ],
+        }
+    },
+    "roller_module": {
+        "C9A5": {
+            "description": "Volets étage",
+            "model": "05-001-02",
+            "channels": [{"description": "Volet chambre"}],
+        }
+    },
+}
+
+
+def _entry_and_coord():
+    coord = MagicMock()
+    coord.dict_module_data = _MODULE_DATA
+    entry = MagicMock()
+    entry.entry_id = "entry_test"
+    entry.runtime_data = coord
+    hass = MagicMock()
+    hass.data = {}
+    return hass, entry, coord
+
+
+class TestOutputPlatformSetup(unittest.TestCase):
+    def _setup(self, platform):
+        hass, entry, coord = _entry_and_coord()
+        added: list = []
+        with patch.object(
+            platform, "register_output_module_devices", MagicMock()
+        ):
+            _run(
+                platform.async_setup_entry(
+                    hass, entry, lambda ents, **kw: added.extend(ents)
+                )
+            )
+        return added
+
+    def test_light_platform_creates_dimmer_entities(self):
+        entities = self._setup(light_platform)
+        self.assertEqual(len(entities), 2)
+        for ent, channel in zip(entities, (1, 2)):
+            self.assertIsInstance(ent, light_platform.NikobusDimmerEntity)
+            self.assertEqual(ent._address, "D1A2")
+            self.assertEqual(ent._channel, channel)
+        # unique_ids must exist and be distinct.
+        uids = [e._attr_unique_id for e in entities]
+        self.assertEqual(len(set(uids)), 2)
+        self.assertTrue(all(uid for uid in uids))
+
+    def test_switch_platform_skips_unused_channels(self):
+        entities = self._setup(switch_platform)
+        # 3 catalogued channels, but "not_in_use" + "disabled" are skipped.
+        relays = [
+            e
+            for e in entities
+            if getattr(e, "_address", None) == "8110"
+        ]
+        self.assertEqual(len(relays), 1)
+        self.assertEqual(relays[0]._channel, 1)
+
+    def test_cover_platform_creates_cover(self):
+        entities = self._setup(cover_platform)
+        covers = [e for e in entities if getattr(e, "_address", None) == "C9A5"]
+        self.assertEqual(len(covers), 1)
+        self.assertEqual(covers[0]._channel, 1)
+
+    def test_routing_is_cached_per_entry(self):
+        hass, entry, coord = _entry_and_coord()
+        added: list = []
+        with patch.object(
+            light_platform, "register_output_module_devices", MagicMock()
+        ):
+            _run(
+                light_platform.async_setup_entry(
+                    hass, entry, lambda ents, **kw: added.extend(ents)
+                )
+            )
+        from custom_components.nikobus.router import _ROUTING_CACHE_KEY
+
+        self.assertIn(_ROUTING_CACHE_KEY, hass.data["nikobus"]["entry_test"])
+
+
+class TestScenePlatformSetup(unittest.TestCase):
+    def test_user_and_cf_scenes_created(self):
+        coord = MagicMock()
+        coord.dict_scene_data = {
+            "scene": [
+                {"id": "sc1", "description": "Soirée", "channels": []},
+                {"description": "sans id — ignorée"},
+            ]
+        }
+        coord.cf_storage.data = {
+            "nikobus_cf": {
+                "3841AA": {
+                    "pattern": "switch_pair",
+                    "outputs": [
+                        {"module_address": "8110", "channel": 1, "mode": "M01"}
+                    ],
+                    "triggered_by": ["3841AA"],
+                },
+                "garbage": "not-a-dict",  # ignored
+            }
+        }
+        entry = MagicMock()
+        entry.runtime_data = coord
+        added: list = []
+        _run(
+            scene_platform.async_setup_entry(
+                MagicMock(), entry, lambda ents, **kw: added.extend(ents)
+            )
+        )
+        user_scenes = [
+            e for e in added if isinstance(e, scene_platform.NikobusSceneEntity)
+        ]
+        cf_scenes = [
+            e for e in added if isinstance(e, scene_platform.NikobusCFSceneEntity)
+        ]
+        self.assertEqual(len(user_scenes), 1)
+        self.assertEqual(len(cf_scenes), 1)
+        self.assertEqual(cf_scenes[0]._bus_address, "3841AA")


### PR DESCRIPTION
## Why this PR

**Phase 1 (#449) was merged into its stacked base branch `claude/phase0-quality`, not into `main`** — GitHub only retargets a stacked PR when its base branch is deleted on merge, and #448 was merged with the branch kept. So `main` currently has phase 0 but **not** the phase-1 test coverage.

This PR is the catch-up: its diff is exactly the phase-1 content already reviewed and approved in **#449** (config-flow test matrix, platform entity-creation tests, conftest flow stubs, `quality_scale.yaml` todos → done). No new changes.

Tip for future stacked PRs: ticking *"delete branch on merge"* makes GitHub retarget the stacked PR automatically, avoiding this situation.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_