### PR TITLE
fix(discovery): coherent progress reporting across every stage

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -479,11 +479,17 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
         self._pclink_first_response_event.set()
         await self.nikobus_discovery.parse_inventory_response(message)
 
-        # Count this frame toward the PC Link progress bar.
-        self.discovery_registers_done = min(
-            self.discovery_registers_total,
-            self.discovery_registers_done + 1,
-        )
+        # Count this frame toward the PC Link progress bar — but ONLY
+        # while we're actually in the inventory sub-phase. The same
+        # ``$2E`` frames keep flowing during the library's identity
+        # phase (96 reads x N modules); counting them here would fight
+        # the authoritative per-module counters the library's
+        # on_progress emits write between frames.
+        if self.discovery_sub_phase == DISCOVERY_SUB_PHASE_INVENTORY:
+            self.discovery_registers_done = min(
+                self.discovery_registers_total,
+                self.discovery_registers_done + 1,
+            )
         # Only own the status message while we're ACTUALLY in the
         # PC-Link inventory sub-phase. ``parse_inventory_response`` also
         # receives the per-register ``$2E`` frames during the library's
@@ -560,7 +566,14 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
             # 0.19.1 also resets these library-side; this is a
             # defence-in-depth so older lib versions get the same
             # behaviour.
-            if sub_phase != self.discovery_sub_phase:
+            if (
+                sub_phase != self.discovery_sub_phase
+                and sub_phase != DISCOVERY_SUB_PHASE_INVENTORY
+            ):
+                # Entering INVENTORY is excluded: start_pc_link_inventory
+                # seeds registers_total (≈92) for the frame-callback's
+                # per-frame counter, and zeroing the total here would
+                # pin that counter at min(0, …) for the whole phase.
                 self.discovery_registers_done = 0
                 self.discovery_registers_total = 0
 
@@ -633,6 +646,20 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
             self.discovery_register_current = (
                 int(register) if register is not None else None
             )
+            if sub_phase == DISCOVERY_SUB_PHASE_INVENTORY:
+                # The library emits inventory progress ONCE, as a single
+                # unit of work (register_total=1, registers_sent=1).
+                # Writing that through would clobber the live 0..92
+                # frame counter ``_discovery_frame_callback`` maintains —
+                # the inventory bar then pinned at "1/1" for the whole
+                # phase (and the frame counter froze on min(total=1, ..)).
+                # The frame callback owns the counters for this phase;
+                # only take the phase/message here.
+                self._update_discovery_state(
+                    phase=legacy_phase,
+                    message=message,
+                )
+                return
             # The library's ``register_total`` is now the cumulative
             # per-module target under the vendor plan (48 for output
             # modules + PC-Logic, 93 for PC-Link, 112 with broad_scan).

--- a/custom_components/nikobus/discovery_mixin.py
+++ b/custom_components/nikobus/discovery_mixin.py
@@ -342,9 +342,14 @@ class NikobusDiscoveryMixin:
             }
 
         # --- Probe with library-owned outer retry ----------------------
+        # NOTE: no ``phase=`` override here (or below). The coarse phase
+        # must stay whatever the run was (module_scan for a register
+        # scan) — forcing it back to pc_link made the status sensor's
+        # state REGRESS at the end of every module scan, and dropped
+        # the progress bar to the legacy 10% fallback for the 5-15 s
+        # the probe takes.
         self.discovery_sub_phase = DISCOVERY_SUB_PHASE_PROBING
         self._update_discovery_state(
-            phase=DISCOVERY_PHASE_PC_LINK,
             message="Probing modules for residue…",
             registers_done=self.discovery_registers_total,
         )
@@ -363,7 +368,6 @@ class NikobusDiscoveryMixin:
 
         # --- Eviction --------------------------------------------------
         self._update_discovery_state(
-            phase=DISCOVERY_PHASE_PC_LINK,
             message="Reconciling discovered inventory…",
         )
         modules = self.module_storage.data.setdefault("nikobus_module", {})
@@ -375,7 +379,6 @@ class NikobusDiscoveryMixin:
                     evicted.append(str(addr).upper())
         if evicted:
             self._update_discovery_state(
-                phase=DISCOVERY_PHASE_PC_LINK,
                 message=f"Evicted {len(evicted)} stale module(s); finalizing…",
             )
 
@@ -595,6 +598,20 @@ class NikobusDiscoveryMixin:
             )
             phase_weight = DISCOVERY_WEIGHT_FINALIZING
             phase_frac = 0.5
+        elif self.discovery_sub_phase == DISCOVERY_SUB_PHASE_PROBING:
+            # Post-discovery residue probe + eviction (reconciliation).
+            # Sits AFTER finalizing's midpoint: without this branch the
+            # property fell through to the legacy fallback and the bar
+            # DROPPED from ~97% to 10% for the 5-15 s the probe takes,
+            # then jumped to 100 — the single most visible progress
+            # glitch, present at the end of every discovery run.
+            floor = (
+                DISCOVERY_WEIGHT_INVENTORY
+                + DISCOVERY_WEIGHT_IDENTITY
+                + DISCOVERY_WEIGHT_REGISTER_SCAN
+            )
+            phase_weight = DISCOVERY_WEIGHT_FINALIZING
+            phase_frac = 0.75
         else:
             # Older libraries may still drive the legacy-phase field only.
             if self.discovery_phase == DISCOVERY_PHASE_PC_LINK:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -440,11 +440,14 @@ class TestDiscoveryFrameRouting(unittest.IsolatedAsyncioTestCase):
 
         await coord._discovery_frame_callback(data)
 
-        # Frame still counted toward the register progress bar
-        # (parse_inventory_response is the per-frame increment hook).
+        # Frame still parsed (the library needs every $2E response)…
         coord.nikobus_discovery.parse_inventory_response.assert_awaited_once_with(data)
-        self.assertEqual(coord.discovery_registers_done, 1)
-        # But the status message must NOT be touched — keeps whatever
+        # …but NOT counted: during identity the library's on_progress
+        # emits own the counters (progress-audit follow-up to 2.11.2 —
+        # counting here fought those authoritative values and produced
+        # flickering/incoherent register counts in the UI).
+        self.assertEqual(coord.discovery_registers_done, 0)
+        # And the status message must NOT be touched — keeps whatever
         # _handle_discovery_progress wrote for the identity phase.
         coord._update_discovery_state.assert_not_called()
 

--- a/tests/test_discovery_progress_vendor_aligned.py
+++ b/tests/test_discovery_progress_vendor_aligned.py
@@ -248,3 +248,85 @@ def test_full_scope_unchanged() -> None:
     c = _percent_coord("full", "register_scan",
                        regs_done=0, regs_total=48, mods_done=0, mods_total=4)
     assert c.discovery_progress_percent == 30.0
+
+
+# ---------------------------------------------------------------------------
+# Progress-pipeline audit regressions (UI: bar jumping back / frozen /
+# incoherent values across stages)
+# ---------------------------------------------------------------------------
+
+def test_probing_subphase_does_not_drop_to_legacy_fallback() -> None:
+    """The bar used to FALL from ~97% to 10% during the 5-15 s residue
+    probe at the end of every run: PROBING wasn't handled by
+    discovery_progress_percent and fell through to the legacy branch."""
+    c = _percent_coord("full", "probing")
+    pct = type(c).discovery_progress_percent.fget(c)
+    assert 95.0 <= pct <= 99.9, pct
+
+
+def test_probing_after_module_scan_scope_stays_high() -> None:
+    c = _percent_coord("module_scan", "probing")
+    pct = type(c).discovery_progress_percent.fget(c)
+    assert 95.0 <= pct <= 99.9, pct
+
+
+def test_inventory_emit_does_not_clobber_frame_counters() -> None:
+    """The library emits inventory progress ONCE as a 1/1 unit; writing
+    that through clobbered the live 0..92 frame counter and pinned the
+    inventory bar at '1/1' for the whole phase."""
+    coord, update = _make_coordinator()
+    # Seeded by start_pc_link_inventory before the library emit arrives.
+    coord.discovery_registers_done = 7
+    coord.discovery_registers_total = 92
+    progress = _FakeProgress(
+        phase="inventory", register_total=1, registers_sent=1
+    )
+    asyncio.run(coord._handle_discovery_progress(progress))
+    kwargs = update.call_args.kwargs
+    assert "registers_done" not in kwargs
+    assert "registers_total" not in kwargs
+    # Sub-phase transition into INVENTORY must not zero the seed either.
+    assert coord.discovery_registers_done == 7
+    assert coord.discovery_registers_total == 92
+
+
+def test_frame_counter_only_counts_during_inventory_subphase() -> None:
+    """$2E frames keep flowing during the identity phase; counting them
+    in the frame callback fought the library's authoritative per-module
+    counters (flicker / incoherent values)."""
+    from custom_components.nikobus.coordinator import NikobusDataCoordinator
+
+    coord = MagicMock(spec=NikobusDataCoordinator)
+    coord.nikobus_discovery = MagicMock()
+    coord.nikobus_discovery.parse_inventory_response = _AsyncNoop()
+    coord.discovery_running = True
+    coord.inventory_query_type = _PCLINK
+    coord._pclink_first_response_event = MagicMock()
+    coord.discovery_registers_done = 5
+    coord.discovery_registers_total = 92
+    coord._update_discovery_state = MagicMock()
+    coord._discovery_frame_callback = (
+        NikobusDataCoordinator._discovery_frame_callback.__get__(coord)
+    )
+
+    # During identity: counter untouched.
+    coord.discovery_sub_phase = "identity"
+    asyncio.run(coord._discovery_frame_callback("$2E0512"))
+    assert coord.discovery_registers_done == 5
+
+    # During inventory: counter advances.
+    coord.discovery_sub_phase = "inventory"
+    asyncio.run(coord._discovery_frame_callback("$2E0512"))
+    assert coord.discovery_registers_done == 6
+
+
+class _AsyncNoop:
+    def __call__(self, *args):  # noqa: D102
+        async def _noop():
+            return None
+        return _noop()
+
+
+from nikobus_connect.discovery import InventoryQueryType as _IQT  # noqa: E402
+
+_PCLINK = _IQT.PC_LINK


### PR DESCRIPTION
## Summary

Fixes the user-reported progress-UI breakage at every discovery stage (bar jumping backward, freezing, incoherent counters, periods without updates). A pipeline audit (library `_emit_progress` → `_handle_discovery_progress` → `discovery_progress_percent` → sensors) found **four interacting defects** — together they explain all four symptoms. All fixed HA-side; no library change needed.

### 1. 🔴 The bar DROPPED ~97 % → 10 % at the end of every run
The reconciliation sets `sub_phase=probing` for its 5-15 s residue probe; `discovery_progress_percent` had **no branch for PROBING** and fell through to the legacy 10 % fallback. Now mapped into the finalizing weight band (~98.8 %). *(→ "bar jumps backward")*

### 2. 🔴 Coarse phase regressed during reconciliation
The three `_update_discovery_state` calls in `_reconcile_post_discovery` forced `phase=pc_link` — after a module scan the status sensor's state **regressed** `module_scan → pc_link` for the probe window, feeding the same 10 % fallback. Phase override removed; the run's phase is kept. *(→ "incoherent values")*

### 3. 🟠 Competing writers froze the inventory bar at "1/1"
The library emits inventory progress **once**, as a single unit (`register_total=1, registers_sent=1`); writing that through clobbered the live 0..92 frame counter from `_discovery_frame_callback`, whose `min(total=1, …)` then froze — bar pinned, message *"PC-Link inventory: 1/1 registers"* for the whole phase. The progress handler now skips register counters during the inventory sub-phase (the frame callback owns them), and the transition-zeroing excludes *entry into* inventory so the seeded total survives. *(→ "frozen bar" + "no updates")*

### 4. 🟠 Frame counter counted during the identity phase
The same `$2E` frames keep flowing during identity (96 reads × N modules); the unconditional increment **fought the library's authoritative per-module counters** between `on_progress` emits (flickering counts). Counting is now gated on the inventory sub-phase, like the message already was (2.11.2). *(→ "incoherent values")*

## Expected behaviour after this PR
- Inventory: smooth 0→92 frame counting, real device count in the message.
- Identity / register scan: library-owned counters, no flicker.
- End of run: ~95 % (finalizing) → ~98.8 % (probing) → **100 %** — monotonic, no drop to 10 %.
- Status sensor state never regresses to `pc_link` after a module scan.

## Tests
**+4 regressions** (probing percent in both scopes, inventory-emit clobber guard incl. transition zeroing, identity-phase counter gate); **1 test updated** — it pinned the old identity-counting behaviour that fix 4 intentionally removes.

`444 passed`, `ruff` clean, `mypy` 100 (= baseline).

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_