### PR TITLE
fix(discovery): response-driven PC-Link inventory progress (no more 0→99 jump)

### DIFF
--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -208,6 +208,12 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
         self.discovery_register_current: int | None = None
         self.discovery_decoded_records: int = 0
         self.discovery_last_error: str | None = None
+        # Identity phase is RESPONSE-driven (the library queues all
+        # N×96 reads up front and emits progress per QUEUED command, so
+        # its counters race to ~100% in <1s while the bus scan takes
+        # ~25s). These track $2E answers as they actually arrive.
+        self.discovery_identity_responses: int = 0
+        self.discovery_identity_expected: int = 0
         self._discovery_finished_event: asyncio.Event = asyncio.Event()
         self._discovery_finished_event.set()  # idle = already set
         self._pclink_first_response_event: asyncio.Event = asyncio.Event()
@@ -490,6 +496,26 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
                 self.discovery_registers_total,
                 self.discovery_registers_done + 1,
             )
+        elif (
+            self.discovery_sub_phase == DISCOVERY_SUB_PHASE_IDENTITY
+            and self.discovery_identity_expected
+        ):
+            # Identity bar is driven from RESPONSES, not the library's
+            # queued-command emits (which all fire in <1s). Each $2E
+            # answer here is one completed register read; advancing the
+            # bar as they arrive makes it track the real ~25s scan
+            # instead of racing to 99% and freezing.
+            self.discovery_identity_responses = min(
+                self.discovery_identity_expected,
+                self.discovery_identity_responses + 1,
+            )
+            self._update_discovery_state(
+                phase=DISCOVERY_PHASE_PC_LINK,
+                message=(
+                    f"Identifying modules — {self.discovery_identity_responses}"
+                    f"/{self.discovery_identity_expected} reads"
+                ),
+            )
         # Only own the status message while we're ACTUALLY in the
         # PC-Link inventory sub-phase. ``parse_inventory_response`` also
         # receives the per-register ``$2E`` frames during the library's
@@ -658,6 +684,25 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
                 self._update_discovery_state(
                     phase=legacy_phase,
                     message=message,
+                )
+                return
+            if sub_phase == DISCOVERY_SUB_PHASE_IDENTITY:
+                # Same problem as inventory, worse: the library queues all
+                # N×96 identity reads up front and emits progress per
+                # QUEUED command, so module_index / registers_sent race to
+                # the end in <1s while the bus scan takes ~25s. Don't let
+                # those counters drive the bar — capture the expected
+                # total (N×96) and let ``_discovery_frame_callback`` advance
+                # it from real $2E answers. Keep modules_total for display.
+                if module_total and register_total:
+                    self.discovery_identity_expected = max(
+                        self.discovery_identity_expected,
+                        module_total * register_total,
+                    )
+                self.discovery_modules_total = module_total
+                self._update_discovery_state(
+                    phase=legacy_phase,
+                    message="Identifying modules…",
                 )
                 return
             # The library's ``register_total`` is now the cumulative

--- a/custom_components/nikobus/discovery_mixin.py
+++ b/custom_components/nikobus/discovery_mixin.py
@@ -565,19 +565,30 @@ class NikobusDiscoveryMixin:
         elif self.discovery_sub_phase == DISCOVERY_SUB_PHASE_IDENTITY:
             floor = DISCOVERY_WEIGHT_INVENTORY
             phase_weight = DISCOVERY_WEIGHT_IDENTITY
-            total = self.discovery_modules_total or 1
-            done = self.discovery_modules_done
-            # 2.11.2: include per-module register progress so the bar
-            # moves smoothly during the ~30 s the library takes to scan
-            # one module's 96 identity registers, instead of jumping
-            # per-module (~0.4 % per step on a 47-module install).
-            per_module = 0.0
-            if self.discovery_registers_total:
-                per_module = min(
+            if self.discovery_identity_expected:
+                # Response-driven: the library queues all N×96 identity
+                # reads up front and emits progress per QUEUED command
+                # (racing to ~100 % in <1 s while the bus scan takes
+                # ~25 s). The frame callback counts the $2E answers as
+                # they actually arrive — that's the real progress.
+                phase_frac = min(
                     1.0,
-                    self.discovery_registers_done / self.discovery_registers_total,
+                    self.discovery_identity_responses
+                    / self.discovery_identity_expected,
                 )
-            phase_frac = min(1.0, (done + per_module) / total)
+            else:
+                # Fallback for older libraries that don't surface the
+                # per-address total: the old module-index estimate.
+                total = self.discovery_modules_total or 1
+                done = self.discovery_modules_done
+                per_module = 0.0
+                if self.discovery_registers_total:
+                    per_module = min(
+                        1.0,
+                        self.discovery_registers_done
+                        / self.discovery_registers_total,
+                    )
+                phase_frac = min(1.0, (done + per_module) / total)
         elif self.discovery_sub_phase == DISCOVERY_SUB_PHASE_REGISTER_SCAN:
             floor = DISCOVERY_WEIGHT_INVENTORY + DISCOVERY_WEIGHT_IDENTITY
             phase_weight = DISCOVERY_WEIGHT_REGISTER_SCAN
@@ -720,6 +731,8 @@ class NikobusDiscoveryMixin:
         self._discovery_finished_event.clear()
         self._last_module_scan_was_full = False
         self._discovery_scope = "inventory"
+        self.discovery_identity_responses = 0
+        self.discovery_identity_expected = 0
         self._update_discovery_state(
             phase=DISCOVERY_PHASE_PC_LINK,
             message="Probing for PC-Link…",

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -383,6 +383,8 @@ class TestDiscoveryFrameRouting(unittest.IsolatedAsyncioTestCase):
         coord.inventory_query_type = InventoryQueryType.PC_LINK
         coord.discovery_registers_done = 0
         coord.discovery_registers_total = 96
+        coord.discovery_identity_responses = 0
+        coord.discovery_identity_expected = 96
         coord.discovery_sub_phase = DISCOVERY_SUB_PHASE_INVENTORY
         coord._update_discovery_state = MagicMock()
         coord.nikobus_command = MagicMock()
@@ -442,14 +444,15 @@ class TestDiscoveryFrameRouting(unittest.IsolatedAsyncioTestCase):
 
         # Frame still parsed (the library needs every $2E response)…
         coord.nikobus_discovery.parse_inventory_response.assert_awaited_once_with(data)
-        # …but NOT counted: during identity the library's on_progress
-        # emits own the counters (progress-audit follow-up to 2.11.2 —
-        # counting here fought those authoritative values and produced
-        # flickering/incoherent register counts in the UI).
+        # …the INVENTORY register counter must NOT advance during identity…
         self.assertEqual(coord.discovery_registers_done, 0)
-        # And the status message must NOT be touched — keeps whatever
-        # _handle_discovery_progress wrote for the identity phase.
-        coord._update_discovery_state.assert_not_called()
+        # …but the identity RESPONSE counter does: the bar is driven from
+        # $2E answers as they arrive (the library queues all reads up
+        # front, so its own emits race ahead and freeze the bar at 99%).
+        self.assertEqual(coord.discovery_identity_responses, 1)
+        # The status message reflects the response progress, not the
+        # stale "PC Link inventory: X/Y" inventory message.
+        coord._update_discovery_state.assert_called_once()
 
     async def test_frame_dropped_when_discovery_not_running(self):
         coord = self._make_coordinator_stub()

--- a/tests/test_discovery_progress_vendor_aligned.py
+++ b/tests/test_discovery_progress_vendor_aligned.py
@@ -198,7 +198,8 @@ def test_handler_resets_counters_on_sub_phase_transition() -> None:
 
 
 def _percent_coord(scope, sub_phase, *, regs_done=0, regs_total=0,
-                   mods_done=0, mods_total=0):
+                   mods_done=0, mods_total=0,
+                   id_responses=0, id_expected=0):
     """Bare coordinator exercising the discovery_progress_percent property."""
     from custom_components.nikobus.coordinator import NikobusDataCoordinator
 
@@ -210,6 +211,8 @@ def _percent_coord(scope, sub_phase, *, regs_done=0, regs_total=0,
     c.discovery_registers_total = regs_total
     c.discovery_modules_done = mods_done
     c.discovery_modules_total = mods_total
+    c.discovery_identity_responses = id_responses
+    c.discovery_identity_expected = id_expected
     return c
 
 
@@ -236,11 +239,22 @@ def test_module_scan_finalizing_near_complete() -> None:
 
 
 def test_inventory_scope_spans_full_bar() -> None:
-    """Load Project Overview (inventory+identity) spans 0→100 on its own."""
+    """Load Project Overview (inventory+identity) spans 0→100 on its own.
+
+    Identity is response-driven: all answers in → raw 30 → /30*100 → 99.9 cap.
+    """
     c = _percent_coord("inventory", "identity",
-                       regs_done=0, regs_total=0, mods_done=1, mods_total=1)
-    # identity done=1/1 → raw 30 → /30*100 = 100 → capped 99.9
+                       id_responses=96, id_expected=96)
     assert c.discovery_progress_percent == 99.9
+
+
+def test_inventory_scope_identity_midpoint_tracks_responses() -> None:
+    """Half the identity answers in → ~midpoint of the identity band,
+    NOT racing to 99% (the queue-ahead bug)."""
+    c = _percent_coord("inventory", "identity",
+                       id_responses=48, id_expected=96)
+    # floor 10 + 0.5*20 = 20 → /30*100 = 66.7
+    assert 60.0 <= c.discovery_progress_percent <= 70.0
 
 
 def test_full_scope_unchanged() -> None:
@@ -309,12 +323,16 @@ def test_frame_counter_only_counts_during_inventory_subphase() -> None:
         NikobusDataCoordinator._discovery_frame_callback.__get__(coord)
     )
 
-    # During identity: counter untouched.
+    # During identity: the INVENTORY counter stays put, but the identity
+    # RESPONSE counter advances (response-driven bar).
     coord.discovery_sub_phase = "identity"
+    coord.discovery_identity_expected = 96
+    coord.discovery_identity_responses = 0
     asyncio.run(coord._discovery_frame_callback("$2E0512"))
     assert coord.discovery_registers_done == 5
+    assert coord.discovery_identity_responses == 1
 
-    # During inventory: counter advances.
+    # During inventory: the inventory counter advances.
     coord.discovery_sub_phase = "inventory"
     asyncio.run(coord._discovery_frame_callback("$2E0512"))
     assert coord.discovery_registers_done == 6
@@ -330,3 +348,29 @@ class _AsyncNoop:
 from nikobus_connect.discovery import InventoryQueryType as _IQT  # noqa: E402
 
 _PCLINK = _IQT.PC_LINK
+
+
+def test_identity_bar_is_response_driven_not_queue_driven() -> None:
+    """Regression (real-log scan): the library queues all N×96 identity
+    reads in <1s and emits progress per QUEUED command, racing the bar
+    to ~99% while the bus scan actually takes ~25s. The handler must NOT
+    advance the bar from those queued emits — it captures the expected
+    total and lets the frame callback advance it per $2E response."""
+    coord, update = _make_coordinator()
+    coord.discovery_identity_responses = 0
+    coord.discovery_identity_expected = 0
+
+    # The 150ms queueing burst: 96 identity emits, registers_sent 1..96.
+    for reg in range(1, 97):
+        asyncio.run(coord._handle_discovery_progress(_FakeProgress(
+            phase="identity", module_index=1, module_total=1,
+            register=0xA0 + reg - 1, register_total=96, registers_sent=reg,
+        )))
+
+    # Expected total captured; the response counter is untouched by the
+    # burst (so the bar is still at the identity floor, not racing ahead).
+    assert coord.discovery_identity_expected == 96
+    assert coord.discovery_identity_responses == 0
+    # And the handler did not write the queued register counters through.
+    last = update.call_args.kwargs
+    assert "registers_done" not in last


### PR DESCRIPTION
## Summary

Your scan log pinned it exactly. The PC-Link inventory bar jumps **0 → 99 %** then freezes ~25 s — and it's a *different* bug from the ones #458 fixed.

### Root cause (from the log)
The **identity phase** (the bulk of a "Load Project Overview") queues all N×96 register reads up front:
- `21:49:25.474` inventory starts
- `21:49:25.624` — **all 96 reads queued** (150 ms)
- `21:49:50.164` — phase **completes**, ~**25 s** later, with the 94 `$2E` answers streaming back over that window (25.7 → 40.1)

The library emits `on_progress` **per queued command**, so all 96 progress events fire in that 150 ms burst → the bar races to ~99 % instantly, then sits frozen for the 25 s the scan actually takes (zero further emits), then snaps to 100.

### Fix (HA-side, no library change)
Drive the identity bar from **responses**, not queued commands — the `$2E` answers already flow through `_discovery_frame_callback` as they arrive:
- **`_handle_discovery_progress`** (identity): capture the expected total (`module_total × register_total` = N×96) and return early — don't let the racing queued counters drive the bar.
- **`_discovery_frame_callback`**: during identity, count each `$2E` answer into `discovery_identity_responses` and refresh the bar/message.
- **`discovery_progress_percent`** (identity): `phase_frac = responses / expected` (falls back to the old module-index estimate for older libraries that don't surface the per-address total).

### Verified against the log's actual values (1 address × 96 reads, 94 responses)

| | before | after |
|---|---|---|
| after 150 ms queue burst | **99.9 %** | **33 %** |
| as answers arrive (24/48/72/94) | frozen 99.9 % | **50 / 67 / 83 / 99 %** |
| finished | 100 % | 100 % |

Smooth and monotonic, tracking the real 25 s scan. Register-scan ("Load Existing Installation") was already real-time (synchronous send-and-wait) and is unchanged.

## Tests
+2 regressions (response-driven vs queue-driven; identity midpoint tracks responses); 3 existing tests updated for the new behaviour. `446 passed`, `ruff` clean, `mypy` 100 (= baseline).

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_