### PR TITLE
scene 3.8.7: channel names in outputs + fix scene-activated event name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.8.7
+
+- **Fix: `nikobus_scene_activated` event carried `name: null`.** Since
+  3.8.5 the scene's name lives on its device (the entity name is `None`
+  to avoid a doubled friendly name), so the event payload now reads the
+  scene name from the device — automations matching on the scene name
+  work again.
+
 ## 3.8.6
 
 - **`.nkb` name import now renames the scene's own device.** 3.8.5 moved

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -22,5 +22,5 @@
     "pyserial-asyncio-fast>=0.16",
     "nikobus-connect>=0.28.0"
   ],
-  "version": "3.8.6"
+  "version": "3.8.7"
 }

--- a/custom_components/nikobus/scene.py
+++ b/custom_components/nikobus/scene.py
@@ -285,7 +285,10 @@ class NikobusCFSceneEntity(NikobusEntity, Scene):
             EVENT_SCENE_ACTIVATED,
             {
                 "address": fired,
-                "name": self._attr_name,
+                # The scene's name now lives on the device (entity name is
+                # None so the friendly name isn't doubled), so the event
+                # payload reads it from there rather than ``_attr_name``.
+                "name": self._device_name,
                 "entity_id": self.entity_id,
                 "member_count": len(self._outputs),
             },

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -373,6 +373,11 @@ class TestCFSceneAttributes(unittest.TestCase):
         self.assertEqual(name, "nikobus_scene_activated")
         self.assertEqual(payload["address"], "DE4E2C")
         self.assertEqual(payload["member_count"], 1)
+        # The event must carry the scene's name (the CF name on the
+        # device), not None — the entity name is now None to avoid a
+        # doubled friendly name, so the payload reads the device name.
+        self.assertIsNotNone(payload["name"])
+        self.assertEqual(payload["name"], e._device_name)
 
     def test_subscribes_to_each_trigger_signal(self):
         from unittest.mock import patch


### PR DESCRIPTION
Two scene-attribute improvements, released together as 3.8.7. (Follow-up to #464, which merged at `7a0d8ce` before these landed.)

## 1. `outputs` attribute now shows channel names (enhancement)

A CF scene's `outputs` attribute listed each member as *module + bare channel number + action*, so reading what a scene actually drives meant mapping channel numbers to rooms by hand:

```
- module: Switch module (Centrale) (4707)
  channel: 6
  action: M03 (Off + Operating time)
```

The channel is now shown as **`Name (N)`** — the output channel's imported (`.nkb`) / user name with the number in parentheses, mirroring how `address_label` formats modules:

```
- module: Switch module (Centrale) (4707)
  channel: Boudoir - Plafonnier (6)
  action: M03 (Off + Operating time)
```

The name reflects manual renames too (resolved from the per-channel entity). Channels with no name keep the bare number. Resolution is via a new `channel_label_map()` on the coordinator.

## 2. Fix: `nikobus_scene_activated` fired with `name: null`

Since 3.8.5 the broadcast CF scene's entity name is `None` (its name lives on its own device, to avoid a doubled friendly name). But `_handle_trigger` still read the event payload's `name` from `self._attr_name` — now `None` — so a physical press fired the event with `name: null`, breaking automations matching a scene by name. The payload now reads `self._device_name` (the CF name).

## Changes

- `discovery_mixin.py`: `channel_label_map()` → `(MODULE, channel) → output name`.
- `scene.py`: `_human_outputs` shows the channel as `Name (N)`; `nikobus_scene_activated` payload `name` uses the device name.
- Tests: outputs show `Name (N)` when known (bare number otherwise); fired event carries the scene name (not `None`).
- Version `3.8.6` → `3.8.7` + CHANGELOG.

## Testing

Full suite passes (469); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)