### PR TITLE
Land phase 5 (scene editor) on main (stacked-merge catch-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,9 @@ Selecting **Scenes** during a [`.nkb` import](#importing-from-your-nkb-project) 
 
 ### User-authored scenes (`nikobus_scene_config.json`)
 
-For HA-side per-channel groupings that **don't** exist as a CF on the bus. Loaded from `/config` at startup; a missing/empty file is fine. Dimmers/shutters use 0–255, switches `"on"`/`"off"`, shutters `"open"`/`"close"`.
+For HA-side per-channel groupings that **don't** exist as a CF on the bus. **Create, edit and delete them from the UI**: *Settings → Devices & Services → Nikobus → Configure → Manage scenes* — pick the module, channel and state per member; the integration writes the file and reloads the scene entities for you.
+
+The file lives in `/config` and is loaded at startup; a missing/empty file is fine, and you can still edit it by hand if you prefer. Dimmers use 0–255, switches `"on"`/`"off"`, shutters `"open"`/`"close"`/`"stop"`.
 
 ```json
 {

--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import logging
 import re
 from typing import Any
@@ -224,6 +225,49 @@ def _polling_schema(defaults: dict[str, Any]) -> vol.Schema:
     })
 
 
+# Valid scene-member states per output module type. Dimmer accepts a
+# 0-255 brightness level instead of a keyword (the README's documented
+# scene format).
+_SCENE_STATES_BY_TYPE: dict[str, tuple[str, ...]] = {
+    "switch_module": ("on", "off"),
+    "roller_module": ("open", "close", "stop"),
+    "dimmer_module": (),  # numeric 0-255
+}
+
+
+def _validate_scene_member(
+    module_type: str | None, module_entry: dict[str, Any], channel: int, state: str
+) -> tuple[bool, int]:
+    """Validate a scene member's state against its module type.
+
+    Returns ``(state_is_valid, channel_count)`` — the caller range-checks
+    the channel against the count separately for a distinct error message.
+    """
+    channels = module_entry.get("channels")
+    channel_count = len(channels) if isinstance(channels, list) and channels else 12
+    keywords = _SCENE_STATES_BY_TYPE.get(module_type or "")
+    if keywords is None:
+        return False, channel_count
+    if keywords:
+        return state in keywords, channel_count
+    # Dimmer: numeric brightness 0-255.
+    try:
+        return 0 <= int(state) <= 255, channel_count
+    except ValueError:
+        return False, channel_count
+
+
+def _unique_scene_id(description: str, existing_ids: set[Any]) -> str:
+    """Derive a stable, unique scene id from the user's description."""
+    slug = re.sub(r"[^a-z0-9]+", "_", description.lower()).strip("_") or "scene"
+    candidate = f"scene_{slug}"
+    suffix = 2
+    while candidate in existing_ids:
+        candidate = f"scene_{slug}_{suffix}"
+        suffix += 1
+    return candidate
+
+
 def _needs_polling(user_input: dict[str, Any]) -> bool:
     """Return True when the selected hardware requires a polling interval."""
     return not (
@@ -409,6 +453,9 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
         self._options: dict[str, Any] = {}
         self._edit_module_address: str | None = None
         self._edit_channel_index: int | None = None
+        # Scene-editor working copy (mutated across steps, persisted on save).
+        self._scene_work: dict[str, Any] | None = None
+        self._scene_is_new: bool = False
 
     def _current(self) -> dict[str, Any]:
         """Merge entry data + options so defaults reflect the live settings."""
@@ -436,7 +483,13 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
         the declarative source of truth. Users on manual-config should
         edit the JSON files directly to make customisations stick.
         """
-        menu_options = ["hardware", "configure_modules", "upload_nkb", "import_nkb"]
+        menu_options = [
+            "hardware",
+            "configure_modules",
+            "manage_scenes",
+            "upload_nkb",
+            "import_nkb",
+        ]
         return self.async_show_menu(
             step_id="init",
             menu_options=menu_options,
@@ -859,3 +912,242 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
             errors=errors,
         )
 
+
+    # --- Scene editor -------------------------------------------------------
+    #
+    # CRUD over the user-authored scenes in ``nikobus_scene_config.json``
+    # (previously hand-edited JSON — see README "User-authored scenes").
+    # The flow works on a deep copy (``self._scene_work``) and only writes
+    # the file on the explicit save/delete actions; closing the flow midway
+    # changes nothing. Saving ends the flow via ``async_create_entry`` so
+    # the entry's update listener reloads the scene platform.
+
+    async def async_step_manage_scenes(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.FlowResult:
+        """Pick a scene to edit, or create a new one."""
+        coordinator = self._coordinator()
+        if coordinator is None:
+            return self.async_abort(reason="not_loaded")
+
+        scenes = coordinator.dict_scene_data.get("scene", []) or []
+
+        if user_input is not None:
+            selected = user_input["scene"]
+            if selected == "__create__":
+                self._scene_work = {"id": "", "description": "", "channels": []}
+                self._scene_is_new = True
+            else:
+                hit = next(
+                    (sc for sc in scenes if isinstance(sc, dict) and sc.get("id") == selected),
+                    None,
+                )
+                if hit is None:
+                    return self.async_abort(reason="scene_not_found")
+                self._scene_work = copy.deepcopy(hit)
+                self._scene_is_new = False
+            return await self.async_step_scene_editor()
+
+        options = [{"value": "__create__", "label": "+ Create a new scene"}]
+        options += [
+            {
+                "value": str(sc.get("id")),
+                "label": (
+                    f"{sc.get('description') or sc.get('id')} "
+                    f"({len(sc.get('channels') or [])} channel(s))"
+                ),
+            }
+            for sc in scenes
+            if isinstance(sc, dict) and sc.get("id")
+        ]
+        return self.async_show_form(
+            step_id="manage_scenes",
+            data_schema=vol.Schema({
+                vol.Required("scene", default="__create__"): SelectSelector(
+                    SelectSelectorConfig(options=options, mode=SelectSelectorMode.LIST)
+                ),
+            }),
+        )
+
+    async def async_step_scene_editor(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.FlowResult:
+        """Edit the working scene: name + next action."""
+        coordinator = self._coordinator()
+        if coordinator is None or self._scene_work is None:
+            return self.async_abort(reason="not_loaded")
+        work = self._scene_work
+
+        if user_input is not None:
+            desc = (user_input.get("description") or "").strip()
+            if desc:
+                work["description"] = desc
+            action = user_input["action"]
+            if action == "add_member":
+                return await self.async_step_scene_member()
+            if action == "remove_member":
+                return await self.async_step_scene_remove_member()
+            if action == "delete":
+                return await self._delete_scene()
+            return await self._save_scene()
+
+        members = work.get("channels") or []
+        summary = ", ".join(
+            f"{m.get('module_id')}/{m.get('channel')}={m.get('state')}"
+            for m in members
+            if isinstance(m, dict)
+        ) or "none"
+        actions = ["add_member"]
+        if members:
+            actions.append("remove_member")
+        actions.append("save")
+        if not self._scene_is_new:
+            actions.append("delete")
+        return self.async_show_form(
+            step_id="scene_editor",
+            data_schema=vol.Schema({
+                vol.Optional(
+                    "description", default=work.get("description") or ""
+                ): TextSelector(TextSelectorConfig()),
+                vol.Required("action", default="save"): SelectSelector(
+                    SelectSelectorConfig(
+                        options=actions,
+                        mode=SelectSelectorMode.LIST,
+                        translation_key="scene_action",
+                    )
+                ),
+            }),
+            description_placeholders={"members": summary},
+        )
+
+    async def async_step_scene_member(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.FlowResult:
+        """Add one (module, channel, state) member to the working scene."""
+        coordinator = self._coordinator()
+        if coordinator is None or self._scene_work is None:
+            return self.async_abort(reason="not_loaded")
+        modules = coordinator.module_storage.data.get("nikobus_module") or {}
+        # Scenes drive output channels only.
+        output_modules = {
+            addr: entry
+            for addr, entry in modules.items()
+            if isinstance(entry, dict)
+            and entry.get("module_type") in _SCENE_STATES_BY_TYPE
+        }
+        if not output_modules:
+            return self.async_abort(reason="no_modules")
+
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            address = str(user_input["module"]).upper()
+            channel = int(user_input["channel"])
+            state = str(user_input.get("state") or "").strip().lower()
+            module_type = (output_modules.get(address) or {}).get("module_type")
+            valid, channel_count = _validate_scene_member(
+                module_type, output_modules.get(address) or {}, channel, state
+            )
+            if not (1 <= channel <= channel_count):
+                errors["base"] = "invalid_scene_channel"
+            elif not valid:
+                errors["base"] = "invalid_scene_state"
+            else:
+                self._scene_work.setdefault("channels", []).append({
+                    "module_id": address,
+                    "channel": str(channel),
+                    "state": state,
+                })
+                return await self.async_step_scene_editor()
+
+        options = [
+            {"value": addr, "label": _module_label(addr, entry)}
+            for addr, entry in sorted(
+                output_modules.items(),
+                key=lambda kv: (_module_type_order(kv[1].get("module_type")), kv[0]),
+            )
+        ]
+        return self.async_show_form(
+            step_id="scene_member",
+            data_schema=vol.Schema({
+                vol.Required("module"): SelectSelector(
+                    SelectSelectorConfig(options=options, mode=SelectSelectorMode.DROPDOWN)
+                ),
+                vol.Required("channel", default=1): NumberSelector(
+                    NumberSelectorConfig(min=1, max=12, step=1, mode=NumberSelectorMode.BOX)
+                ),
+                vol.Required("state", default="on"): TextSelector(TextSelectorConfig()),
+            }),
+            errors=errors,
+        )
+
+    async def async_step_scene_remove_member(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.FlowResult:
+        """Remove one member from the working scene."""
+        if self._scene_work is None:
+            return self.async_abort(reason="not_loaded")
+        members = self._scene_work.get("channels") or []
+
+        if user_input is not None:
+            idx = int(user_input["member"])
+            if 0 <= idx < len(members):
+                members.pop(idx)
+            return await self.async_step_scene_editor()
+
+        options = [
+            {
+                "value": str(idx),
+                "label": f"{m.get('module_id')} channel {m.get('channel')} -> {m.get('state')}",
+            }
+            for idx, m in enumerate(members)
+            if isinstance(m, dict)
+        ]
+        return self.async_show_form(
+            step_id="scene_remove_member",
+            data_schema=vol.Schema({
+                vol.Required("member"): SelectSelector(
+                    SelectSelectorConfig(options=options, mode=SelectSelectorMode.LIST)
+                ),
+            }),
+        )
+
+    async def _save_scene(self) -> config_entries.FlowResult:
+        """Persist the working scene to the store + JSON file and finish."""
+        coordinator = self._coordinator()
+        assert coordinator is not None and self._scene_work is not None
+        work = self._scene_work
+        scenes: list[dict[str, Any]] = coordinator.dict_scene_data.setdefault("scene", [])
+
+        if self._scene_is_new:
+            existing_ids = {sc.get("id") for sc in scenes if isinstance(sc, dict)}
+            work["id"] = _unique_scene_id(work.get("description") or "scene", existing_ids)
+            scenes.append(work)
+        else:
+            for pos, sc in enumerate(scenes):
+                if isinstance(sc, dict) and sc.get("id") == work.get("id"):
+                    scenes[pos] = work
+                    break
+
+        await coordinator.nikobus_config.save_json_data(
+            "nikobus_scene_config.json", "scene", coordinator.dict_scene_data
+        )
+        # Close the flow; the entry update listener reloads the scene platform.
+        return self.async_create_entry(
+            data={**self.config_entry.options, **self._options}
+        )
+
+    async def _delete_scene(self) -> config_entries.FlowResult:
+        """Remove the working scene from the store + JSON file and finish."""
+        coordinator = self._coordinator()
+        assert coordinator is not None and self._scene_work is not None
+        scene_id = self._scene_work.get("id")
+        scenes = coordinator.dict_scene_data.get("scene", [])
+        coordinator.dict_scene_data["scene"] = [
+            sc for sc in scenes if not (isinstance(sc, dict) and sc.get("id") == scene_id)
+        ]
+        await coordinator.nikobus_config.save_json_data(
+            "nikobus_scene_config.json", "scene", coordinator.dict_scene_data
+        )
+        return self.async_create_entry(
+            data={**self.config_entry.options, **self._options}
+        )

--- a/custom_components/nikobus/nkbconfig.py
+++ b/custom_components/nikobus/nkbconfig.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 from typing import Any
 
 from aiofiles import open as aio_open
@@ -50,6 +51,26 @@ class NikobusConfig:
         except Exception as err:
             _LOGGER.error("Failed to load %s data: %s", data_type, err, exc_info=True)
             raise NikobusDataError(f"Failed to load {data_type} data: {err}") from err
+
+    async def save_json_data(
+        self, file_name: str, data_type: str, data: dict[str, Any]
+    ) -> None:
+        """Persist JSON data to a config file in the HA config directory.
+
+        Write-then-rename so a crash mid-write can't truncate the
+        existing file (the scene editor writes user-authored data the
+        user has no other copy of).
+        """
+        file_path = self._hass.config.path(file_name)
+        tmp_path = f"{file_path}.tmp"
+        _LOGGER.info("Saving %s data to %s", data_type, file_path)
+        try:
+            async with aio_open(tmp_path, mode="w") as file:
+                await file.write(json.dumps(data, indent=4, ensure_ascii=False))
+            await asyncio.to_thread(os.replace, tmp_path, file_path)
+        except OSError as err:
+            _LOGGER.error("Failed to save %s data: %s", data_type, err, exc_info=True)
+            raise NikobusDataError(f"Failed to save {data_type} data: {err}") from err
 
     def _handle_file_not_found(self, file_path: str, data_type: str) -> None:
         """Handle the case where the configuration file is not found."""

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -175,7 +175,8 @@
     "abort": {
       "not_loaded": "The Nikobus integration is not loaded. Please reload the integration and try again.",
       "module_not_found": "The selected module was not found in storage.",
-      "channel_not_found": "The selected channel was not found."
+      "channel_not_found": "The selected channel was not found.",
+      "scene_not_found": "Scene not found — it may have been removed."
     },
     "error": {
       "invalid_hex_address": "LED address must be exactly 6 hexadecimal characters (or empty).",
@@ -183,7 +184,9 @@
       "upload_failed": "Could not save the uploaded file. Check the Home Assistant logs.",
       "nkb_nothing_selected": "Pick at least one thing to import.",
       "nkb_not_found": "No .nkb file found — upload one first (Configure → Upload .nkb project file).",
-      "nkb_parse_failed": "Could not read the .nkb file. See the Home Assistant logs."
+      "nkb_parse_failed": "Could not read the .nkb file. See the Home Assistant logs.",
+      "invalid_scene_state": "Invalid state for this module type ('on'/'off', 'open'/'close'/'stop', or 0-255 for dimmers).",
+      "invalid_scene_channel": "Channel number is out of range for this module."
     },
     "step": {
       "hardware": {
@@ -206,7 +209,8 @@
           "configure_modules": "Customize a module (description, entity type, LED triggers, travel time)",
           "hardware": "Change hardware settings",
           "upload_nkb": "Upload .nkb project file",
-          "import_nkb": "Import from .nkb (choose what)"
+          "import_nkb": "Import from .nkb (choose what)",
+          "manage_scenes": "Manage scenes (create / edit / delete)"
         },
         "title": "Nikobus"
       },
@@ -264,6 +268,36 @@
           "areas": "Areas (from rooms)",
           "scenes": "Scenes (light + shutter/master)",
           "overwrite": "Overwrite names/Areas I've already set"
+        }
+      },
+      "manage_scenes": {
+        "title": "Scenes",
+        "description": "Pick a scene to edit, or create a new one. Scenes are stored in nikobus_scene_config.json.",
+        "data": {
+          "scene": "Scene"
+        }
+      },
+      "scene_editor": {
+        "title": "Edit scene",
+        "description": "Current channels: {members}",
+        "data": {
+          "description": "Scene name",
+          "action": "Action"
+        }
+      },
+      "scene_member": {
+        "title": "Add a channel",
+        "description": "State: 'on'/'off' for switches, 'open'/'close'/'stop' for shutters, 0-255 for dimmers.",
+        "data": {
+          "module": "Module",
+          "channel": "Channel",
+          "state": "State"
+        }
+      },
+      "scene_remove_member": {
+        "title": "Remove a channel",
+        "data": {
+          "member": "Channel to remove"
         }
       }
     }
@@ -354,6 +388,14 @@
         "switch": "Switch",
         "light": "Light",
         "disabled": "Disabled (hide channel)"
+      }
+    },
+    "scene_action": {
+      "options": {
+        "add_member": "Add a channel",
+        "remove_member": "Remove a channel",
+        "save": "Save scene",
+        "delete": "Delete scene"
       }
     }
   }

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -69,7 +69,8 @@
           "hardware": "Modifier la configuration matérielle",
           "configure_modules": "Personnaliser un module (description, type d'entité, déclencheurs LED, temps de course)",
           "upload_nkb": "Téléverser le fichier projet .nkb",
-          "import_nkb": "Importer depuis .nkb (choisir)"
+          "import_nkb": "Importer depuis .nkb (choisir)",
+          "manage_scenes": "Gérer les scènes (créer / modifier / supprimer)"
         }
       },
       "hardware": {
@@ -141,12 +142,43 @@
           "scenes": "Scènes (lumière + volets/maître)",
           "overwrite": "Écraser les noms/zones que j'ai déjà définis"
         }
+      },
+      "manage_scenes": {
+        "title": "Scènes",
+        "description": "Choisissez une scène à modifier, ou créez-en une nouvelle. Les scènes sont stockées dans nikobus_scene_config.json.",
+        "data": {
+          "scene": "Scène"
+        }
+      },
+      "scene_editor": {
+        "title": "Modifier la scène",
+        "description": "Canaux actuels : {members}",
+        "data": {
+          "description": "Nom de la scène",
+          "action": "Action"
+        }
+      },
+      "scene_member": {
+        "title": "Ajouter un canal",
+        "description": "État : 'on'/'off' pour les relais, 'open'/'close'/'stop' pour les volets, 0-255 pour les variateurs.",
+        "data": {
+          "module": "Module",
+          "channel": "Canal",
+          "state": "État"
+        }
+      },
+      "scene_remove_member": {
+        "title": "Retirer un canal",
+        "data": {
+          "member": "Canal à retirer"
+        }
       }
     },
     "abort": {
       "not_loaded": "L'intégration Nikobus n'est pas chargée. Veuillez la recharger puis réessayer.",
       "channel_not_found": "Le canal sélectionné est introuvable.",
-      "module_not_found": "Le module sélectionné est introuvable dans le stockage."
+      "module_not_found": "Le module sélectionné est introuvable dans le stockage.",
+      "scene_not_found": "Scène introuvable — elle a peut-être été supprimée."
     },
     "error": {
       "invalid_nkb": "Ce fichier n'est pas un projet Nikobus .nkb lisible (il doit s'agir de l'export .nkb — une archive ZIP contenant la base de données du projet).",
@@ -154,7 +186,9 @@
       "nkb_nothing_selected": "Choisissez au moins un élément à importer.",
       "nkb_not_found": "Aucun fichier .nkb trouvé — téléversez-en un d'abord (Configurer → Téléverser le fichier projet .nkb).",
       "nkb_parse_failed": "Impossible de lire le fichier .nkb. Consultez les journaux Home Assistant.",
-      "invalid_hex_address": "L'adresse de la LED doit comporter exactement 6 caractères hexadécimaux (ou être vide)."
+      "invalid_hex_address": "L'adresse de la LED doit comporter exactement 6 caractères hexadécimaux (ou être vide).",
+      "invalid_scene_state": "État invalide pour ce type de module ('on'/'off', 'open'/'close'/'stop', ou 0-255 pour un variateur).",
+      "invalid_scene_channel": "Numéro de canal hors limites pour ce module."
     }
   },
   "entity": {
@@ -296,6 +330,14 @@
         "switch": "Interrupteur",
         "light": "Lumière",
         "disabled": "Désactivé (masquer le canal)"
+      }
+    },
+    "scene_action": {
+      "options": {
+        "add_member": "Ajouter un canal",
+        "remove_member": "Retirer un canal",
+        "save": "Enregistrer la scène",
+        "delete": "Supprimer la scène"
       }
     }
   },

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -69,7 +69,8 @@
           "hardware": "Hardware-instellingen wijzigen",
           "configure_modules": "Module aanpassen (beschrijving, entiteitstype, LED-triggers, looptijd)",
           "upload_nkb": "Projectbestand .nkb uploaden",
-          "import_nkb": "Importeren uit .nkb (kiezen)"
+          "import_nkb": "Importeren uit .nkb (kiezen)",
+          "manage_scenes": "Scènes beheren (aanmaken / bewerken / verwijderen)"
         }
       },
       "hardware": {
@@ -141,12 +142,43 @@
           "scenes": "Scènes (licht + rolluik/master)",
           "overwrite": "Namen/gebieden die ik al heb ingesteld overschrijven"
         }
+      },
+      "manage_scenes": {
+        "title": "Scènes",
+        "description": "Kies een scène om te bewerken, of maak een nieuwe aan. Scènes worden opgeslagen in nikobus_scene_config.json.",
+        "data": {
+          "scene": "Scène"
+        }
+      },
+      "scene_editor": {
+        "title": "Scène bewerken",
+        "description": "Huidige kanalen: {members}",
+        "data": {
+          "description": "Naam van de scène",
+          "action": "Actie"
+        }
+      },
+      "scene_member": {
+        "title": "Kanaal toevoegen",
+        "description": "Status: 'on'/'off' voor relais, 'open'/'close'/'stop' voor rolluiken, 0-255 voor dimmers.",
+        "data": {
+          "module": "Module",
+          "channel": "Kanaal",
+          "state": "Status"
+        }
+      },
+      "scene_remove_member": {
+        "title": "Kanaal verwijderen",
+        "data": {
+          "member": "Te verwijderen kanaal"
+        }
       }
     },
     "abort": {
       "not_loaded": "De Nikobus-integratie is niet geladen. Herlaad de integratie en probeer het opnieuw.",
       "channel_not_found": "Het geselecteerde kanaal is niet gevonden.",
-      "module_not_found": "De geselecteerde module is niet gevonden in de opslag."
+      "module_not_found": "De geselecteerde module is niet gevonden in de opslag.",
+      "scene_not_found": "Scène niet gevonden — mogelijk verwijderd."
     },
     "error": {
       "invalid_nkb": "Dit bestand is geen leesbaar Nikobus .nkb-project (het moet de .nkb-export zijn — een ZIP met de projectdatabase).",
@@ -154,7 +186,9 @@
       "nkb_nothing_selected": "Kies minstens één ding om te importeren.",
       "nkb_not_found": "Geen .nkb-bestand gevonden — upload er eerst een (Configureren → Projectbestand .nkb uploaden).",
       "nkb_parse_failed": "Kon het .nkb-bestand niet lezen. Zie de Home Assistant-logboeken.",
-      "invalid_hex_address": "Het LED-adres moet exact 6 hexadecimale tekens bevatten (of leeg zijn)."
+      "invalid_hex_address": "Het LED-adres moet exact 6 hexadecimale tekens bevatten (of leeg zijn).",
+      "invalid_scene_state": "Ongeldige status voor dit moduletype ('on'/'off', 'open'/'close'/'stop', of 0-255 voor dimmers).",
+      "invalid_scene_channel": "Kanaalnummer valt buiten het bereik van deze module."
     }
   },
   "entity": {
@@ -296,6 +330,14 @@
         "switch": "Schakelaar",
         "light": "Lamp",
         "disabled": "Uitgeschakeld (kanaal verbergen)"
+      }
+    },
+    "scene_action": {
+      "options": {
+        "add_member": "Kanaal toevoegen",
+        "remove_member": "Kanaal verwijderen",
+        "save": "Scène opslaan",
+        "delete": "Scène verwijderen"
       }
     }
   },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -186,7 +186,13 @@ class TestOptionsFlow(unittest.TestCase):
         self.assertEqual(result["type"], "menu")
         self.assertEqual(
             result["menu_options"],
-            ["hardware", "configure_modules", "upload_nkb", "import_nkb"],
+            [
+                "hardware",
+                "configure_modules",
+                "manage_scenes",
+                "upload_nkb",
+                "import_nkb",
+            ],
         )
 
     def test_hardware_with_feedback_creates_entry(self):
@@ -211,3 +217,112 @@ class TestOptionsFlow(unittest.TestCase):
         result = _run(flow.async_step_polling({CONF_REFRESH_INTERVAL: 600}))
         self.assertEqual(result["type"], "create_entry")
         self.assertEqual(result["data"][CONF_REFRESH_INTERVAL], 600)
+
+
+class TestSceneEditor(unittest.TestCase):
+    """Options-flow scene editor: create / add member / save / delete."""
+
+    def _flow_with_store(self, scenes=None):
+        flow = NikobusOptionsFlow()
+        coord = MagicMock()
+        coord.dict_scene_data = {"scene": list(scenes or [])}
+        coord.module_storage.data = {
+            "nikobus_module": {
+                "8110": {
+                    "module_type": "switch_module",
+                    "description": "Relais RDC",
+                    "channels": [{"description": f"ch{i}"} for i in range(1, 5)],
+                },
+                "D1A2": {
+                    "module_type": "dimmer_module",
+                    "description": "Dimmer salon",
+                    "channels": [{"description": "spots"}],
+                },
+                "940C": {"module_type": "pc_logic", "channels": []},  # not scene-able
+            }
+        }
+        coord.nikobus_config.save_json_data = AsyncMock()
+        entry = MagicMock()
+        entry.runtime_data = coord
+        entry.options = {}
+        entry.data = {}
+        flow.config_entry = entry
+        return flow, coord
+
+    def test_manage_scenes_lists_existing_and_create(self):
+        flow, _ = self._flow_with_store(
+            scenes=[{"id": "scene_soiree", "description": "Soirée", "channels": []}]
+        )
+        result = _run(flow.async_step_manage_scenes(None))
+        self.assertEqual(result["step_id"], "manage_scenes")
+
+    def test_create_scene_add_member_and_save(self):
+        flow, coord = self._flow_with_store()
+        # Create → editor
+        result = _run(flow.async_step_manage_scenes({"scene": "__create__"}))
+        self.assertEqual(result["step_id"], "scene_editor")
+        # Name it + add a member
+        result = _run(
+            flow.async_step_scene_editor(
+                {"description": "Tout éteindre", "action": "add_member"}
+            )
+        )
+        self.assertEqual(result["step_id"], "scene_member")
+        result = _run(
+            flow.async_step_scene_member(
+                {"module": "8110", "channel": 2, "state": "off"}
+            )
+        )
+        self.assertEqual(result["step_id"], "scene_editor")
+        # Save
+        result = _run(flow.async_step_scene_editor({"action": "save"}))
+        self.assertEqual(result["type"], "create_entry")
+        coord.nikobus_config.save_json_data.assert_awaited_once()
+        scenes = coord.dict_scene_data["scene"]
+        self.assertEqual(len(scenes), 1)
+        self.assertEqual(scenes[0]["id"], "scene_tout_teindre")
+        self.assertEqual(
+            scenes[0]["channels"],
+            [{"module_id": "8110", "channel": "2", "state": "off"}],
+        )
+
+    def test_member_validation_rejects_bad_state_and_channel(self):
+        flow, _ = self._flow_with_store()
+        _run(flow.async_step_manage_scenes({"scene": "__create__"}))
+        # switch with a dimmer level → invalid state
+        result = _run(
+            flow.async_step_scene_member({"module": "8110", "channel": 1, "state": "128"})
+        )
+        self.assertEqual(result["errors"], {"base": "invalid_scene_state"})
+        # channel out of range (module has 4)
+        result = _run(
+            flow.async_step_scene_member({"module": "8110", "channel": 9, "state": "on"})
+        )
+        self.assertEqual(result["errors"], {"base": "invalid_scene_channel"})
+        # dimmer accepts a numeric level
+        result = _run(
+            flow.async_step_scene_member({"module": "D1A2", "channel": 1, "state": "128"})
+        )
+        self.assertEqual(result["step_id"], "scene_editor")
+
+    def test_delete_scene_removes_and_saves(self):
+        flow, coord = self._flow_with_store(
+            scenes=[{"id": "scene_x", "description": "X", "channels": [
+                {"module_id": "8110", "channel": "1", "state": "on"},
+            ]}]
+        )
+        result = _run(flow.async_step_manage_scenes({"scene": "scene_x"}))
+        self.assertEqual(result["step_id"], "scene_editor")
+        result = _run(flow.async_step_scene_editor({"action": "delete"}))
+        self.assertEqual(result["type"], "create_entry")
+        self.assertEqual(coord.dict_scene_data["scene"], [])
+        coord.nikobus_config.save_json_data.assert_awaited_once()
+
+    def test_unique_id_suffix_on_collision(self):
+        flow, coord = self._flow_with_store(
+            scenes=[{"id": "scene_test", "description": "Test", "channels": []}]
+        )
+        _run(flow.async_step_manage_scenes({"scene": "__create__"}))
+        _run(flow.async_step_scene_editor({"description": "Test", "action": "save"}))
+        ids = [sc["id"] for sc in coord.dict_scene_data["scene"]]
+        self.assertEqual(ids, ["scene_test", "scene_test_2"])


### PR DESCRIPTION
## Why this PR

Same stacked-merge situation as #450: **#451 was merged into its base branch `claude/phase0-quality`, not into `main`** (the base branch wasn't deleted when #450 merged, so GitHub didn't retarget). `main` is missing the scene editor.

This catch-up PR's diff is exactly the phase-5 content already reviewed and approved in **#451** (options-flow scene editor, atomic JSON save, en/fr/nl translations, README, +5 tests). No new changes.

After merging, **deleting `claude/phase0-quality`** is safe — everything it carries will be on `main`.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_