### PR TITLE
feat(scene): show output channel names in scene attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 3.8.8
+
+- **Scene `outputs` attribute now shows channel names.** Each member of a
+  CF scene's `outputs` attribute shows its channel as `Name (N)` — the
+  output channel's imported / user name with the channel number in
+  parentheses, e.g. `Boudoir - Plafonnier (8)` — so you can read what a
+  scene drives without mapping channel numbers by hand. The name reflects
+  the `.nkb` channel-name import and any manual rename; channels with no
+  name keep the bare number.
+
 ## 3.8.7
 
 - **Fix: `nikobus_scene_activated` event carried `name: null`.** Since

--- a/custom_components/nikobus/discovery_mixin.py
+++ b/custom_components/nikobus/discovery_mixin.py
@@ -153,6 +153,30 @@ class NikobusDiscoveryMixin:
         def invalidate_controlled_by_index(self) -> None: ...
         async def async_send_button_press(self, address: str) -> None: ...
 
+    def channel_label_map(self) -> dict[tuple[str, int], str]:
+        """Map ``(MODULE_ADDR_UPPER, channel) -> output channel name``.
+
+        Reads the per-channel output entities from the registry, so the
+        names reflect the ``.nkb`` channel-name import *and* any manual
+        rename — e.g. ``("0E6C", 8) -> "Boudoir - Plafonnier"``. Lets CF
+        scene attributes show human channel names instead of bare numbers.
+        Channels with no name are omitted.
+        """
+        out: dict[tuple[str, int], str] = {}
+        if self.hass is None:
+            return out
+        ent_reg = er.async_get(self.hass)
+        for ent in er.async_entries_for_config_entry(
+            ent_reg, self.config_entry.entry_id
+        ):
+            key = _output_entity_key(ent.unique_id)
+            if key is None:
+                continue
+            name = ent.name or ent.original_name
+            if name:
+                out[key] = name
+        return out
+
     def _surface_legacy_undecoded_buttons(
         self, buttons: dict[str, Any]
     ) -> None:

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -22,5 +22,5 @@
     "pyserial-asyncio-fast>=0.16",
     "nikobus-connect>=0.28.0"
   ],
-  "version": "3.8.7"
+  "version": "3.8.8"
 }

--- a/custom_components/nikobus/scene.py
+++ b/custom_components/nikobus/scene.py
@@ -248,13 +248,27 @@ class NikobusCFSceneEntity(NikobusEntity, Scene):
 
     def _human_outputs(self) -> list[dict[str, Any]]:
         """Members with module names + level; address kept for reference."""
+        # ``(MODULE, channel) -> output name`` so each member shows its
+        # real channel name (e.g. "Appliques Salon") instead of a bare
+        # number; built once for the whole member list.
+        channel_names = self.coordinator.channel_label_map()
         out_list: list[dict[str, Any]] = []
         for member in self._outputs:
             if not isinstance(member, dict):
                 continue
+            channel = member.get("channel")
+            module_addr = str(member.get("module_address") or "").upper()
+            # Show the channel as "Name (N)" when the output has an
+            # imported / user name (mirrors ``address_label``), else the
+            # bare number.
+            channel_label: Any = channel
+            if isinstance(channel, int):
+                name = channel_names.get((module_addr, channel))
+                if name:
+                    channel_label = f"{name} ({channel})"
             entry: dict[str, Any] = {
                 "module": self.coordinator.address_label(member.get("module_address")),
-                "channel": member.get("channel"),
+                "channel": channel_label,
                 "action": member.get("mode"),
             }
             level = member.get("t1")

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -286,10 +286,11 @@ class TestCFRollerScene(unittest.TestCase):
 
 
 class TestCFSceneAttributes(unittest.TestCase):
-    def _make(self, outputs):
+    def _make(self, outputs, channel_names=None):
         coord = MagicMock()
         coord.address_label = lambda a: f"mod_{a} ({a})" if a else ""
         coord.get_button_context = MagicMock(return_value=None)
+        coord.channel_label_map = MagicMock(return_value=channel_names or {})
         e = NikobusCFSceneEntity(
             coord,
             bus_address="DE4E2C",
@@ -314,6 +315,25 @@ class TestCFSceneAttributes(unittest.TestCase):
             outs[1],
             {"module": "mod_8394 (8394)", "channel": 1, "action": "M02 (Open)"},
         )
+
+    def test_human_outputs_include_channel_name(self):
+        """When the output channel has an imported/user name, the channel
+        field is shown as "Name (N)"; otherwise it's the bare number."""
+        e, _ = self._make(
+            [
+                {"module_address": "0E6C", "channel": 8,
+                 "mode": "M12 (Preset on)", "t1": "5%"},
+                {"module_address": "4707", "channel": 6,
+                 "mode": "M03 (Off + Operating time)", "t1": "0s"},
+            ],
+            channel_names={
+                ("0E6C", 8): "Boudoir - Plafonnier",
+                # 4707 ch6 has no name -> bare number
+            },
+        )
+        outs = e._human_outputs()
+        self.assertEqual(outs[0]["channel"], "Boudoir - Plafonnier (8)")
+        self.assertEqual(outs[1]["channel"], 6)
 
     def test_triggered_by_falls_back_to_address(self):
         e, coord = self._make([])


### PR DESCRIPTION
Enhancement requested after #465 merged (so it needs its own PR). Version `3.8.7` → `3.8.8`.

## What

A CF scene's `outputs` attribute listed each member as *module + bare channel number + action*, so reading what a scene actually drives meant mapping channel numbers to rooms by hand:

```
- module: Switch module (Centrale) (4707)
  channel: 6
  action: M03 (Off + Operating time)
```

Each entry now shows its channel as **`Name (N)`** — the output channel's imported (`.nkb`) / user name with the number in parentheses, mirroring how `address_label` formats modules:

```
- module: Switch module (Centrale) (4707)
  channel: Boudoir - Plafonnier (6)
  action: M03 (Off + Operating time)
```

The name reflects the `.nkb` channel-name import **and** any manual rename (resolved from the per-channel entity in the registry). Channels with no name keep the bare number.

## Changes

- `discovery_mixin.py`: new `channel_label_map()` → `(MODULE, channel) → output name`, read from the per-channel light/switch/cover entities.
- `scene.py`: `_human_outputs` renders the channel as `Name (N)`.
- Tests: outputs show `Name (N)` when the channel is named, bare number otherwise.
- Version `3.8.7` → `3.8.8` + CHANGELOG.

## Testing

Full suite passes (469); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_