### PR TITLE
fix(discovery): clean up stuck discovery_running on probe failure (audit companion)

### DIFF
--- a/custom_components/nikobus/discovery_mixin.py
+++ b/custom_components/nikobus/discovery_mixin.py
@@ -799,6 +799,16 @@ class NikobusDiscoveryMixin:
                 "manual config files.",
                 err,
             )
+            # Same cleanup as the CancelledError path above: the library
+            # sets ``discovery_running`` before the point where
+            # ``start_inventory_discovery`` can raise. Without this, a
+            # probe failure left the flag stuck True — polling suppressed
+            # forever and every new scan rejected as "already running".
+            # (nikobus-connect 0.27.1 also resets its own state on this
+            # path; this is the integration's defence in depth for older
+            # library versions.)
+            self.discovery_running = False
+            self._discovery_finished_event.set()
             return False
 
     async def _apply_manual_inventory_as_fallback(self) -> bool:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1620,6 +1620,30 @@ class TestUnifiedStep1Discovery(unittest.IsolatedAsyncioTestCase):
 
         coord.nikobus_discovery.start_inventory_discovery.assert_awaited_once()
 
+    async def test_pclink_probe_exception_clears_running_flag(self):
+        """Audit regression: the library sets ``discovery_running`` before
+        the point where ``start_inventory_discovery`` can raise. The
+        generic-exception fallback path must clean up like the
+        CancelledError path does — otherwise the flag is stuck True
+        (polling suppressed forever, every new scan rejected)."""
+        coord = self._make_coord()
+
+        async def fail():
+            # Mirrors the library: flag set, then the send raises.
+            coord.discovery_running = True
+            raise OSError("bus gone")
+
+        coord.nikobus_discovery.start_inventory_discovery.side_effect = fail
+
+        with patch(
+            "custom_components.nikobus.nkbmanual.async_apply_manual_config",
+            new_callable=AsyncMock, return_value=True,
+        ):
+            await coord.start_pc_link_inventory(auto_reload=False)
+
+        self.assertFalse(coord.discovery_running)
+        self.assertTrue(coord._discovery_finished_event.is_set())
+
     async def test_pclink_timeout_falls_back_to_manual_files(self):
         coord = self._make_coord()
 


### PR DESCRIPTION
## Summary

Companion to **nikobus-connect #119** (discovery-process audit) — the HA side of the same stuck-flag bug, found independently during my own read of `discovery_mixin.py`.

In `_try_pclink_inventory`, the `CancelledError` path cleared `discovery_running` and set the finished event — but the **generic-exception path returned `False` with no cleanup**. The library sets `discovery_running=True` *before* the point where `start_inventory_discovery` can raise (not connected, send failure), so a probe failure left the flag **stuck True**: polling suppressed forever (`_async_update_data` early-returns) and every new scan rejected as *"discovery already running"*. Only an HA restart recovered.

The except path now mirrors the CancelledError cleanup. (0.27.1 also resets library-side on that path — this is the integration's defence in depth for older library versions, and the pin stays `>=0.27.0`.)

## Verification

+1 regression test (probe raises after the library set the flag → flag cleared, event set, fallback still runs). `436 passed`, `ruff` clean, `mypy` 100 (= baseline).

Independent of #119 — both can merge in any order; publishing **0.27.1** to PyPI after #119 merges gets the library-side fixes to new installs automatically (no pin bump needed).

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_