### PR TITLE
Land the 0.27.0 consumption on main (final stacked-merge catch-up)

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -16,7 +16,13 @@ from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from nikobus_connect import NikobusAPI, NikobusCommandHandler, NikobusConnect, NikobusEventListener
+from nikobus_connect import (
+    CoordinatorProtocol,
+    NikobusAPI,
+    NikobusCommandHandler,
+    NikobusConnect,
+    NikobusEventListener,
+)
 from nikobus_connect.discovery import (
     NikobusDiscovery,
     InventoryQueryType,
@@ -155,20 +161,16 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
         self._module_states: dict[str, bytearray] = {}
 
         self.discovery_running = False
-        # The following are written by nikobus-connect, which holds this
-        # coordinator as ``self._coordinator`` and assigns these attributes
-        # cross-object during discovery. They look unassigned to a grep of
-        # THIS file — the writer is in the library — so do NOT remove them:
-        # the library both writes and READS them (e.g. ``if not
-        # self._coordinator.discovery_module``), and a missing seed here
-        # would raise AttributeError if the library reads before its first
-        # write.
-        #   * ``discovery_module`` / ``discovery_module_address`` — current
-        #     per-module register-scan target; read in the library's frame
-        #     routing.
-        #   * ``inventory_query_type`` — PC_LINK / MODULE phase marker, read
-        #     by ``_inventory_callback`` / ``_discovery_frame_callback`` to
-        #     route $18 / $2E / $1E frames.
+        # ``discovery_module`` / ``discovery_module_address`` /
+        # ``inventory_query_type`` are part of the
+        # ``nikobus_connect.CoordinatorProtocol`` contract: the library
+        # holds this coordinator as ``self._coordinator`` and both writes
+        # and reads them during discovery (per-module register-scan
+        # target + the PC_LINK / MODULE phase marker that routes
+        # $18 / $2E / $1E frames). The ``_implements_coordinator_protocol``
+        # check at the bottom of this module makes mypy verify the full
+        # surface, so a removal here is a type error, not a runtime
+        # AttributeError mid-scan.
         self.discovery_module = None
         self.discovery_module_address: str | None = None
         self.inventory_query_type: InventoryQueryType | None = None
@@ -1190,44 +1192,35 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
         )
 
     async def _reconnect_loop(self) -> None:
-        """Exponential back-off reconnect loop."""
-        delay = RECONNECT_DELAY_INITIAL
-        attempt = 0
-        while not self._stopping:
-            attempt += 1
+        """Reconnect via the library's backoff primitive, then restart
+        the subsystems.
+
+        nikobus-connect 0.27.0 owns the transport part (exponential
+        capped backoff, handshake, cancellation) and the per-connection
+        state clearing (``command.reset()`` / ``listener.reset()``) —
+        this loop only orchestrates the HA side: availability updates,
+        subsystem restart, and the first refresh.
+        """
+
+        def _on_attempt(attempt: int, _delay: float) -> None:
             self._reconnect_attempts += 1
-            _LOGGER.info("Nikobus reconnect attempt %d (delay %ds)", attempt, delay)
             self.async_update_listeners()
+
+        while not self._stopping:
             try:
-                await self.nikobus_connection.connect()
+                attempts = await self.nikobus_connection.reconnect_with_backoff(
+                    initial_delay=RECONNECT_DELAY_INITIAL,
+                    max_delay=RECONNECT_DELAY_MAX,
+                    on_attempt=_on_attempt,
+                )
             except asyncio.CancelledError:
-                raise
-            except Exception as err:
-                _LOGGER.warning("Reconnect %d failed: %s — retrying in %ds", attempt, err, delay)
-                try:
-                    await asyncio.sleep(delay)
-                except asyncio.CancelledError:
-                    return
-                delay = min(delay * 2, RECONNECT_DELAY_MAX)
-                continue
+                return  # stop() cancelled the reconnect task
 
             try:
-                # Drain stale queue entries and reset listener state
-                while not self.nikobus_command._command_queue.empty():
-                    try:
-                        self.nikobus_command._command_queue.get_nowait()
-                    except asyncio.QueueEmpty:
-                        break
-                self.nikobus_command._queued_get_keys.clear()
-
-                self.nikobus_listener._frame_buffer = ""
-                self.nikobus_listener._last_query_group.clear()
-                while not self.nikobus_listener.response_queue.empty():
-                    try:
-                        self.nikobus_listener.response_queue.get_nowait()
-                    except asyncio.QueueEmpty:
-                        break
-
+                # Clear state queued against the dead connection, then
+                # bring the pipeline back up on the new one.
+                self.nikobus_command.reset()
+                self.nikobus_listener.reset()
                 await self.nikobus_command.start()
                 self.nikobus_listener.on_connection_lost = self._handle_connection_lost
                 await self.nikobus_listener.start()
@@ -1235,18 +1228,13 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
                 self._reconnect_attempts = 0
                 await self._async_update_data()
                 self.async_update_listeners()
-                _LOGGER.info("Nikobus reconnected after %d attempt(s)", attempt)
+                _LOGGER.info("Nikobus reconnected after %d attempt(s)", attempts)
                 return
             except asyncio.CancelledError:
                 raise
             except Exception:
                 _LOGGER.exception("Subsystem restart failed after reconnect — retrying")
                 await self.nikobus_connection.disconnect()
-                try:
-                    await asyncio.sleep(delay)
-                except asyncio.CancelledError:
-                    return
-                delay = min(delay * 2, RECONNECT_DELAY_MAX)
 
     # ------------------------------------------------------------------
     # Stop
@@ -1407,3 +1395,14 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
         # Clear the cached router spec so newly-discovered modules show up.
         self._invalidate_routing_cache()
 
+
+
+def _implements_coordinator_protocol(
+    coordinator: NikobusDataCoordinator,
+) -> "CoordinatorProtocol":
+    """mypy-time structural check: the coordinator satisfies the library's
+    ``CoordinatorProtocol`` (nikobus-connect 0.27.0+). Never called at
+    runtime — if a contract member is removed from this class, this
+    function stops type-checking instead of discovery failing with an
+    AttributeError mid-scan."""
+    return coordinator

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -1,19 +1,26 @@
 {
   "domain": "nikobus",
   "name": "Nikobus",
-  "codeowners": ["@fdebrus"],
+  "codeowners": [
+    "@fdebrus"
+  ],
   "config_flow": true,
-  "dependencies": ["file_upload"],
+  "dependencies": [
+    "file_upload"
+  ],
   "documentation": "https://github.com/fdebrus/nikobus-ha",
   "integration_type": "hub",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/fdebrus/nikobus-ha/issues",
-  "loggers": ["nikobus", "nikobus_connect"],
+  "loggers": [
+    "nikobus",
+    "nikobus_connect"
+  ],
   "quality_scale": "gold",
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.26.0"
+    "nikobus-connect>=0.27.0"
   ],
   "version": "3.8.3"
 }

--- a/tests/test_reconnect.py
+++ b/tests/test_reconnect.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import unittest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 from custom_components.nikobus.coordinator import NikobusDataCoordinator
 from custom_components.nikobus.const import RECONNECT_DELAY_INITIAL, RECONNECT_DELAY_MAX
@@ -52,15 +52,19 @@ def _make_coordinator():
     coord.nikobus_connection.is_connected = False
     coord.nikobus_connection.connect = AsyncMock()
     coord.nikobus_connection.disconnect = AsyncMock()
+    # nikobus-connect 0.27.0 backoff primitive — returns the attempt count.
+    coord.nikobus_connection.reconnect_with_backoff = AsyncMock(return_value=1)
 
     coord.nikobus_command = MagicMock()
     coord.nikobus_command.start = AsyncMock()
     coord.nikobus_command.stop = AsyncMock()
+    coord.nikobus_command.reset = MagicMock()
     coord.nikobus_command._command_queue = asyncio.Queue()
 
     coord.nikobus_listener = MagicMock()
     coord.nikobus_listener.start = AsyncMock()
     coord.nikobus_listener.stop = AsyncMock()
+    coord.nikobus_listener.reset = MagicMock()
     coord.nikobus_listener.on_connection_lost = None
 
     coord.async_update_listeners = MagicMock()
@@ -127,95 +131,53 @@ class TestHandleConnectionLost(unittest.IsolatedAsyncioTestCase):
 # ---------------------------------------------------------------------------
 
 class TestReconnectLoop(unittest.IsolatedAsyncioTestCase):
-    async def test_succeeds_on_first_attempt(self):
+    """The transport backoff lives in nikobus-connect 0.27.0
+    (``reconnect_with_backoff``, tested there); these tests cover the
+    HA-side orchestration: delegation parameters, per-connection state
+    reset, subsystem restart, and the retry-on-restart-failure path."""
+
+    async def test_delegates_backoff_to_library(self):
         coord = _make_coordinator()
-        coord.nikobus_connection.connect = AsyncMock()  # succeeds immediately
-
         await coord._reconnect_loop()
+        coord.nikobus_connection.reconnect_with_backoff.assert_awaited_once()
+        kwargs = coord.nikobus_connection.reconnect_with_backoff.await_args.kwargs
+        self.assertEqual(kwargs["initial_delay"], RECONNECT_DELAY_INITIAL)
+        self.assertEqual(kwargs["max_delay"], RECONNECT_DELAY_MAX)
+        self.assertTrue(callable(kwargs["on_attempt"]))
 
-        coord.nikobus_connection.connect.assert_called_once()
+    async def test_on_attempt_updates_availability(self):
+        coord = _make_coordinator()
+        await coord._reconnect_loop()
+        on_attempt = coord.nikobus_connection.reconnect_with_backoff.await_args.kwargs[
+            "on_attempt"
+        ]
+        before = coord.async_update_listeners.call_count
+        on_attempt(3, 8.0)
+        self.assertEqual(coord.async_update_listeners.call_count, before + 1)
+
+    async def test_restarts_subsystems_after_reconnect(self):
+        coord = _make_coordinator()
+        await coord._reconnect_loop()
+        coord.nikobus_command.reset.assert_called_once()
+        coord.nikobus_listener.reset.assert_called_once()
         coord.nikobus_command.start.assert_called_once()
         coord.nikobus_listener.start.assert_called_once()
         coord._async_update_data.assert_called_once()
-        # Called once for "reconnecting" state, once for "connected" state after success.
-        self.assertEqual(coord.async_update_listeners.call_count, 2)
-
-    async def test_retries_after_connection_failure(self):
-        coord = _make_coordinator()
-        # Fail once, succeed on second attempt
-        coord.nikobus_connection.connect = AsyncMock(
-            side_effect=[Exception("refused"), None]
-        )
-
-        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-            await coord._reconnect_loop()
-
-        self.assertEqual(coord.nikobus_connection.connect.call_count, 2)
-        mock_sleep.assert_called_once_with(RECONNECT_DELAY_INITIAL)
-
-    async def test_backoff_doubles_each_retry(self):
-        coord = _make_coordinator()
-        # Fail twice, succeed on third
-        coord.nikobus_connection.connect = AsyncMock(
-            side_effect=[Exception("err"), Exception("err"), None]
-        )
-
-        sleep_calls = []
-        async def _fake_sleep(delay):
-            sleep_calls.append(delay)
-
-        with patch("asyncio.sleep", side_effect=_fake_sleep):
-            await coord._reconnect_loop()
-
-        self.assertEqual(sleep_calls[0], RECONNECT_DELAY_INITIAL)
-        self.assertEqual(sleep_calls[1], RECONNECT_DELAY_INITIAL * 2)
-
-    async def test_backoff_capped_at_max(self):
-        coord = _make_coordinator()
-        # Enough failures to hit the cap
-        failures = [Exception("err")] * 10 + [None]
-        coord.nikobus_connection.connect = AsyncMock(side_effect=failures)
-
-        sleep_calls = []
-        async def _fake_sleep(delay):
-            sleep_calls.append(delay)
-
-        with patch("asyncio.sleep", side_effect=_fake_sleep):
-            await coord._reconnect_loop()
-
-        # All delays after the cap should equal RECONNECT_DELAY_MAX
-        self.assertTrue(all(d <= RECONNECT_DELAY_MAX for d in sleep_calls))
-        self.assertIn(RECONNECT_DELAY_MAX, sleep_calls)
+        self.assertEqual(coord._reconnect_attempts, 0)
 
     async def test_exits_immediately_when_stopping(self):
         coord = _make_coordinator()
         coord._stopping = True
         await coord._reconnect_loop()
-        coord.nikobus_connection.connect.assert_not_called()
+        coord.nikobus_connection.reconnect_with_backoff.assert_not_called()
 
-    async def test_exits_if_stopping_set_during_sleep(self):
+    async def test_cancellation_during_backoff_returns_cleanly(self):
         coord = _make_coordinator()
-        coord.nikobus_connection.connect = AsyncMock(side_effect=Exception("err"))
-
-        async def _set_stopping_and_raise(delay):
-            coord._stopping = True
-            # Simulate CancelledError that asyncio.sleep raises when task is cancelled
-            raise asyncio.CancelledError()
-
-        with patch("asyncio.sleep", side_effect=_set_stopping_and_raise):
-            await coord._reconnect_loop()  # should return, not raise
-
-        coord.nikobus_connection.connect.assert_called_once()
-
-    async def test_drains_stale_commands_before_restart(self):
-        coord = _make_coordinator()
-        # Pre-load the queue with stale items
-        coord.nikobus_command._command_queue.put_nowait({"cmd": "stale1"})
-        coord.nikobus_command._command_queue.put_nowait({"cmd": "stale2"})
-
-        await coord._reconnect_loop()
-
-        self.assertTrue(coord.nikobus_command._command_queue.empty())
+        coord.nikobus_connection.reconnect_with_backoff = AsyncMock(
+            side_effect=asyncio.CancelledError()
+        )
+        await coord._reconnect_loop()  # must return, not raise
+        coord.nikobus_command.start.assert_not_called()
 
     async def test_registers_on_connection_lost_callback(self):
         """After reconnect, the callback must be re-armed on the listener."""
@@ -223,23 +185,18 @@ class TestReconnectLoop(unittest.IsolatedAsyncioTestCase):
         await coord._reconnect_loop()
         self.assertEqual(coord.nikobus_listener.on_connection_lost, coord._handle_connection_lost)
 
-    async def test_disconnects_on_subsystem_start_failure(self):
-        """If restarting subsystems fails, the connection is closed and we retry."""
+    async def test_disconnects_and_retries_on_subsystem_start_failure(self):
+        """If restarting subsystems fails, the connection is closed and the
+        loop re-enters the library backoff."""
         coord = _make_coordinator()
         coord.nikobus_command.start = AsyncMock(
             side_effect=[Exception("start failed"), None]
         )
-        coord.nikobus_connection.connect = AsyncMock()
-
-        sleep_calls = []
-        async def _fake_sleep(delay):
-            sleep_calls.append(delay)
-
-        with patch("asyncio.sleep", side_effect=_fake_sleep):
-            await coord._reconnect_loop()
-
+        await coord._reconnect_loop()
         coord.nikobus_connection.disconnect.assert_called_once()
-        self.assertEqual(len(sleep_calls), 1)
+        self.assertEqual(
+            coord.nikobus_connection.reconnect_with_backoff.await_count, 2
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why this PR

Same stacked-merge situation a third time: **#453 was merged into its base branch `claude/phase0-quality`, not into `main`**. `main` is missing the final increment (manifest pin `>=0.27.0`, `_reconnect_loop` delegation, `CoordinatorProtocol` conformance).

This catch-up PR's diff is exactly the content already approved in **#453**. No new changes.

✅ **Unblocked**: `nikobus-connect 0.27.0` is now live on PyPI, and I re-ran the full HA suite **against the actual PyPI release** (not the local checkout): `429 passed`.

**This is the last PR of the roadmap.** After merging, please **delete `claude/phase0-quality`** — everything it carries will be on `main`, and that also prevents this stacking situation from recurring.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_