### PR TITLE
fix(cover): audit correctness fixes — swallowed bus STOP, position re-anchor, 0x03 episodes

### DIFF
--- a/custom_components/nikobus/cover.py
+++ b/custom_components/nikobus/cover.py
@@ -150,6 +150,14 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
 
         self._movement_source = "ha"
         self._current_run_limit: float = 0.0
+        # Last direction a motion actually ran in — used for the stop
+        # command when _state has already been committed to STOPPED
+        # (e.g. the 0x03 motor-protection clear, where the old code
+        # always fell through to "closing").
+        self._last_motion_direction = "closing"
+        # One protection-clear write per 0x03 episode; re-armed when the
+        # bus leaves the error state.
+        self._error_clear_sent = False
 
         # Set by _handle_button_pressed when a physical button starts a new move.
         # Used by _handle_coordinator_update to backdate the travel calculator so
@@ -231,6 +239,12 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
         """React to state changes reported by the Nikobus bus."""
         new_bus_state = self.coordinator.get_cover_state(self._address, self._channel)
 
+        # Re-arm the one-shot protection clear as soon as the bus has
+        # left 0x03 — before the same-state early return below, which
+        # would otherwise skip it (STOPPED == STOPPED).
+        if new_bus_state != STATE_ERROR:
+            self._error_clear_sent = False
+
         if new_bus_state == self._state:
             super()._handle_coordinator_update()
             return
@@ -243,11 +257,15 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
         #               schedule a follow-up refresh to catch the 0x00 transition.
         if new_bus_state == STATE_ERROR:
             if self._movement_source == "ha":
-                _LOGGER.debug(
-                    "Cover %s ch%d motor-protection (0x03) after HA move — writing 0 to clear",
-                    self._address, self._channel,
-                )
-                self.hass.async_create_task(self._stop(send_stop=True, force_api=True))
+                if not self._error_clear_sent:
+                    self._error_clear_sent = True
+                    _LOGGER.debug(
+                        "Cover %s ch%d motor-protection (0x03) after HA move — writing 0 to clear",
+                        self._address, self._channel,
+                    )
+                    self.hass.async_create_task(
+                        self._stop(send_stop=True, force_api=True)
+                    )
             else:
                 _LOGGER.debug(
                     "Cover %s ch%d motor-protection (0x03) after Nikobus move — waiting for auto-clear",
@@ -301,9 +319,15 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
 
         if self._state == STATE_STOPPED:
             # Cover is about to start moving — record now for detection latency.
+            # A None channel (undecoded button link) is acceptable here: the
+            # timestamp is benign (bounded to 10 s, overwritten on use).
             self._last_button_press_monotonic = time.monotonic()
-        else:
-            # Cover is moving — this press is a stop command.
+        elif event_channel is not None:
+            # Cover is moving — this press is a stop command. Require a
+            # RESOLVED channel: with channel=None (undecoded link) every
+            # cover on the module receives this event, and stopping a
+            # moving cover on an unrelated button press would desync the
+            # simulated position from the physical shutter.
             send_stop = (self._movement_source == "ha")
             await self._stop(send_stop=send_stop)
 
@@ -384,6 +408,7 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
             self._motion_task.cancel()
 
         self._state = STATE_OPENING if direction == "opening" else STATE_CLOSING
+        self._last_motion_direction = direction
 
         active_op_time = (
             self._calculator.time_up if direction == "opening" else self._calculator.time_down
@@ -452,9 +477,18 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
 
     async def _stop(self, send_stop: bool = False, force_api: bool = False) -> None:
         """Stop movement and finalize position."""
-        if self._motion_task:
-            self._motion_task.cancel()
-            self._motion_task = None
+        task = self._motion_task
+        self._motion_task = None
+        if task is not None and task is not asyncio.current_task():
+            # Never cancel the task we are running IN: when the motion
+            # loop itself calls _stop (target reached / end-stop), a
+            # self-cancel would inject CancelledError at the next await
+            # — which is the api.stop_cover() call below — and the bus
+            # STOP frame would silently never be sent (the loop's
+            # ``except CancelledError: pass`` swallows it). The loop
+            # ``break``s right after this returns, so not cancelling it
+            # is correct.
+            task.cancel()
 
         stopped_state = self._state
         self._calculator.stop()
@@ -468,7 +502,15 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
         self.coordinator.set_bytearray_state(self._address, self._channel, STATE_STOPPED)
 
         if send_stop and (stopped_state != STATE_STOPPED or force_api):
-            dir_cmd = "opening" if stopped_state == STATE_OPENING else "closing"
+            if stopped_state == STATE_OPENING:
+                dir_cmd = "opening"
+            elif stopped_state == STATE_CLOSING:
+                dir_cmd = "closing"
+            else:
+                # Already committed to STOPPED (force_api path, e.g. the
+                # 0x03 protection clear) — use the direction the motion
+                # actually ran in instead of an arbitrary "closing".
+                dir_cmd = self._last_motion_direction
             await self.coordinator.api.stop_cover(self._address, self._channel, dir_cmd)
 
         self.async_write_ha_state()

--- a/custom_components/nikobus/nkbtravelcalculator.py
+++ b/custom_components/nikobus/nkbtravelcalculator.py
@@ -31,7 +31,14 @@ class NikobusTravelCalculator:
         position rather than the stale pre-move position.
 
         Latency must be non-negative; negative values are clamped to zero.
+
+        Anchors on the *in-flight* position: when called while a travel
+        is already running (re-target in the same direction), the
+        committed ``self.position`` is stale — using it would snap the
+        simulated position back to the pre-move value and make the new
+        run start from the wrong base.
         """
+        self.position = self.current_position()
         self._start_pos = self.position
         self._start_time = time.monotonic() - max(0.0, latency)
         self._direction = 1 if direction == "opening" else -1

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -398,3 +398,115 @@ class TestRequestMove(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# ---------------------------------------------------------------------------
+# Regressions from the cover.py correctness audit
+# ---------------------------------------------------------------------------
+class TestStopFromMotionLoopSendsBusStop(unittest.TestCase):
+    def test_self_cancel_does_not_swallow_stop_command(self):
+        """BUG 1: _stop() called FROM the motion task must still deliver
+        the bus STOP. The old code cancelled its own task; CancelledError
+        was injected at the next await — the api.stop_cover call itself —
+        and swallowed by the loop, so the physical shutter kept moving.
+        AsyncMock has no suspension point and masked this; this stub
+        suspends for real."""
+
+        async def scenario():
+            ent, coord = _make_cover()
+            sent = []
+
+            async def real_stop(*args):
+                await asyncio.sleep(0)  # genuine suspension point
+                sent.append(args)
+
+            coord.api.stop_cover = real_stop
+            ent._state = STATE_CLOSING
+
+            async def fake_motion_loop():
+                # Mirrors _motion_loop's structure: stop from within the
+                # task registered as _motion_task, CancelledError swallowed.
+                try:
+                    await ent._stop(send_stop=True)
+                except asyncio.CancelledError:
+                    pass
+
+            task = asyncio.get_event_loop().create_task(fake_motion_loop())
+            ent._motion_task = task
+            await asyncio.sleep(0.05)
+            return sent, task
+
+        sent, task = _run(scenario())
+        self.assertEqual(len(sent), 1, "bus STOP was swallowed by self-cancel")
+        self.assertTrue(task.done() and not task.cancelled())
+
+
+class TestRetargetSameDirection(unittest.TestCase):
+    def test_start_travel_anchors_on_in_flight_position(self):
+        """BUG 2: re-targeting mid-travel in the same direction must not
+        snap the simulated position back to the stale committed value."""
+        c = NikobusTravelCalculator(10, 10)
+        c.set_position(100)
+        clock = {"t": 1000.0}
+        with patch(_MONO, lambda: clock["t"]):
+            c.start_travel("closing")
+            clock["t"] = 1005.0  # 5 s of 10 s → position 50
+            self.assertEqual(c.current_position(), 50.0)
+            c.start_travel("closing")  # re-target while moving
+            self.assertEqual(c.current_position(), 50.0)  # not 100
+            clock["t"] = 1007.0  # 2 more seconds → 30
+            self.assertEqual(c.current_position(), 30.0)
+
+
+class TestUnresolvedChannelPress(unittest.TestCase):
+    def test_press_without_channel_does_not_stop_moving_cover(self):
+        """D3: a press payload with channel=None (undecoded button link)
+        reaches every cover on the module — it must not stop one that is
+        moving (that desyncs the simulated position from the shutter)."""
+        ent, coord = _make_cover()
+        ent._state = STATE_CLOSING
+        ent._movement_source = "ha"
+        _run(ent._handle_button_pressed({"address": "9105", "channel": None}))
+        self.assertEqual(ent._state, STATE_CLOSING)  # untouched
+        coord.api.stop_cover and self.assertFalse(
+            getattr(coord.api.stop_cover, "await_count", 0)
+        )
+
+    def test_press_with_matching_channel_still_stops(self):
+        ent, coord = _make_cover()
+        ent._state = STATE_CLOSING
+        ent._movement_source = "ha"
+        _run(ent._handle_button_pressed({"address": "9105", "channel": 1}))
+        self.assertEqual(ent._state, STATE_STOPPED)
+        coord.api.stop_cover.assert_awaited_once()
+
+
+class TestErrorClearEpisode(unittest.TestCase):
+    def _ent_with_bus_states(self, states):
+        ent, coord = _make_cover()
+        coord.get_cover_state = MagicMock(side_effect=states)
+        ent._movement_source = "ha"
+        return ent, coord
+
+    def test_clear_sent_once_per_error_episode(self):
+        """D4: repeated polls while 0x03 persists must not re-send the
+        protection clear; leaving 0x03 re-arms it for the next episode."""
+        ent, _ = self._ent_with_bus_states(
+            [STATE_ERROR, STATE_ERROR, STATE_STOPPED, STATE_ERROR]
+        )
+        ent._handle_coordinator_update()  # episode 1 → clear
+        ent._handle_coordinator_update()  # still 0x03 → suppressed
+        self.assertEqual(ent.hass.async_create_task.call_count, 1)
+        ent._handle_coordinator_update()  # bus left 0x03 → re-arm
+        ent._handle_coordinator_update()  # episode 2 → clear again
+        self.assertEqual(ent.hass.async_create_task.call_count, 2)
+
+    def test_protection_clear_uses_last_motion_direction(self):
+        """D4: the force_api stop fires after _state is already STOPPED —
+        it must use the direction the motion actually ran in, not an
+        arbitrary 'closing'."""
+        ent, coord = _make_cover()
+        ent._state = STATE_STOPPED
+        ent._last_motion_direction = "opening"
+        _run(ent._stop(send_stop=True, force_api=True))
+        coord.api.stop_cover.assert_awaited_once_with("9105", 1, "opening")


### PR DESCRIPTION
## Summary

Line-by-line correctness audit of `cover.py` (+ `nkbtravelcalculator.py`, the `press_signal` payload path, and `test_cover.py`). **The architecture is sound and has no performance issues** — but the audit confirmed **2 real bugs by executable repro**, plus 2 secondary defects. All four fixed here.

### 🔴 1. Swallowed bus STOP on target reached (severe)
`_stop()` called **from within** `_motion_loop` (target reached / end-stop) cancelled `self._motion_task` — **its own task**. The `CancelledError` lands at the next `await`, which is precisely `api.stop_cover(...)`, then gets swallowed by the loop's `except CancelledError: pass`.

**Real-world effect: `set_cover_position(50)` → HA shows "50, stopped" while the physical shutter keeps moving to the end-stop.** Invisible to the existing tests because `AsyncMock` never suspends — repro with a genuinely-suspending stub: **0 STOP frames sent**. Fix: never cancel `asyncio.current_task()` in `_stop` (the loop `break`s right after it returns anyway).

### 🟠 2. Position snap-back on same-direction re-target
`start_travel()` anchored on the stale *committed* position. Re-targeting mid-travel jumped the simulated position back (repro: 95 → 100), so the new run started from a wrong base and stopped at the wrong physical spot. Fix: commit `current_position()` before anchoring (re-played repro now passes: 95 → 95).

### 🟡 3. Unresolved-channel press stopped every moving cover on the module
`press_signal` payloads carry `channel=None` when the button link is undecoded; the filter let those through to the moving-cover stop branch. Fix: require a resolved channel for the stop path (the stopped-path timestamp stays — benign and bounded to 10 s).

### 🟡 4. 0x03 motor-protection episode handling
The HA-source protection clear was re-sent on **every poll** while 0x03 persisted, and its direction was computed after `_state` was already STOPPED (always fell through to `"closing"`). Fix: one clear per episode (re-armed when the bus leaves 0x03 — *before* the same-state early return that would otherwise skip re-arming) + a remembered `_last_motion_direction`.

## Tests

**+6 regressions** (45 in test_cover.py, 437 total), including one with a **genuinely-suspending** stop stub — the class of bug `AsyncMock` masks — and the re-anchor repro as a clock-mocked calculator test.

`437 passed`, `ruff` clean, `mypy` 105 (= this main's baseline, no regression).

## Audit conclusion (no further changes needed)
Time-based dead-reckoning, debounce/coalesce, bounded detection latency, state diffing, restore, reversal paths: all correct. No O(n²), no hot-path issues — `controlled_by` is served from the coordinator's cached index.

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_