### PR TITLE
fix(scene): timed roller stop composes from current state, not the activation snapshot

### DIFF
--- a/custom_components/nikobus/scene.py
+++ b/custom_components/nikobus/scene.py
@@ -386,18 +386,40 @@ class NikobusSceneEntity(NikobusEntity, Scene):
         )
 
     async def _delayed_roller_stop(
-        self, module_id: str, state: bytearray, indexes: set[int], delay: float, token: str
+        self, module_id: str, sent_state: bytearray, indexes: set[int], delay: float, token: str
     ) -> None:
-        """Stop roller movement after operation time expires."""
+        """Stop roller movement after operation time expires.
+
+        Composes the stop frame from the module's CURRENT state at
+        timeout, not the snapshot captured at activation: during the
+        30-60 s of travel any channel of this module may have been
+        redirected by the user, a wall button or another scene, and
+        replaying the stale snapshot would silently restart it. Channels
+        this activation commanded are only forced to STOPPED when they
+        are still doing what we sent — a channel someone has since
+        stopped or reversed is no longer ours to touch.
+        """
         await asyncio.sleep(delay)
 
-        # Abort if a newer scene activation has taken control of this module
+        # Abort if a newer activation of this scene has taken control
+        # of this module.
         if self._module_tokens.get(module_id) != token:
             return
 
-        stop_state = bytearray(state)
+        current = self.coordinator.nikobus_module_states.get(module_id)
+        stop_state = bytearray(current) if current else bytearray(sent_state)
+        changed = False
         for idx in indexes:
-            stop_state[idx] = STATE_STOPPED
+            if idx < len(stop_state) and stop_state[idx] == sent_state[idx]:
+                stop_state[idx] = STATE_STOPPED
+                changed = True
+        if not changed:
+            _LOGGER.debug(
+                "Timed stop for module %s skipped — every commanded roller "
+                "channel was redirected during travel",
+                module_id,
+            )
+            return
 
         _LOGGER.debug("Timed stop for rollers on module %s", module_id)
         try:

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import unittest
+import unittest.mock
 from unittest.mock import AsyncMock, MagicMock
 
 from custom_components.nikobus.scene import (
@@ -290,3 +291,72 @@ class TestCoordinatorSceneHelpers(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# ---------------------------------------------------------------------------
+# Regression: _delayed_roller_stop must not replay a stale module snapshot
+# ---------------------------------------------------------------------------
+class TestDelayedRollerStop(unittest.TestCase):
+    """The timed stop fires 30-60 s after activation. It must compose the
+    stop frame from the module's CURRENT state, and only force STOPPED on
+    channels still doing what THIS activation sent — anything redirected
+    during travel (user, wall button, another scene) is not ours."""
+
+    def _scene_with_module_state(self, current: bytearray | None):
+        ent = _scene()
+        ent.coordinator.nikobus_module_states = (
+            {"C9A5": current} if current is not None else {}
+        )
+        ent._apply_module_state = AsyncMock()
+        ent._module_tokens["C9A5"] = "tok"
+        return ent
+
+    def _run_stop(self, ent, sent, indexes, token="tok"):
+        async def scenario():
+            with unittest.mock.patch("asyncio.sleep", new=AsyncMock()):
+                await ent._delayed_roller_stop("C9A5", sent, indexes, 30.0, token)
+        _run(scenario())
+
+    def test_nominal_stop_uses_current_state_basis(self):
+        # Scene sent ch1=OPEN; meanwhile ch2 (untouched by the scene) was
+        # turned to CLOSE by the user. The stop frame must carry the
+        # CURRENT ch2 value, not the activation snapshot's.
+        sent = bytearray(12)
+        sent[0] = 0x01  # ch1 OPEN
+        current = bytearray(12)
+        current[0] = 0x01  # ch1 still ours
+        current[1] = 0x02                               # ch2 changed meanwhile
+        ent = self._scene_with_module_state(current)
+        self._run_stop(ent, sent, {0})
+        ent._apply_module_state.assert_awaited_once()
+        frame = ent._apply_module_state.await_args.args[1]
+        self.assertEqual(frame[0], 0x00)  # our channel stopped
+        self.assertEqual(frame[1], 0x02)  # bystander channel preserved
+
+    def test_redirected_channel_is_left_alone(self):
+        # Scene sent ch1=OPEN; user reversed it to CLOSE during travel.
+        # The timed stop must not touch it (no forced STOPPED, and
+        # certainly no replay of OPEN).
+        sent = bytearray(12)
+        sent[0] = 0x01
+        current = bytearray(12)
+        current[0] = 0x02  # reversed by user
+        ent = self._scene_with_module_state(current)
+        self._run_stop(ent, sent, {0})
+        ent._apply_module_state.assert_not_awaited()    # nothing left to stop
+
+    def test_stale_token_aborts(self):
+        sent = bytearray(12)
+        sent[0] = 0x01
+        ent = self._scene_with_module_state(bytearray(sent))
+        ent._module_tokens["C9A5"] = "newer-token"
+        self._run_stop(ent, sent, {0}, token="old-token")
+        ent._apply_module_state.assert_not_awaited()
+
+    def test_missing_current_state_falls_back_to_sent(self):
+        sent = bytearray(12)
+        sent[0] = 0x01
+        ent = self._scene_with_module_state(None)
+        self._run_stop(ent, sent, {0})
+        frame = ent._apply_module_state.await_args.args[1]
+        self.assertEqual(frame[0], 0x00)


### PR DESCRIPTION
## Summary

Platform audit — the cover.py treatment extended to **light, switch, scene, button, binary_sensor and the shared entity base** (full line-by-line read, hunting the same bug classes: task self-cancellation, stale-state replay, `channel=None` payloads, AsyncMock-masked paths, optimistic races).

### ✅ Clean (no changes needed)
- **light.py / switch.py** — optimistic patterns are correct: `_previous_brightness` read *before* mutation, error paths revert to coordinator state, the A/B latch mutates *after* the await (so a failed bus write never lies in the UI).
- **button.py** — long discovery actions properly backgrounded with a `discovery_running` guard.
- **binary_sensor.py** — event-driven pulse with the reset timer cancelled on removal.
- **entity.py** — diffing/availability base is sound.

### 🟠 One real defect, fixed: stale-snapshot replay in the scene timed stop
`_delayed_roller_stop` fires **30–60 s after activation** and replayed the **full module snapshot captured at activation**, with only the scene's roller channels forced to STOPPED. Any channel of that module redirected during travel — another shutter adjusted by hand, a wall button, another scene — was **silently overwritten with the stale state and restarted**. The token guard only protects against re-activation of the *same scene entity*.

**Fix:** compose the stop frame from the module's **current** coordinator state at timeout, and only force STOPPED on channels **still doing what this activation sent** — a channel someone has since stopped or reversed is no longer ours to touch (the write is skipped entirely when nothing commanded is still running).

## Tests

`_delayed_roller_stop` previously had **zero coverage**. +4 regressions: bystander channel preserved, redirected channel left alone, stale-token abort, missing-current fallback.

`439 passed`, `ruff` clean, `mypy` 100 (= baseline, no regression).

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_