### PR TITLE
fix(scene): CF scenes get their own device, named by the scene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 3.8.5
+
+- **Central Function scenes now get their own device, named after the
+  scene.** A CF scene whose bus address is also a physical button (e.g.
+  *CloseHouse - Leave*, triggered by a *Corridor Master DOWN* wall button)
+  was being merged into that button's HA device and shown under the
+  button's name — the scene was buried as a sub-entity. CF scenes now
+  register a distinct ``cf_<address>`` device under the Scenes hub, named
+  by the CF (the directional roller Open/Close scenes share one device per
+  CF). The physical button keeps its own device. Entity IDs are unchanged,
+  so dashboards and history referencing the scene survive. The matched
+  ``.nkb`` scene name is also persisted onto the CF record so the scene
+  device keeps the right name on its own device.
+
 ## 3.8.4
 
 - **Roller central functions are now actionable from HA.** An imported

--- a/custom_components/nikobus/discovery_mixin.py
+++ b/custom_components/nikobus/discovery_mixin.py
@@ -1070,11 +1070,20 @@ class NikobusDiscoveryMixin:
         if "scenes" in cats and self.cf_storage is not None:
             scene_by_members = {sc.members: sc.name for sc in data.scenes}
             matched_scene_members: set[frozenset[tuple[str, int, str]]] = set()
+            names_persisted = False
             for cf_addr, cf in self.cf_storage.data.get("nikobus_cf", {}).items():
                 hit = scene_by_members.get(cf_member_set(cf))
                 if hit:
                     cf_name_by_addr[str(cf_addr).upper()] = hit
                     matched_scene_members.add(cf_member_set(cf))
+                    # Persist the name onto the CF itself. The scene entity
+                    # lives on its own ``cf_<addr>`` device (so it isn't
+                    # merged into the trigger button's device), which the
+                    # address-keyed registry rename below doesn't reach —
+                    # so the name has to travel with the CF record.
+                    if cf.get("name") != hit:
+                        cf["name"] = hit
+                        names_persisted = True
             graph = build_routing_graph(self.dict_button_data)
             existing = self.cf_storage.data.setdefault("nikobus_cf", {})
             new_entries: dict[str, dict[str, Any]] = {}
@@ -1099,8 +1108,9 @@ class NikobusDiscoveryMixin:
                 cf_name_by_addr[canonical] = sc.name
             if new_entries:
                 existing.update(new_entries)
-                await self.cf_storage.async_save()
                 scenes_created = len(new_entries)
+            if new_entries or names_persisted:
+                await self.cf_storage.async_save()
 
         dev_reg = dr.async_get(self.hass)
         ent_reg = er.async_get(self.hass)

--- a/custom_components/nikobus/entity.py
+++ b/custom_components/nikobus/entity.py
@@ -62,8 +62,19 @@ class NikobusEntity(CoordinatorEntity[NikobusDataCoordinator]):
         name: str,
         model: str,
         via_device: tuple[str, str] | None = None,
+        device_identifier: str | None = None,
     ) -> None:
-        """Initialize the entity with shared device information."""
+        """Initialize the entity with shared device information.
+
+        ``address`` is the bus address used for state-refresh signal
+        routing and the module-address attribute. ``device_identifier``
+        overrides the HA *device* this entity belongs to; it defaults to
+        ``address`` (one device per module). Pass a distinct value to
+        give an entity its own device even though it shares a bus address
+        with another — e.g. a Central Function scene whose ``address`` is
+        also a physical button, so the scene gets its own device named by
+        the CF rather than being merged into the button's device.
+        """
         super().__init__(coordinator)
         self._address = address
         self._device_name = name
@@ -71,7 +82,7 @@ class NikobusEntity(CoordinatorEntity[NikobusDataCoordinator]):
 
         # Group every channel of a module under one physical device.
         device_info = dr.DeviceInfo(
-            identifiers={(DOMAIN, self._address)},
+            identifiers={(DOMAIN, device_identifier or self._address)},
             name=self._device_name,
             manufacturer=BRAND,
             model=self._device_model,

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -22,5 +22,5 @@
     "pyserial-asyncio-fast>=0.16",
     "nikobus-connect>=0.27.3"
   ],
-  "version": "3.8.4"
+  "version": "3.8.5"
 }

--- a/custom_components/nikobus/scene.py
+++ b/custom_components/nikobus/scene.py
@@ -195,6 +195,10 @@ class NikobusCFSceneEntity(NikobusEntity, Scene):
             name=name,
             model=f"CF Broadcast ({pattern})",
             via_device=(DOMAIN, CATEGORY_SCENES),
+            # Own device, keyed off the CF (not the bare bus address), so a
+            # scene whose address is also a physical button isn't merged
+            # into — and renamed after — that button's device.
+            device_identifier=f"cf_{addr.lower()}",
         )
         self._bus_address = addr
         self._pattern = pattern
@@ -206,7 +210,10 @@ class NikobusCFSceneEntity(NikobusEntity, Scene):
             self._triggered_by = [str(t).upper() for t in triggers]
         else:
             self._triggered_by = [addr]
-        self._attr_name = name
+        # The scene is the device's primary feature, so it carries no
+        # entity-name part — its friendly name is just the device name
+        # (the CF name), not "<CF name> <CF name>".
+        self._attr_name = None
         self._attr_unique_id = f"nikobus_cf_{addr.lower()}"
 
     @property
@@ -325,19 +332,24 @@ class NikobusCFRollerSceneEntity(NikobusEntity, Scene):
         else:
             base = f"Nikobus roller CF {addr}"
         suffix = "Open" if direction == "open" else "Close"
-        name = f"{base} {suffix}"
 
         super().__init__(
             coordinator=coordinator,
             address=addr,
-            name=name,
+            # Device name is the CF base; both directions share one device.
+            name=base,
             model=f"CF Scene ({pattern})",
             via_device=(DOMAIN, CATEGORY_SCENES),
+            # Own device per CF (shared by the Open/Close entities), keyed
+            # off the CF rather than the bus address so it isn't merged
+            # into a physical button's device.
+            device_identifier=f"cf_{addr.lower()}",
         )
         self._bus_address = addr
         self._pattern = pattern
         self._members = members  # [{module_address, channel, time}, ...]
-        self._attr_name = name
+        # Direction is the entity-name part → "<base> Open" / "<base> Close".
+        self._attr_name = suffix
         self._attr_unique_id = f"nikobus_cf_{addr.lower()}_{direction}"
 
         # Guard against overlapping roller release tasks (per module token).

--- a/tests/test_nkbnames.py
+++ b/tests/test_nkbnames.py
@@ -152,6 +152,11 @@ def test_import_names_areas_and_scene_match():
     # (no room) keep their bare name.
     assert names == {"d1": "Dimcontroller (Centrale)", "d2": "Entree (Living)",
                      "d3": "Scene - Test"}
+    # The matched name is persisted onto the CF record too — the scene
+    # entity lives on its own ``cf_<addr>`` device (not merged into the
+    # trigger button), which the address-keyed device rename can't reach,
+    # so the name has to travel with the CF.
+    assert coord.cf_storage.data["nikobus_cf"]["DE4E2C"]["name"] == "Scene - Test"
     # areas assigned for the two room-bearing devices (not the scene)
     area_calls = [c for c in dev_reg.async_update_device.call_args_list
                   if "area_id" in c.kwargs]

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -13,6 +13,7 @@ import unittest
 import unittest.mock
 from unittest.mock import AsyncMock, MagicMock
 
+from custom_components.nikobus.const import DOMAIN
 from custom_components.nikobus.scene import (
     NikobusCFRollerSceneEntity,
     NikobusCFSceneEntity,
@@ -130,6 +131,28 @@ class TestCFSceneActivation(unittest.TestCase):
         _run(e.async_activate())
         coord.async_activate_cf_broadcast.assert_awaited_once_with("DE4E2C")
 
+    def test_scene_gets_own_device_named_by_cf(self):
+        """A CF scene whose address is also a physical button must not be
+        merged into that button's device — it gets its own ``cf_<addr>``
+        device named by the CF, with no entity-name part (so its friendly
+        name is just the CF name, not doubled)."""
+        e = NikobusCFSceneEntity(
+            MagicMock(),
+            bus_address="C177CE",
+            cf_config={
+                "pattern": "nkb_scene",
+                "name": "CloseHouse - Leave",
+                "outputs": [],
+                "triggered_by": ["C177CE"],
+            },
+        )
+        self.assertEqual(
+            e._attr_device_info["identifiers"], {(DOMAIN, "cf_c177ce")}
+        )
+        self.assertEqual(e._device_name, "CloseHouse - Leave")
+        self.assertIsNone(e._attr_name)
+        self.assertEqual(e._attr_unique_id, "nikobus_cf_c177ce")
+
 
 class TestParseCfTime(unittest.TestCase):
     def test_seconds_minutes_and_invalid(self):
@@ -188,7 +211,15 @@ class TestCFRollerScene(unittest.TestCase):
             [{"module_address": "8CF5", "channel": 1, "time": "40 s"}],
             "close",
         )
-        self.assertEqual(e._attr_name, "Gordijnen keuken Close")
+        # The CF name is the device name; the direction is the entity-name
+        # part, so HA composes "Gordijnen keuken Close".
+        self.assertEqual(e._device_name, "Gordijnen keuken")
+        self.assertEqual(e._attr_name, "Close")
+        # Own device, keyed off the CF (not the bare bus address) and
+        # shared by both directions.
+        self.assertEqual(
+            e._attr_device_info["identifiers"], {(DOMAIN, "cf_3880cd")}
+        )
 
     def test_close_drives_members_atomically_once_per_module(self):
         e, coord = _make_roller_scene("close")


### PR DESCRIPTION
## Problem

A Central Function scene whose bus address is also a physical button gets buried under the button's name. Concretely, on a real install: address `C177CE` is both the **CloseHouse - Leave** CF scene *and* the **Corridor Master DOWN** wall button. In HA they appeared as a single device named `BT_GF_Corridor_Master_DOWN`, with the scene hidden as a sub-entity — so the scene wasn't discoverable by its real name.

Root cause: both the button entity (`button.py`) and the scene entity (via `entity.py`) registered their device with the **same identifier** `(DOMAIN, address)`, so HA merged them into one device. The `.nkb` *device-name* import then set that device's name to the button name, and the button name won.

## Fix

CF scenes now register a **distinct device** keyed off the CF — `(DOMAIN, "cf_<addr>")` — under the existing Scenes hub, named by the CF. The physical button keeps its own device. The directional roller Open/Close scenes share one device per CF (CF name = device name, direction = entity-name part, so `"<CF> Open"` / `"<CF> Close"`).

Because the address-keyed device-name import no longer reaches the scene device, the matched `.nkb` scene name is now **persisted onto the CF record** so the name travels with the CF.

## Changes

- `entity.py`: `NikobusEntity` gains an optional `device_identifier` (defaults to the bus address — module entities unchanged).
- `scene.py`: broadcast + directional roller CF scenes pass a `cf_<addr>` device identifier; the broadcast scene's name moves to the device (entity name `None` → friendly name is the bare CF name, not doubled).
- `discovery_mixin.py`: a matched `.nkb` scene name is written onto the CF record (not just the address-keyed device registry).
- Tests: own-device + name-split assertions for both scene classes; matched-name persistence.
- Version `3.8.4` → `3.8.5` + CHANGELOG.

## Compatibility

Entity unique IDs (`nikobus_cf_<addr>`, `nikobus_cf_<addr>_<dir>`) are unchanged, so entity IDs, history, and dashboards referencing the scene survive. Only the device grouping changes: on next load the scene re-homes to its own device and the button device keeps its press/sensor entities.

## Testing

`468 passed`; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_