### PR TITLE
feat: roller central functions as grouped covers (+ scene-mapping spec)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 3.9.0
+
+- **Roller central functions are now grouped covers, not scenes.** A
+  Nikobus Central Function whose members are *all* roller (shutter)
+  channels — including `M01` "open-stop-close" toggle groups — is now
+  surfaced as a single member-driving **cover** (open / close / stop)
+  instead of a broadcast or directional scene. The cover drives every
+  member channel atomically through the per-module commit path (one bus
+  frame per module) with a timed stop from the channels' operation times,
+  so it is deterministic even for `M01` toggle groups, which a broadcast
+  could not be. These covers live under a new **"Central functions"**
+  device category. Mixed (light + roller) and light-only CFs are
+  unchanged — they stay scenes/broadcasts.
+
 ## 3.8.8
 
 - **Scene `outputs` attribute now shows channel names.** Each member of a

--- a/custom_components/nikobus/const.py
+++ b/custom_components/nikobus/const.py
@@ -35,6 +35,7 @@ CATEGORY_WALL_BUTTONS: Final[str] = "category_wall_buttons"
 CATEGORY_REMOTES: Final[str] = "category_remotes"
 CATEGORY_INTERFACES: Final[str] = "category_interfaces"
 CATEGORY_SCENES: Final[str] = "category_scenes"
+CATEGORY_CENTRAL_FUNCTIONS: Final[str] = "category_central_functions"
 
 # Display metadata for each category device (identifier → (name, model)).
 # Order is the order they get registered in; HA preserves it in the device
@@ -51,6 +52,7 @@ CATEGORY_DEVICES: Final[tuple[tuple[str, str, str], ...]] = (
     (CATEGORY_INTERFACES, "Interfaces",
      "Push-button / switch / universal interfaces"),
     (CATEGORY_SCENES, "Scenes", "Software scenes"),
+    (CATEGORY_CENTRAL_FUNCTIONS, "Central functions", "Roller / shutter groups"),
 )
 
 # =============================================================================

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -1388,27 +1388,21 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
                 known.add(f"{DOMAIN}_scene_{sid}")
         # CF entities classified by the library during discovery. Most
         # surface as a single ``NikobusCFSceneEntity`` (unique_id
-        # ``nikobus_cf_<addr>``). A roller CF with decoded open/close
-        # members instead surfaces as one ``NikobusCFRollerSceneEntity``
-        # per direction (unique_id ``nikobus_cf_<addr>_<open|close>``). The
-        # split must match what the scene platform creates
-        # (``cf_roller_directions`` is the single source of truth), else
-        # ``_async_cleanup_orphan_entities`` evicts the entity right after
-        # its platform creates it.
+        # ``nikobus_cf_<addr>``). A pure-roller CF (every member a shutter
+        # channel, incl. ``M01`` toggle groups) instead surfaces as a
+        # grouped ``NikobusCFCoverEntity`` (unique_id
+        # ``nikobus_cf_cover_<addr>``). The split must match what the cover /
+        # scene platforms create (``is_pure_roller_cf`` is the single source
+        # of truth), else ``_async_cleanup_orphan_entities`` evicts the
+        # entity right after its platform creates it.
         if self.cf_storage is not None:
             cf_entries = self.cf_storage.data.get("nikobus_cf", {})
             if isinstance(cf_entries, dict):
-                from .nkbreconcile import cf_roller_directions
+                from .nkbreconcile import is_pure_roller_cf
                 for cf_addr, cf in cf_entries.items():
                     addr_lower = str(cf_addr).lower()
-                    directions = (
-                        cf_roller_directions(cf)
-                        if isinstance(cf, dict) and cf.get("pattern") == "roller_pair"
-                        else {}
-                    )
-                    if directions:
-                        for direction in directions:
-                            known.add(f"nikobus_cf_{addr_lower}_{direction}")
+                    if isinstance(cf, dict) and is_pure_roller_cf(cf):
+                        known.add(f"nikobus_cf_cover_{addr_lower}")
                     else:
                         known.add(f"nikobus_cf_{addr_lower}")
         known.add(f"{DOMAIN}_connection_status")

--- a/custom_components/nikobus/cover.py
+++ b/custom_components/nikobus/cover.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+import uuid
 from typing import Any
 
 from homeassistant.components.cover import (
@@ -20,13 +21,16 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
+    CATEGORY_CENTRAL_FUNCTIONS,
     DEFAULT_COVER_DEBOUNCE_DELAY,
     DEFAULT_COVER_MOVEMENT_BUFFER,
     DEFAULT_COVER_OPERATION_TIME,
+    DOMAIN,
     press_signal,
 )
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity, command_error
+from .nkbreconcile import cf_cover_members, is_pure_roller_cf
 from .nkbtravelcalculator import NikobusTravelCalculator
 from .router import build_unique_id, get_routing, register_output_module_devices
 
@@ -64,6 +68,28 @@ STATE_STOPPED = 0x00
 STATE_OPENING = 0x01
 STATE_CLOSING = 0x02
 STATE_ERROR = 0x03  # Catches logic engine conflicts
+
+
+def _parse_cf_time(value: Any) -> float | None:
+    """Parse a CF member timing string (e.g. ``"30 s"`` / ``"2 m"``) to seconds.
+
+    Returns ``None`` when the value is missing or unparseable, so the caller
+    can fall back to the module's configured operation time.
+    """
+    if value is None:
+        return None
+    text = str(value).strip().lower()
+    if not text:
+        return None
+    minutes = text.endswith("m") and not text.endswith("ms")
+    number = text.rstrip("ms ").strip()
+    try:
+        seconds = float(number)
+    except ValueError:
+        return None
+    if seconds <= 0:
+        return None
+    return seconds * 60.0 if minutes else seconds
 
 
 async def async_setup_entry(
@@ -104,6 +130,26 @@ async def async_setup_entry(
                 op_time_down,
             )
         )
+
+    # Pure-roller central functions (every member a shutter channel) become
+    # actionable grouped covers. A roller CF bundles its members' open /
+    # close / toggle links, so broadcasting its address can't express a
+    # direction; instead the grouped cover drives the member channels
+    # through the atomic per-module commit path (like a scene). This works
+    # for ``M01`` toggle groups too, because it commands the output state
+    # directly rather than replaying a link.
+    cf_storage = getattr(coordinator, "cf_storage", None)
+    cf_data = cf_storage.data.get("nikobus_cf", {}) if cf_storage is not None else {}
+    if isinstance(cf_data, dict):
+        for bus_address, cf in cf_data.items():
+            if not isinstance(cf, dict) or not is_pure_roller_cf(cf):
+                continue
+            members = cf_cover_members(cf)
+            if not members:
+                continue
+            entities.append(
+                NikobusCFCoverEntity(coordinator, str(bus_address), cf, members)
+            )
 
     async_add_entities(entities)
 
@@ -514,3 +560,364 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
             await self.coordinator.api.stop_cover(self._address, self._channel, dir_cmd)
 
         self.async_write_ha_state()
+
+
+class NikobusCFCoverEntity(NikobusEntity, CoverEntity):
+    """A pure-roller central function surfaced as a grouped cover.
+
+    A pure-roller CF bundles the roller link records for several channels —
+    the keys of a physical wall control (a 2-button open/close, or an
+    ``M01`` "open-stop-close" toggle). Broadcasting the CF address can't
+    express a single direction, so this entity drives the member channels
+    directly through the **atomic per-module commit path**
+    (``set_output_states_for_module``): every channel of one module moves in
+    a single bus frame, with a timed stop scheduled from the channels'
+    operation times — the same engine :class:`NikobusSceneEntity` uses for
+    roller scenes. The result behaves like the native Nikobus scene
+    (all-at-once), while giving HA proper open / close / stop. Driving the
+    output state directly makes it deterministic even for an ``M01`` toggle.
+
+    Position is modelled at the group level by one travel calculator (seeded
+    with the slowest member's run time) so "fully open/closed" reflects the
+    last shutter to finish. The motion loop only advances the displayed
+    position; the real bus stop is sent by the per-module timed-stop tasks,
+    so the loop never cancels itself mid-command.
+    """
+
+    _attr_device_class = CoverDeviceClass.SHUTTER
+    _attr_supported_features = (
+        CoverEntityFeature.OPEN
+        | CoverEntityFeature.CLOSE
+        | CoverEntityFeature.STOP
+    )
+
+    def __init__(
+        self,
+        coordinator: NikobusDataCoordinator,
+        bus_address: str,
+        cf_config: dict[str, Any],
+        members: list[dict[str, Any]],
+    ) -> None:
+        """Initialize the grouped CF cover from its resolved members."""
+        addr = str(bus_address).upper()
+        pattern = str(cf_config.get("pattern") or "roller")
+
+        imported = cf_config.get("name")
+        if isinstance(imported, str) and imported.strip():
+            name = imported.strip()
+        else:
+            name = f"Nikobus CF cover {addr}"
+
+        super().__init__(
+            coordinator=coordinator,
+            address=addr,
+            name=name,
+            model=f"CF Cover ({pattern})",
+            via_device=(DOMAIN, CATEGORY_CENTRAL_FUNCTIONS),
+            # Own device per CF, keyed off the CF (not the bare bus address),
+            # so a cover whose address is also a physical button isn't merged
+            # into — and renamed after — that button's device.
+            device_identifier=f"cf_cover_{addr.lower()}",
+        )
+        self._bus_address = addr
+        self._pattern = pattern
+        self._attr_name = name
+        self._attr_unique_id = f"nikobus_cf_cover_{addr.lower()}"
+
+        # Resolve per-member run times: the CF's own t1 wins, else the
+        # module's configured operation time for that channel/direction.
+        self._members: list[dict[str, Any]] = []
+        max_open = 0.0
+        max_close = 0.0
+        for member in members:
+            module = member["module_address"]
+            channel = member["channel"]
+            open_t = _parse_cf_time(member.get("open_time")) or (
+                coordinator.get_cover_operation_time(module, channel, "up")
+            )
+            close_t = _parse_cf_time(member.get("close_time")) or (
+                coordinator.get_cover_operation_time(module, channel, "down")
+            )
+            self._members.append(
+                {
+                    "module_address": module,
+                    "channel": channel,
+                    "open_time": open_t,
+                    "close_time": close_t,
+                }
+            )
+            max_open = max(max_open, open_t)
+            max_close = max(max_close, close_t)
+
+        self._calculator = NikobusTravelCalculator(
+            max_open or DEFAULT_COVER_OPERATION_TIME,
+            max_close or DEFAULT_COVER_OPERATION_TIME,
+        )
+        self._position: float = 100.0
+        self._state = STATE_STOPPED
+        self._run_limit: float = 0.0
+        self._motion_task: asyncio.Task[None] | None = None
+        # One stop token per module, re-minted on every move so a stale
+        # timed stop from a previous activation can't fire on a fresh move.
+        self._module_tokens: dict[str, str] = {}
+        self._stop_tasks: list[asyncio.Task[None]] = []
+
+    @property
+    def current_cover_position(self) -> int:
+        """Return the current group position (0-100)."""
+        return int(round(self._position))
+
+    @property
+    def is_opening(self) -> bool:
+        return self._state == STATE_OPENING and self._position < 100
+
+    @property
+    def is_closing(self) -> bool:
+        return self._state == STATE_CLOSING and self._position > 0
+
+    @property
+    def is_closed(self) -> bool:
+        return self.current_cover_position == 0
+
+    @property
+    def is_open(self) -> bool:
+        return self.current_cover_position == 100
+
+    def _render_state(self) -> Any:
+        """Group cover has no single bus channel to poll — opt out of diffing."""
+        return (self._state, self.current_cover_position)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        parent = super().extra_state_attributes or {}
+        return {
+            **parent,
+            "bus_address": self._bus_address,
+            "pattern": self._pattern,
+            "member_count": len(self._members),
+            "members": [
+                {
+                    "module": self.coordinator.address_label(m["module_address"]),
+                    "channel": m["channel"],
+                    "open_time": m["open_time"],
+                    "close_time": m["close_time"],
+                }
+                for m in self._members
+            ],
+        }
+
+    async def async_added_to_hass(self) -> None:
+        """Cancel any pending motion / timed-stop tasks on removal."""
+        await super().async_added_to_hass()
+
+        def _cancel_tasks() -> None:
+            self._module_tokens.clear()
+            if self._motion_task:
+                self._motion_task.cancel()
+                self._motion_task = None
+            for task in self._stop_tasks:
+                task.cancel()
+            self._stop_tasks.clear()
+
+        self.async_on_remove(_cancel_tasks)
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Open every member shutter."""
+        try:
+            await self._move("opening")
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            raise command_error(err) from err
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Close every member shutter."""
+        try:
+            await self._move("closing")
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            raise command_error(err) from err
+
+    async def async_stop_cover(self, **kwargs: Any) -> None:
+        """Stop every member shutter."""
+        try:
+            await self._stop()
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            raise command_error(err) from err
+
+    def _members_by_module(self) -> dict[str, list[dict[str, Any]]]:
+        grouped: dict[str, list[dict[str, Any]]] = {}
+        for member in self._members:
+            grouped.setdefault(member["module_address"], []).append(member)
+        return grouped
+
+    async def _move(self, direction: str) -> None:
+        """Drive all members in ``direction`` via per-module atomic commits."""
+        byte_val = STATE_OPENING if direction == "opening" else STATE_CLOSING
+        time_key = "open_time" if direction == "opening" else "close_time"
+
+        # Cancel any in-flight motion / pending stops from a previous move.
+        self._cancel_motion()
+        self._cancel_stops()
+
+        # Longest member run time decides the shared stop deadline, mirroring
+        # the scene path: the most generous buffer absorbs bus contention so a
+        # slow shutter still reaches its end-stop before the stop frame fires.
+        delay = 0.0
+        commanded: dict[str, set[int]] = {}
+        sent_states: dict[str, bytearray] = {}
+
+        for module_id, members in self._members_by_module().items():
+            current = self.coordinator.nikobus_module_states.get(module_id, bytearray(12))
+            state = bytearray(current)
+            for member in members:
+                idx = member["channel"] - 1
+                if 0 <= idx < len(state):
+                    state[idx] = byte_val
+                    commanded.setdefault(module_id, set()).add(idx)
+                op_time = float(member[time_key] or 0.0)
+                if op_time > 0:
+                    delay = max(delay, op_time + DEFAULT_COVER_MOVEMENT_BUFFER)
+            sent_states[module_id] = state
+            await self._commit_module(module_id, state)
+
+        # Schedule the timed stop per module once all are moving.
+        for module_id, indexes in commanded.items():
+            token = uuid.uuid4().hex
+            self._module_tokens[module_id] = token
+            task = self.hass.async_create_task(
+                self._delayed_stop(module_id, sent_states[module_id], indexes, delay, token)
+            )
+            self._stop_tasks.append(task)
+            task.add_done_callback(
+                lambda t: self._stop_tasks.remove(t) if t in self._stop_tasks else None
+            )
+
+        self._start_motion(direction)
+
+    async def _commit_module(self, module_id: str, state: bytearray) -> None:
+        """Stage and push a whole module's state in one bus commit (per group)."""
+        num_chans = self.coordinator.get_module_channel_count(module_id)
+        self.coordinator.set_bytearray_group_state(module_id, 1, state[:6].hex())
+        if num_chans > 6:
+            self.coordinator.set_bytearray_group_state(module_id, 2, state[6:12].hex())
+        await self.coordinator.api.set_output_states_for_module(address=module_id)
+        await self.coordinator.async_event_handler(
+            "nikobus_refreshed", {"impacted_module_address": module_id}
+        )
+
+    async def _delayed_stop(
+        self,
+        module_id: str,
+        sent_state: bytearray,
+        indexes: set[int],
+        delay: float,
+        token: str,
+    ) -> None:
+        """Send the bus stop once travel time elapses.
+
+        Composes the stop frame from the module's CURRENT state at timeout,
+        not the activation snapshot: a channel redirected during travel (by a
+        wall button, another scene, or a direct cover) is left alone — only
+        channels still doing what we commanded are forced to STOPPED.
+        """
+        await asyncio.sleep(delay)
+        if self._module_tokens.get(module_id) != token:
+            return
+
+        current = self.coordinator.nikobus_module_states.get(module_id)
+        stop_state = bytearray(current) if current else bytearray(sent_state)
+        changed = False
+        for idx in indexes:
+            if idx < len(stop_state) and stop_state[idx] == sent_state[idx]:
+                stop_state[idx] = STATE_STOPPED
+                changed = True
+        if not changed:
+            return
+
+        try:
+            await self._commit_module(module_id, stop_state)
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            _LOGGER.error("CF cover %s: timed stop failed for %s: %s", self._bus_address, module_id, err)
+
+    async def _stop(self) -> None:
+        """Stop all members now: cancel timers, commit STOPPED per module."""
+        self._cancel_motion()
+        self._cancel_stops()
+
+        self._calculator.stop()
+        self._position = self._calculator.current_position()
+        self._state = STATE_STOPPED
+
+        for module_id, members in self._members_by_module().items():
+            current = self.coordinator.nikobus_module_states.get(module_id, bytearray(12))
+            state = bytearray(current)
+            for member in members:
+                idx = member["channel"] - 1
+                if 0 <= idx < len(state):
+                    state[idx] = STATE_STOPPED
+            await self._commit_module(module_id, state)
+
+        self.async_write_ha_state()
+
+    def _start_motion(self, direction: str) -> None:
+        """Start the group-level position model for the UI."""
+        self._cancel_motion()
+        self._state = STATE_OPENING if direction == "opening" else STATE_CLOSING
+        active = (
+            self._calculator.time_up if direction == "opening" else self._calculator.time_down
+        )
+        self._calculator.start_travel(direction)
+        self._position = self._calculator.current_position()
+        self._run_limit = max(DEFAULT_COVER_MOVEMENT_BUFFER, active)
+        self._motion_task = self.hass.async_create_task(self._motion_loop())
+        self.async_write_ha_state()
+
+    async def _motion_loop(self) -> None:
+        """Advance the displayed position until travel completes.
+
+        Does not send bus frames — the hardware stop is the job of the
+        per-module timed-stop tasks — so this loop can be cancelled freely
+        without ever swallowing a STOP command.
+        """
+        try:
+            start = time.monotonic()
+            while self._state in (STATE_OPENING, STATE_CLOSING):
+                elapsed = time.monotonic() - start
+                self._position = self._calculator.current_position()
+                if elapsed >= self._run_limit:
+                    self._position = 100.0 if self._state == STATE_OPENING else 0.0
+                    self._calculator.set_position(self._position)
+                    self._state = STATE_STOPPED
+                    self.async_write_ha_state()
+                    break
+                self.async_write_ha_state()
+                await asyncio.sleep(0.5)
+        except asyncio.CancelledError:
+            pass
+
+    def _cancel_motion(self) -> None:
+        task = self._motion_task
+        self._motion_task = None
+        if task is not None and task is not asyncio.current_task():
+            task.cancel()
+
+    def _cancel_stops(self) -> None:
+        self._module_tokens.clear()
+        for task in self._stop_tasks:
+            task.cancel()
+        self._stop_tasks.clear()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Group cover has no single bus channel — ignore poll updates.
+
+        Its state is driven entirely by HA actions and the local motion
+        model; reading a per-channel byte back would be ambiguous across
+        members, so we deliberately don't react to coordinator refreshes.
+        """

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -22,5 +22,5 @@
     "pyserial-asyncio-fast>=0.16",
     "nikobus-connect>=0.28.0"
   ],
-  "version": "3.8.8"
+  "version": "3.9.0"
 }

--- a/custom_components/nikobus/nkbreconcile.py
+++ b/custom_components/nikobus/nkbreconcile.py
@@ -241,25 +241,68 @@ def flatten_cf_broadcasts(broadcasts: dict[str, Any]) -> dict[str, dict[str, Any
     return flat
 
 
-def cf_roller_directions(cf: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
-    """Split a roller CF's outputs into its per-direction member channels.
+def _is_roller_member(mode: Any) -> bool:
+    """True if an output's *mode wording* makes it a roller (shutter) member.
 
-    A roller central function carries open (``M02``) and/or close (``M03``)
-    link records. Returns ``{"open": [...], "close": [...]}`` where each
-    value is the list of ``{module_address, channel, time}`` members for
-    that direction (``time`` is the record's ``t1``), preserving
-    first-sighting order and de-duplicating ``(module, channel)`` within a
-    direction. Directions with no members are omitted::
-
-        2-button (open+close) -> {"open": [...], "close": [...]}
-        single-direction      -> {"close": [...]}  (or {"open": [...]})
-        1-button M01 toggle   -> {}   (no M02/M03 -> not direction-drivable)
-
-    An empty dict means the CF isn't direction-drivable as scenes (e.g. an
-    ``M01`` "open-stop-close" toggle); the caller keeps it a broadcast scene.
+    Detection is by WORDING, not mode code: a roller member's mode label
+    contains ``open``, ``close`` or ``stop`` (case-insensitive) — e.g.
+    ``"M01 (Open - stop - close)"``, ``"M02 (Open)"``, ``"M03 (Close)"``.
+    The ``M02`` / ``M03`` *codes* are shared with switch modules
+    (``"M02 (On + Operating time)"``, ``"M03 (Off + Operating time)"``),
+    so keying off the code would misclassify a switch member as a roller.
+    Dimmer / switch modes like ``"M12 (Preset on)"`` or
+    ``"M04 (Light scene on)"`` carry none of those words and so are not
+    roller members.
     """
-    dirs: dict[str, list[dict[str, Any]]] = {"open": [], "close": []}
-    seen: dict[str, set[tuple[str, int]]] = {"open": set(), "close": set()}
+    if not isinstance(mode, str):
+        return False
+    text = mode.lower()
+    return ("open" in text) or ("close" in text) or ("stop" in text)
+
+
+def is_pure_roller_cf(cf: dict[str, Any]) -> bool:
+    """True iff a CF has at least one member and *every* member is a roller.
+
+    A pure-roller CF (all shutter members, by mode wording) becomes a
+    member-driving grouped cover (open/close/stop). A CF with a non-roller
+    member — a light scene, preset or switch action, e.g. one carrying an
+    ``"M04 (Light scene on)"`` member — is mixed (or a light CF) and stays
+    a scene/broadcast.
+    """
+    outputs = (cf or {}).get("outputs")
+    if not isinstance(outputs, list):
+        return False
+    members = [o for o in outputs if isinstance(o, dict)]
+    if not members:
+        return False
+    return all(_is_roller_member(o.get("mode")) for o in members)
+
+
+def cf_cover_members(cf: dict[str, Any]) -> list[dict[str, Any]]:
+    """Collapse a roller CF's outputs into distinct grouped-cover members.
+
+    A roller central function bundles the roller link records for its
+    channels; a ``(module, channel)`` may appear more than once (e.g. a
+    2-button CF carrying both an open ``M02`` and a close ``M03`` record).
+    Returns one entry per distinct ``(module_address, channel)`` —
+    preserving first-sighting order — with the open / close timing strings
+    (``t1``) pulled from the matching mode::
+
+        [{"module_address", "channel", "open_time", "close_time"}, ...]
+
+    Direction comes from mode wording (not code, which is shared with
+    switch modules):
+
+    * ``M01`` ("Open - stop - close"): contains both *open* and
+      *close*/*stop* → both ``open_time`` and ``close_time`` get its ``t1``.
+    * *open*-only (``M02`` / ``M06`` with control time): ``open_time = t1``.
+    * *close*-only (``M03`` / ``M07`` with control time): ``close_time = t1``.
+
+    Non-roller members (no open/close/stop wording) are skipped: without a
+    decoded direction there is nothing for a cover to drive.
+    """
+    members: dict[tuple[str, int], dict[str, Any]] = {}
+    order: list[tuple[str, int]] = []
     for o in (cf or {}).get("outputs") or []:
         if not isinstance(o, dict):
             continue
@@ -267,21 +310,35 @@ def cf_roller_directions(cf: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
         ch = o.get("channel")
         if not (isinstance(mod, str) and isinstance(ch, int)):
             continue
-        code = mode_code(o.get("mode"))
-        if code == "M02":
-            direction = "open"
-        elif code == "M03":
-            direction = "close"
-        else:
+        mode = o.get("mode")
+        if not _is_roller_member(mode):
             continue
+        text = str(mode).lower()
+        has_open = "open" in text
+        has_close = ("close" in text) or ("stop" in text)
         key = (mod.upper(), ch)
-        if key in seen[direction]:
-            continue
-        seen[direction].add(key)
-        dirs[direction].append(
-            {"module_address": mod.upper(), "channel": ch, "time": o.get("t1")}
-        )
-    return {direction: members for direction, members in dirs.items() if members}
+        if key not in members:
+            members[key] = {
+                "module_address": mod.upper(),
+                "channel": ch,
+                "open_time": None,
+                "close_time": None,
+            }
+            order.append(key)
+        t1 = o.get("t1")
+        if has_open and has_close:
+            # M01 "open - stop - close": one time for both directions.
+            if members[key]["open_time"] is None:
+                members[key]["open_time"] = t1
+            if members[key]["close_time"] is None:
+                members[key]["close_time"] = t1
+        elif has_open:
+            if members[key]["open_time"] is None:
+                members[key]["open_time"] = t1
+        elif has_close:
+            if members[key]["close_time"] is None:
+                members[key]["close_time"] = t1
+    return [members[k] for k in order]
 
 
 def build_routing_graph(

--- a/custom_components/nikobus/scene.py
+++ b/custom_components/nikobus/scene.py
@@ -21,7 +21,7 @@ from .const import (
 )
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity, command_error
-from .nkbreconcile import cf_roller_directions
+from .nkbreconcile import is_pure_roller_cf
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,37 +34,11 @@ STATE_CLOSE = 0x02
 STATE_ON = 0xFF
 STATE_OFF = 0x00
 
-# Buffer added to a roller's run time before the timed stop fires — the
-# scene path's convention (absorbs bus contention so a slow shutter still
-# reaches its end-stop before the stop frame).
-_ROLLER_STOP_BUFFER = 3.0
-
 _STATE_MAPPING = {
     "switch_module": {"on": STATE_ON, "off": STATE_OFF, "true": STATE_ON, "false": STATE_OFF},
     "roller_module": {"open": STATE_OPEN, "close": STATE_CLOSE, "stop": STATE_STOPPED}
 }
 
-
-def _parse_cf_time(value: Any) -> float | None:
-    """Parse a CF member timing string (e.g. ``"30 s"`` / ``"2 m"``) to seconds.
-
-    Returns ``None`` when the value is missing or unparseable, so the caller
-    can fall back to the module's configured operation time.
-    """
-    if value is None:
-        return None
-    text = str(value).strip().lower()
-    if not text:
-        return None
-    minutes = text.endswith("m") and not text.endswith("ms")
-    number = text.rstrip("ms ").strip()
-    try:
-        seconds = float(number)
-    except ValueError:
-        return None
-    if seconds <= 0:
-        return None
-    return seconds * 60.0 if minutes else seconds
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -83,18 +57,12 @@ async def async_setup_entry(
        single :class:`NikobusCFSceneEntity` whose activation broadcasts the
        CF address; the output modules fire atomically via their link records.
 
-    Roller CFs are handled specially. A single broadcast can't express a
-    *direction*, so a roller CF with decoded open (``M02``) / close
-    (``M03``) members is materialised as one
-    :class:`NikobusCFRollerSceneEntity` **per direction**, each driving its
-    member channels directly through the atomic per-module commit:
-
-    * a 2-button (open+close) CF → two scenes ("… Open" + "… Close");
-    * a single-direction CF → one scene for that direction.
-
-    A roller CF with no M02/M03 members (an ``M01`` "open-stop-close"
-    toggle) has no direction to drive and stays a broadcast
-    :class:`NikobusCFSceneEntity`.
+    Pure-roller CFs (every member a shutter channel, incl. ``M01``
+    open-stop-close toggle groups) are **not** scenes — they become
+    member-driving grouped covers (open/close/stop) on the cover platform.
+    They are skipped here so they aren't also surfaced as broadcasts. Mixed
+    (light + roller) and light CFs stay :class:`NikobusCFSceneEntity`
+    broadcasts.
     """
     coordinator: NikobusDataCoordinator = entry.runtime_data
     entities: list[Scene] = []
@@ -119,22 +87,9 @@ async def async_setup_entry(
     for bus_address, cf in cf_data.items():
         if not isinstance(cf, dict):
             continue
-        directions = (
-            cf_roller_directions(cf) if cf.get("pattern") == "roller_pair" else {}
-        )
-        if directions:
-            # A direction-drivable roller CF → one member-driving scene per
-            # direction (Open / Close), instead of a non-actionable broadcast.
-            for direction, members in directions.items():
-                entities.append(
-                    NikobusCFRollerSceneEntity(
-                        coordinator=coordinator,
-                        bus_address=bus_address,
-                        cf_config=cf,
-                        members=members,
-                        direction=direction,
-                    )
-                )
+        # A pure-roller CF becomes a grouped cover (cover platform), not a
+        # scene/broadcast — skip it here.
+        if is_pure_roller_cf(cf):
             continue
         entities.append(
             NikobusCFSceneEntity(
@@ -311,204 +266,6 @@ class NikobusCFSceneEntity(NikobusEntity, Scene):
     async def async_activate(self, **kwargs: Any) -> None:
         """Send the CF activation broadcast on the bus."""
         await self.coordinator.async_activate_cf_broadcast(self._bus_address)
-
-
-class NikobusCFRollerSceneEntity(NikobusEntity, Scene):
-    """One direction of a roller central function, as a member-driving scene.
-
-    A roller CF can't be activated by a single broadcast — the broadcast
-    address carries both the open and close links, so it can't express a
-    direction. This entity instead drives the CF's member channels for a
-    single direction (``open`` → ``M02``, ``close`` → ``M03``) through the
-    atomic per-module commit (``set_output_states_for_module``): every
-    member channel of a module moves in one bus frame, with a timed stop
-    scheduled from the channels' run times — the same engine
-    :class:`NikobusSceneEntity` uses for roller scenes.
-
-    A bidirectional 2-button CF yields two of these (one ``open``, one
-    ``close``); a single-direction CF yields one. Activation is a one-shot
-    scene fire (all-at-once), matching the native Nikobus scene behaviour.
-    """
-
-    def __init__(
-        self,
-        coordinator: NikobusDataCoordinator,
-        bus_address: str,
-        cf_config: dict[str, Any],
-        members: list[dict[str, Any]],
-        direction: str,
-    ) -> None:
-        addr = str(bus_address).upper()
-        pattern = str(cf_config.get("pattern") or "roller_pair")
-        self._direction = direction  # "open" | "close"
-        self._byte = STATE_OPEN if direction == "open" else STATE_CLOSE
-
-        imported = cf_config.get("name")
-        if isinstance(imported, str) and imported.strip():
-            base = imported.strip()
-        else:
-            base = f"Nikobus roller CF {addr}"
-        suffix = "Open" if direction == "open" else "Close"
-
-        super().__init__(
-            coordinator=coordinator,
-            address=addr,
-            # Device name is the CF base; both directions share one device.
-            name=base,
-            model=f"CF Scene ({pattern})",
-            via_device=(DOMAIN, CATEGORY_SCENES),
-            # Own device per CF (shared by the Open/Close entities), keyed
-            # off the CF rather than the bus address so it isn't merged
-            # into a physical button's device.
-            device_identifier=f"cf_{addr.lower()}",
-        )
-        self._bus_address = addr
-        self._pattern = pattern
-        self._members = members  # [{module_address, channel, time}, ...]
-        # Direction is the entity-name part → "<base> Open" / "<base> Close".
-        self._attr_name = suffix
-        self._attr_unique_id = f"nikobus_cf_{addr.lower()}_{direction}"
-
-        # Guard against overlapping roller release tasks (per module token).
-        self._module_tokens: dict[str, str] = {}
-        self._roller_stop_tasks: list[asyncio.Task[None]] = []
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        parent = super().extra_state_attributes or {}
-        return {
-            **parent,
-            "bus_address": self._bus_address,
-            "pattern": self._pattern,
-            "direction": self._direction,
-            "member_count": len(self._members),
-            "members": [
-                {
-                    "module": self.coordinator.address_label(m["module_address"]),
-                    "channel": m["channel"],
-                    "time": m.get("time"),
-                }
-                for m in self._members
-            ],
-        }
-
-    async def async_added_to_hass(self) -> None:
-        """Register cleanup of pending roller-stop tasks on removal."""
-        await super().async_added_to_hass()
-
-        def _cancel_roller_tasks() -> None:
-            self._module_tokens.clear()
-            for task in self._roller_stop_tasks:
-                task.cancel()
-            self._roller_stop_tasks.clear()
-
-        self.async_on_remove(_cancel_roller_tasks)
-
-    async def async_activate(self, **kwargs: Any) -> None:
-        """Drive all member channels in this scene's direction."""
-        try:
-            await self._drive()
-        except asyncio.CancelledError:
-            raise
-        except Exception as err:
-            raise command_error(err) from err
-
-    async def _drive(self) -> None:
-        """Commit the direction per module (one frame each) + schedule stops."""
-        _LOGGER.info("Activating Nikobus roller CF scene: %s", self._attr_name)
-        op_dir = "up" if self._direction == "open" else "down"
-
-        by_module: dict[str, list[dict[str, Any]]] = {}
-        for member in self._members:
-            by_module.setdefault(member["module_address"], []).append(member)
-
-        delay = 0.0
-        commanded: dict[str, set[int]] = {}
-        sent_states: dict[str, bytearray] = {}
-
-        for module_id, members in by_module.items():
-            current = self.coordinator.nikobus_module_states.get(module_id, bytearray(12))
-            state = bytearray(current)
-            for member in members:
-                idx = member["channel"] - 1
-                if 0 <= idx < len(state):
-                    state[idx] = self._byte
-                    commanded.setdefault(module_id, set()).add(idx)
-                op_time = _parse_cf_time(member.get("time")) or (
-                    self.coordinator.get_cover_operation_time(
-                        module_id, member["channel"], op_dir
-                    )
-                )
-                if op_time > 0:
-                    delay = max(delay, op_time + _ROLLER_STOP_BUFFER)
-            sent_states[module_id] = state
-            await self._apply_module_state(module_id, state)
-
-        for module_id, indexes in commanded.items():
-            token = uuid.uuid4().hex
-            self._module_tokens[module_id] = token
-            task = self.hass.async_create_task(
-                self._delayed_roller_stop(
-                    module_id, sent_states[module_id], indexes, delay, token
-                )
-            )
-            self._roller_stop_tasks.append(task)
-            task.add_done_callback(
-                lambda t: self._roller_stop_tasks.remove(t)
-                if t in self._roller_stop_tasks
-                else None
-            )
-
-    async def _apply_module_state(self, module_id: str, state: bytearray) -> None:
-        """Push a whole module's state in one bus commit (per group)."""
-        num_chans = self.coordinator.get_module_channel_count(module_id)
-        self.coordinator.set_bytearray_group_state(module_id, 1, state[:6].hex())
-        if num_chans > 6:
-            self.coordinator.set_bytearray_group_state(module_id, 2, state[6:12].hex())
-        await self.coordinator.api.set_output_states_for_module(address=module_id)
-        await self.coordinator.async_event_handler(
-            "nikobus_refreshed", {"impacted_module_address": module_id}
-        )
-
-    async def _delayed_roller_stop(
-        self,
-        module_id: str,
-        sent_state: bytearray,
-        indexes: set[int],
-        delay: float,
-        token: str,
-    ) -> None:
-        """Send the bus stop once travel time elapses.
-
-        Composes the stop frame from the module's CURRENT state at timeout,
-        not the activation snapshot: a channel redirected during travel (by
-        a wall button, another scene, or a direct cover) is left alone —
-        only channels still doing what we commanded are forced to STOPPED.
-        """
-        await asyncio.sleep(delay)
-        if self._module_tokens.get(module_id) != token:
-            return
-
-        current = self.coordinator.nikobus_module_states.get(module_id)
-        stop_state = bytearray(current) if current else bytearray(sent_state)
-        changed = False
-        for idx in indexes:
-            if idx < len(stop_state) and stop_state[idx] == sent_state[idx]:
-                stop_state[idx] = STATE_STOPPED
-                changed = True
-        if not changed:
-            return
-
-        try:
-            await self._apply_module_state(module_id, stop_state)
-        except asyncio.CancelledError:
-            raise
-        except Exception as err:
-            _LOGGER.error("Failed to send timed stop for module %s: %s", module_id, err)
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Stateless scene: ignore general coordinator updates."""
 
 
 class NikobusSceneEntity(NikobusEntity, Scene):

--- a/documentation/scene-mapping.md
+++ b/documentation/scene-mapping.md
@@ -1,0 +1,136 @@
+# Nikobus Central Functions → Home Assistant mapping
+
+This is the design spec for how the integration should surface Nikobus
+*Central Functions* ("Light scenes" / groups) as Home Assistant entities.
+It is derived from the official Nikobus software manual in this folder
+(`PHNikobus_EN.pdf`, software v3.0). Page references below point there.
+
+## 1. A Nikobus "scene" is a *group*, not an HA scene
+
+> *"Using the **Light scene / Central functions** command, it is possible
+> to place several alliances [outputs] in a **group** … This programming …
+> can be different for every output that is part of the group."* — p.162
+
+So a Central Function (CF) is an **output group** where **each member
+channel carries its own mode**. The group is fired by linking it to an
+input through connection mode **MCF** ("Activate Light scene / Central
+function", p.164).
+
+When the group is created you choose its **type of operation —
+1-button, 2-button or 4-button** — and *"Depending on this decision, only
+certain modes will be available."* (p.163). This is the `1 Knops / 2 Knops
+/ 4 Knops` choice in the mode dialog.
+
+## 2. Determinism = button-count **and** mode
+
+The button-count decides how many bus commands the group has, and the
+member mode decides what each does:
+
+| Operation | Bus commands | Behavior |
+|---|---|---|
+| **1-button, single-action mode** (`open`, `close`, `on`, `off`, `atmosphere on`, `preset on`) | one address | **deterministic one-shot** — fires the defined action |
+| **1-button, on/off mode** (`atmosphere on/off`, `dim on/off`) | one address | **toggle** — alternates each press (p.595 "alternately switch on and off") |
+| **2-button / 4-button** (any) | **two (or more) addresses** — an *activate* and a *deactivate* | **two-state / deterministic per button** (p.30: upper = open, lower = close, either-while-moving = stop) |
+
+Key point: a **2-button group is fired by a *pair* of inputs** — one for
+the "on/open/activate" half and one for the "off/close/deactivate" half.
+It is **not** a single one-shot and **not** a toggle.
+
+## 3. Mode reference (per module type)
+
+From the mode tables on p.110–111, with the resulting effect:
+
+### Shutter module (rolluikmodule)
+| Mode | Meaning | Buttons | Effect |
+|---|---|---|---|
+| `M02` | Open | 1 | deterministic open (re-press = stop) |
+| `M03` | Close | 1 | deterministic close (re-press = stop) |
+| `M04` | Stop | 1 | stop |
+| `M06`/`M07` | Open/Close with control time | 1 | timed open/close |
+| `M01` | Open – stop – close | **2** | up = open, down = close, stop |
+| `M05` | RF and interface | **4** | RF-triggered — **not on the wired bus** |
+
+### Dimmer (dimcontroller)
+| Mode | Meaning | Buttons | Effect |
+|---|---|---|---|
+| `M04` | Atmosphere on (Sfeer aan) | 1 | deterministic scene recall |
+| `M12` | Preset on | 1 | deterministic preset level |
+| `M05`/`M06` | On / Off | 1 | deterministic on / off |
+| `M13` | Dim on/off | 1 | toggle |
+| `M01` | Dim on/off | **2** | up = brighter/on, down = dimmer/off |
+| `M02` | Dim on/off | **4** | separate on/off/up/down |
+| `M03` | Atmosphere on/off (Sfeer aan/uit) | **4** | scene on **and** off |
+| `M11` | Preset on/off | **4** | preset on **and** off |
+
+### Switch module (schakelmodule)
+| Mode | Meaning | Buttons | Effect |
+|---|---|---|---|
+| `M02` | On with operating time | 1 | deterministic on |
+| `M03` | Off with operating time | 1 | deterministic off |
+| `M04` | Push | 1 | on while pressed |
+| `M05` | Pulse (teleruptor) | 1 | toggle |
+| `M14` | Atmosphere on | 1 | deterministic scene recall |
+| `M01` | On / off | **2** | up = on, down = off |
+| `M13` | Step switch | **2** | step |
+| `M15` | Atmosphere on/off | **2** | scene on **and** off |
+
+## 4. How a 2-button group behaves, by content
+
+A 2-button group has an *activate* input and a *deactivate* input
+(two bus addresses); each member still runs its own mode:
+
+| Group contents | Activate | Deactivate | Net |
+|---|---|---|---|
+| **All covers** | every shutter opens | every shutter closes (re-press = stop) | deterministic open/close/stop |
+| **All lights** | lights → on / preset | lights → off | deterministic on/off |
+| **Mixed** | full "on" state (lights to preset + shutters open) | "off" state (lights off + shutters close) | two-state scene |
+
+## 5. Mapping rules → HA entity
+
+The faithful mirror routes each group to the HA primitive that matches its
+behavior — **not everything is an HA "scene".**
+
+| Nikobus group | HA entity | Notes |
+|---|---|---|
+| **1-button, scene/preset recall** (`atmosphere on` `M04`/`M14`, `preset on` `M12`) | **scene** | one-shot state recall — already correct today |
+| **1-button / broadcast deterministic** group of `M02`/`M03`/on/off members (e.g. a close-all) | **scene** | broadcasting the address executes the defined action deterministically — correct today |
+| **Shutter group** (`M01`/`M02`/`M03` roller members) | **cover** (open/close/stop), member-driving | the faithful "group" representation; deterministic regardless of `M01` toggle |
+| **2-button light group** (`atmosphere on/off`, on/off) | **two scenes** (On + Off) or a light/switch **group** | a single HA scene loses the "off" half |
+| **2-button mixed group** | **two scenes** (Activate + Deactivate) | |
+| **`M05` RF group** (e.g. OpenHouse) | — | not bus-discoverable; comes only from the `.nkb` if member links exist |
+
+## 6. Current state vs target
+
+**Correct today**
+- Per-channel roller **covers** (open/close/stop) — every shutter is individually deterministic.
+- **Scene/preset** CFs (`M04`/`M12`) → broadcast scene (deterministic recall).
+- CFs with deterministic `M02`/`M03`/on-off members fired by broadcast (e.g. *CloseHouse - Leave* closes everything) → correct.
+- `roller_pair` (`3880xx`) CFs **with `M02`+`M03` members** → directional Open/Close member-driving scenes.
+- User software scenes from `nikobus_scene_config.json` → member-driving, deterministic.
+
+**Gaps to close**
+1. **`M01` shutter *groups* are broadcast toggles** (e.g. *ShuttersSalonCuisine*, 9105 ch2–5 `M01`). Faithful but non-deterministic in HA. → make them **member-driving grouped covers** (open/close/stop), which works for `M01` too because it commands the output state, not the link.
+2. **The member-driving path is gated on `pattern == "roller_pair"` (address `3880xx`) only.** It should key on **"has roller members"** so `nkb_scene` / `light_scene` roller groups are covered too.
+3. **2-button light/switch groups** (`M15` / `M01` on-off) → broadcast toggle; could be a deterministic on/off pair.
+
+## 7. Caveats
+
+- **`M05` RF groups** (OpenHouse / CloseHouse-Sleep): triggered by an RF
+  wall transmitter (`PhysicalAddress = 0x3FFFFF`). They carry **no output
+  link records** in the project, so they cannot be reconstructed from the
+  bus or the `.nkb` — out of scope until Niko exposes the membership.
+- **Determining direction for a 2-button group** needs knowing which of a
+  CF's trigger addresses is the *open/on* half vs the *close/off* half. For
+  a member-driving cover this is sidestepped (we drive the channel state
+  directly); for a broadcast on/off pair it must be resolved from the link
+  records.
+- **Mixed groups** (lights + a shutter, e.g. `829201`) stay **scenes** —
+  their intent includes a light-state recall.
+
+## 8. References
+
+`documentation/PHNikobus_EN.pdf` (Nikobus software manual v3.0):
+- p.30 — §5.11, the 2-button garage-door example (up / close / stop)
+- p.110–111 — shutter, dimmer and switch mode tables
+- p.162–165 — §15.6 *Light scene / Central functions* = output group,
+  1/2/4-button operation, MCF activation

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -15,8 +15,11 @@ import asyncio
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from custom_components.nikobus.const import CATEGORY_CENTRAL_FUNCTIONS, DOMAIN
 from custom_components.nikobus.cover import (
+    NikobusCFCoverEntity,
     NikobusCoverEntity,
+    _parse_cf_time,
     _parse_operation_time,
     STATE_STOPPED,
     STATE_OPENING,
@@ -510,3 +513,203 @@ class TestErrorClearEpisode(unittest.TestCase):
         ent._last_motion_direction = "opening"
         _run(ent._stop(send_stop=True, force_api=True))
         coord.api.stop_cover.assert_awaited_once_with("9105", 1, "opening")
+
+
+# ---------------------------------------------------------------------------
+# _parse_cf_time — CF member timing strings → seconds
+# ---------------------------------------------------------------------------
+class TestParseCfTime(unittest.TestCase):
+    def test_seconds(self):
+        self.assertEqual(_parse_cf_time("40 s"), 40.0)
+        self.assertEqual(_parse_cf_time("30s"), 30.0)
+
+    def test_minutes(self):
+        self.assertEqual(_parse_cf_time("2 m"), 120.0)
+
+    def test_none_and_unparseable(self):
+        self.assertIsNone(_parse_cf_time(None))
+        self.assertIsNone(_parse_cf_time(""))
+        self.assertIsNone(_parse_cf_time("abc"))
+
+    def test_non_positive(self):
+        self.assertIsNone(_parse_cf_time("0 s"))
+        self.assertIsNone(_parse_cf_time("-5 s"))
+
+
+# ---------------------------------------------------------------------------
+# NikobusCFCoverEntity — pure-roller central function as a grouped cover
+# ---------------------------------------------------------------------------
+def _make_cf_cover(members=None, modules_channels=6, cf_config=None):
+    """A CF cover over module 8CF5 channels 1,2,3 by default."""
+    if members is None:
+        members = [
+            {"module_address": "8CF5", "channel": 1, "open_time": "40 s", "close_time": "40 s"},
+            {"module_address": "8CF5", "channel": 2, "open_time": "30 s", "close_time": "30 s"},
+            {"module_address": "8CF5", "channel": 3, "open_time": "30 s", "close_time": "30 s"},
+        ]
+    coord = MagicMock()
+    coord.get_cover_operation_time = MagicMock(return_value=30.0)
+    coord.get_module_channel_count = MagicMock(return_value=modules_channels)
+    coord.nikobus_module_states = {}
+    coord.set_bytearray_group_state = MagicMock()
+    coord.api.set_output_states_for_module = AsyncMock()
+    coord.async_event_handler = AsyncMock()
+    coord.address_label = MagicMock(side_effect=lambda a: f"name({a})")
+    if cf_config is None:
+        cf_config = {"pattern": "roller", "outputs": []}
+    ent = NikobusCFCoverEntity(coord, "3880cd", cf_config, members)
+    ent.hass = MagicMock()
+
+    def _fake_create_task(arg):
+        if asyncio.iscoroutine(arg):
+            arg.close()
+        return MagicMock()
+
+    ent.hass.async_create_task = MagicMock(side_effect=_fake_create_task)
+    ent.async_write_ha_state = MagicMock()
+    return ent, coord
+
+
+class TestCFCoverConstruction(unittest.TestCase):
+    def test_unique_id_and_calculator_seeded_with_max(self):
+        ent, _ = _make_cf_cover()
+        self.assertEqual(ent._attr_unique_id, "nikobus_cf_cover_3880cd")
+        self.assertEqual(ent._bus_address, "3880CD")
+        # Slowest member (40 s) seeds the group travel model.
+        self.assertEqual(ent._calculator.time_up, 40.0)
+        self.assertEqual(ent._calculator.time_down, 40.0)
+        self.assertEqual(len(ent._members), 3)
+
+    def test_placed_under_central_functions_category(self):
+        """The grouped cover lives under the new Central functions category
+        device and gets its own ``cf_cover_<addr>`` device."""
+        ent, _ = _make_cf_cover(
+            cf_config={"pattern": "roller", "name": "Gordijnen keuken", "outputs": []}
+        )
+        self.assertEqual(
+            ent._attr_device_info["via_device"],
+            (DOMAIN, CATEGORY_CENTRAL_FUNCTIONS),
+        )
+        self.assertEqual(
+            ent._attr_device_info["identifiers"], {(DOMAIN, "cf_cover_3880cd")}
+        )
+        self.assertEqual(ent._device_name, "Gordijnen keuken")
+
+    def test_default_name_when_no_import(self):
+        ent, _ = _make_cf_cover(cf_config={"pattern": "roller", "outputs": []})
+        self.assertEqual(ent._device_name, "Nikobus CF cover 3880CD")
+
+    def test_unparseable_time_falls_back_to_module_config(self):
+        members = [{"module_address": "8CF5", "channel": 1,
+                    "open_time": None, "close_time": None}]
+        ent, coord = _make_cf_cover(members=members)
+        # _parse_cf_time(None) → coordinator.get_cover_operation_time (30.0)
+        self.assertEqual(ent._members[0]["open_time"], 30.0)
+        self.assertEqual(ent._members[0]["close_time"], 30.0)
+
+
+class TestCFCoverMove(unittest.TestCase):
+    def test_close_commits_once_per_module_atomically(self):
+        ent, coord = _make_cf_cover()
+        _run(ent._move("closing"))
+        # All three channels are on one module → exactly one bus commit.
+        coord.api.set_output_states_for_module.assert_awaited_once_with(address="8CF5")
+        # Group-1 state staged with channels 1,2,3 = CLOSING (0x02).
+        group1_hex = coord.set_bytearray_group_state.call_args_list[0].args[2]
+        self.assertEqual(group1_hex[:6], "020202")
+        self.assertEqual(ent._state, STATE_CLOSING)
+
+    def test_open_stages_opening_byte(self):
+        ent, coord = _make_cf_cover()
+        _run(ent._move("opening"))
+        group1_hex = coord.set_bytearray_group_state.call_args_list[0].args[2]
+        self.assertEqual(group1_hex[:6], "010101")  # 0x01 = opening
+        self.assertEqual(ent._state, STATE_OPENING)
+
+    def test_cross_module_commits_once_per_module(self):
+        members = [
+            {"module_address": "8CF5", "channel": 1, "open_time": "40 s", "close_time": "40 s"},
+            {"module_address": "9105", "channel": 2, "open_time": "30 s", "close_time": "30 s"},
+        ]
+        ent, coord = _make_cf_cover(members=members)
+        _run(ent._move("closing"))
+        self.assertEqual(coord.api.set_output_states_for_module.await_count, 2)
+        addrs = {c.kwargs["address"] for c in coord.api.set_output_states_for_module.await_args_list}
+        self.assertEqual(addrs, {"8CF5", "9105"})
+
+    def test_move_schedules_timed_stops(self):
+        ent, _ = _make_cf_cover()
+        _run(ent._move("closing"))
+        # One module → one timed-stop token.
+        self.assertEqual(len(ent._module_tokens), 1)
+        self.assertIn("8CF5", ent._module_tokens)
+
+
+class TestCFCoverStop(unittest.TestCase):
+    def test_stop_commits_stopped_and_cancels_pending(self):
+        ent, coord = _make_cf_cover()
+        # Pretend a move is in flight with a pending stop task.
+        pending = MagicMock()
+        ent._stop_tasks = [pending]
+        ent._module_tokens = {"8CF5": "tok"}
+        _run(ent._stop())
+        pending.cancel.assert_called_once()
+        self.assertEqual(ent._module_tokens, {})
+        self.assertEqual(ent._state, STATE_STOPPED)
+        # Stopped byte (0x00) staged for the member channels.
+        group1_hex = coord.set_bytearray_group_state.call_args_list[-1].args[2]
+        self.assertEqual(group1_hex[:6], "000000")
+        coord.api.set_output_states_for_module.assert_awaited_with(address="8CF5")
+
+
+class TestCFCoverActionErrors(unittest.TestCase):
+    def test_close_translates_bus_error(self):
+        from homeassistant.exceptions import HomeAssistantError
+
+        ent, coord = _make_cf_cover()
+        coord.api.set_output_states_for_module = AsyncMock(
+            side_effect=RuntimeError("bus down")
+        )
+        with self.assertRaises(HomeAssistantError) as cm:
+            _run(ent.async_close_cover())
+        self.assertEqual(cm.exception.translation_key, "communication_error")
+
+    def test_open_translates_bus_error(self):
+        from homeassistant.exceptions import HomeAssistantError
+
+        ent, coord = _make_cf_cover()
+        coord.api.set_output_states_for_module = AsyncMock(
+            side_effect=RuntimeError("bus down")
+        )
+        with self.assertRaises(HomeAssistantError) as cm:
+            _run(ent.async_open_cover())
+        self.assertEqual(cm.exception.translation_key, "communication_error")
+
+
+class TestCFCoverTimedStop(unittest.TestCase):
+    def test_delayed_stop_only_touches_unchanged_channels(self):
+        """A channel redirected during travel (its byte no longer matches
+        what we sent) is left alone by the timed stop."""
+        ent, coord = _make_cf_cover()
+        sent = bytearray(12)
+        sent[0] = STATE_CLOSING  # ch1 we sent closing
+        sent[1] = STATE_CLOSING  # ch2 we sent closing
+        # Current state: ch1 still closing (ours), ch2 reversed to opening.
+        current = bytearray(12)
+        current[0] = STATE_CLOSING
+        current[1] = STATE_OPENING
+        coord.nikobus_module_states = {"8CF5": current}
+        ent._module_tokens = {"8CF5": "tok"}
+        with patch("custom_components.nikobus.cover.asyncio.sleep", new=AsyncMock()):
+            _run(ent._delayed_stop("8CF5", sent, {0, 1}, 0.0, "tok"))
+        # Committed stop state: ch1 → stopped, ch2 untouched (still opening).
+        group1_hex = coord.set_bytearray_group_state.call_args_list[-1].args[2]
+        self.assertEqual(group1_hex[:4], "0001")  # 00=ch1 stopped, 01=ch2 left opening
+
+    def test_delayed_stop_aborted_when_token_superseded(self):
+        ent, coord = _make_cf_cover()
+        ent._module_tokens = {"8CF5": "newtok"}
+        sent = bytearray(12)
+        with patch("custom_components.nikobus.cover.asyncio.sleep", new=AsyncMock()):
+            _run(ent._delayed_stop("8CF5", sent, {0}, 0.0, "oldtok"))
+        coord.api.set_output_states_for_module.assert_not_awaited()

--- a/tests/test_known_entity_cf_scenes.py
+++ b/tests/test_known_entity_cf_scenes.py
@@ -54,49 +54,48 @@ class TestKnownEntityIdsIncludeCFScenes(unittest.TestCase):
         known = coord.get_known_entity_unique_ids()
         self.assertIn("nikobus_cf_ab1234", known)
 
-    def test_bidirectional_roller_pair_registers_directional_scene_ids(self):
-        """A bidirectional roller_pair CF (M02+M03) surfaces as two
-        directional roller scenes (``nikobus_cf_<addr>_open`` /
-        ``..._close``), not a single broadcast scene — the known-id set must
-        match, else orphan cleanup evicts them right after creation."""
+    def test_pure_roller_cf_registers_cover_id(self):
+        """A pure-roller CF (all shutter members, by mode wording) surfaces
+        as a grouped cover (``nikobus_cf_cover_<addr>``), not a broadcast
+        scene — the known-id set must match, else orphan cleanup evicts the
+        cover right after creation."""
         coord = _coord_with_cfs([])
         coord.cf_storage.data = {"nikobus_cf": {
             "3880CD": {"pattern": "roller_pair", "outputs": [
-                {"module_address": "8CF5", "channel": 1, "mode": "M02", "t1": "40 s"},
-                {"module_address": "8CF5", "channel": 1, "mode": "M03", "t1": "40 s"},
-            ]},
-        }}
-        known = coord.get_known_entity_unique_ids()
-        self.assertIn("nikobus_cf_3880cd_open", known)
-        self.assertIn("nikobus_cf_3880cd_close", known)
-        self.assertNotIn("nikobus_cf_3880cd", known)
-
-    def test_single_direction_roller_pair_registers_one_directional_id(self):
-        """A close-only roller CF → one ``..._close`` directional scene id."""
-        coord = _coord_with_cfs([])
-        coord.cf_storage.data = {"nikobus_cf": {
-            "3880CE": {"pattern": "roller_pair", "outputs": [
+                {"module_address": "8CF5", "channel": 1, "mode": "M02 (Open)", "t1": "40 s"},
                 {"module_address": "8CF5", "channel": 1, "mode": "M03 (Close)", "t1": "40 s"},
             ]},
         }}
         known = coord.get_known_entity_unique_ids()
-        self.assertIn("nikobus_cf_3880ce_close", known)
-        self.assertNotIn("nikobus_cf_3880ce_open", known)
-        self.assertNotIn("nikobus_cf_3880ce", known)
+        self.assertIn("nikobus_cf_cover_3880cd", known)
+        self.assertNotIn("nikobus_cf_3880cd", known)
 
-    def test_m01_roller_pair_stays_a_broadcast_scene_id(self):
-        """A 1-button (M01 toggle) roller_pair has no direction to drive, so
-        it stays a broadcast CF scene — register the plain scene id."""
+    def test_m01_pure_roller_cf_registers_cover_id(self):
+        """A 1-button (M01 toggle) pure-roller CF also becomes a grouped
+        cover — register the cover id, not the broadcast scene id."""
         coord = _coord_with_cfs([])
         coord.cf_storage.data = {"nikobus_cf": {
             "3880C8": {"pattern": "roller_pair", "outputs": [
-                {"module_address": "C7C1", "channel": 1, "mode": "M01 (Open-stop-close)"},
+                {"module_address": "C7C1", "channel": 1, "mode": "M01 (Open - stop - close)"},
             ]},
         }}
         known = coord.get_known_entity_unique_ids()
-        self.assertIn("nikobus_cf_3880c8", known)
-        self.assertNotIn("nikobus_cf_3880c8_open", known)
-        self.assertNotIn("nikobus_cf_3880c8_close", known)
+        self.assertIn("nikobus_cf_cover_3880c8", known)
+        self.assertNotIn("nikobus_cf_3880c8", known)
+
+    def test_mixed_cf_stays_a_broadcast_scene_id(self):
+        """A mixed (switch + roller) CF is not pure-roller, so it stays a
+        broadcast CF scene — register the plain scene id, not a cover id."""
+        coord = _coord_with_cfs([])
+        coord.cf_storage.data = {"nikobus_cf": {
+            "3880C9": {"pattern": "nkb_scene", "outputs": [
+                {"module_address": "C1C7", "channel": 1, "mode": "M03 (Off + Operating time)"},
+                {"module_address": "8CF5", "channel": 2, "mode": "M03 (Close)"},
+            ]},
+        }}
+        known = coord.get_known_entity_unique_ids()
+        self.assertIn("nikobus_cf_3880c9", known)
+        self.assertNotIn("nikobus_cf_cover_3880c9", known)
 
     def test_no_cfs_is_safe(self):
         coord = _coord_with_cfs([])

--- a/tests/test_nkbreconcile.py
+++ b/tests/test_nkbreconcile.py
@@ -8,12 +8,13 @@ from custom_components.nikobus.nkbreconcile import (
     all_outputs_registry_sourced,
     build_controlled_by_index,
     build_routing_graph,
+    cf_cover_members,
     cf_member_set,
-    cf_roller_directions,
     classify_button_status,
     collect_button_outputs,
     flatten_cf_broadcasts,
     has_pc_logic_module,
+    is_pure_roller_cf,
     member_set_from_outputs,
 )
 
@@ -235,79 +236,130 @@ def test_build_routing_graph_empty_and_malformed():
     assert build_routing_graph({"nikobus_button": "nope"}) == {}
 
 
+
+
 # ---------------------------------------------------------------------------
-# cf_roller_directions — split a roller CF's outputs into open/close members
+# is_pure_roller_cf — every member a roller (shutter) channel, by mode wording
 # ---------------------------------------------------------------------------
-def test_cf_roller_directions_bidirectional_splits_open_and_close():
-    """A 2-button roller CF lists each channel as M02 (open) + M03 (close);
-    cf_roller_directions returns both directions with their members."""
-    cf = {
-        "pattern": "roller_pair",
-        "outputs": [
-            {"module_address": "8cf5", "channel": 1, "mode": "M02 (Open)", "t1": "40 s"},
-            {"module_address": "8cf5", "channel": 2, "mode": "M02 (Open)", "t1": "30 s"},
-            {"module_address": "8cf5", "channel": 1, "mode": "M03 (Close)", "t1": "40 s"},
-            {"module_address": "8cf5", "channel": 2, "mode": "M03 (Close)", "t1": "30 s"},
-        ],
-    }
-    dirs = cf_roller_directions(cf)
-    assert set(dirs) == {"open", "close"}
-    assert dirs["open"] == [
-        {"module_address": "8CF5", "channel": 1, "time": "40 s"},
-        {"module_address": "8CF5", "channel": 2, "time": "30 s"},
-    ]
-    assert dirs["close"] == [
-        {"module_address": "8CF5", "channel": 1, "time": "40 s"},
-        {"module_address": "8CF5", "channel": 2, "time": "30 s"},
-    ]
-
-
-def test_cf_roller_directions_preserves_first_sighting_order_per_direction():
-    cf = {
-        "outputs": [
-            {"module_address": "B", "channel": 3, "mode": "M02", "t1": None},
-            {"module_address": "A", "channel": 1, "mode": "M02", "t1": None},
-            {"module_address": "B", "channel": 3, "mode": "M02", "t1": None},  # dupe
-        ],
-    }
-    dirs = cf_roller_directions(cf)
-    assert list(dirs) == ["open"]
-    assert [(m["module_address"], m["channel"]) for m in dirs["open"]] == [
-        ("B", 3), ("A", 1)
-    ]
-
-
-def test_cf_roller_directions_single_direction():
-    """Close-only / open-only CFs yield just that one direction."""
-    close_only = {"outputs": [
-        {"module_address": "8CF5", "channel": 1, "mode": "M03 (Close)", "t1": "40 s"},
-        {"module_address": "8CF5", "channel": 2, "mode": "M03 (Close)", "t1": "30 s"},
-    ]}
-    dirs = cf_roller_directions(close_only)
-    assert list(dirs) == ["close"]
-    assert len(dirs["close"]) == 2
-
-
-def test_cf_roller_directions_m01_toggle_is_not_directional():
-    """1-button M01 (open-stop-close) roller CFs have no M02/M03 → {}."""
+def test_is_pure_roller_cf_all_roller_members_true():
+    """A CF whose every member is a roller mode (open/close/stop wording)
+    is a pure-roller CF → grouped cover."""
     cf = {"outputs": [
-        {"module_address": "C7C1", "channel": 1, "mode": "M01 (Open-stop-close)"},
+        {"module_address": "8CF5", "channel": 1, "mode": "M01 (Open - stop - close)"},
+        {"module_address": "8CF5", "channel": 2, "mode": "M02 (Open)"},
+        {"module_address": "8CF5", "channel": 3, "mode": "M03 (Close)"},
     ]}
-    assert cf_roller_directions(cf) == {}
+    assert is_pure_roller_cf(cf) is True
 
 
-def test_cf_roller_directions_drops_malformed():
+def test_is_pure_roller_cf_mixed_light_and_roller_false():
+    """A mixed CF with a light-scene member (no open/close/stop wording) is
+    not pure-roller → stays a scene."""
     cf = {"outputs": [
-        {"module_address": "8CF5", "channel": 2, "mode": "M02", "t1": "20 s"},
+        {"module_address": "0E6C", "channel": 1, "mode": "M04 (Light scene on)"},
+        {"module_address": "8CF5", "channel": 2, "mode": "M02 (Open)"},
+    ]}
+    assert is_pure_roller_cf(cf) is False
+
+
+def test_is_pure_roller_cf_switch_modes_are_not_roller():
+    """Switch modes share the M02/M03 codes but carry no roller wording —
+    a CF of switch members is not pure-roller (e.g. a CloseHouse broadcast)."""
+    cf = {"outputs": [
+        {"module_address": "C1C7", "channel": 1, "mode": "M03 (Off + Operating time)"},
+        {"module_address": "C1C7", "channel": 2, "mode": "M02 (On + Operating time)"},
+    ]}
+    assert is_pure_roller_cf(cf) is False
+
+
+def test_is_pure_roller_cf_mixed_switch_close_and_roller_close_false():
+    """CloseHouse-Leave style: a switch M03 (Off + Operating time) member +
+    a roller M03 (Close) member is MIXED, not pure-roller."""
+    cf = {"outputs": [
+        {"module_address": "C1C7", "channel": 1, "mode": "M03 (Off + Operating time)"},
+        {"module_address": "8CF5", "channel": 2, "mode": "M03 (Close)"},
+    ]}
+    assert is_pure_roller_cf(cf) is False
+
+
+def test_is_pure_roller_cf_empty_or_malformed_false():
+    assert is_pure_roller_cf({}) is False
+    assert is_pure_roller_cf({"outputs": []}) is False
+    assert is_pure_roller_cf({"outputs": None}) is False
+    # outputs with only non-dict entries → no members → False
+    assert is_pure_roller_cf({"outputs": ["garbage"]}) is False
+
+
+# ---------------------------------------------------------------------------
+# cf_cover_members — collapse a roller CF's outputs into cover members
+# ---------------------------------------------------------------------------
+def test_cf_cover_members_m01_sets_both_open_and_close_to_t1():
+    """An M01 'Open - stop - close' member is bidirectional: both open_time
+    and close_time take its t1."""
+    cf = {"outputs": [
+        {"module_address": "9105", "channel": 2,
+         "mode": "M01 (Open - stop - close)", "t1": "30 s"},
+    ]}
+    members = cf_cover_members(cf)
+    assert members == [
+        {"module_address": "9105", "channel": 2,
+         "open_time": "30 s", "close_time": "30 s"},
+    ]
+
+
+def test_cf_cover_members_collapses_open_close_pair():
+    """A 2-button CF lists each channel as M02 (open) + M03 (close); they
+    collapse into one member with both timings."""
+    cf = {"outputs": [
+        {"module_address": "8cf5", "channel": 1, "mode": "M02 (Open)", "t1": "40 s"},
+        {"module_address": "8cf5", "channel": 1, "mode": "M03 (Close)", "t1": "35 s"},
+    ]}
+    members = cf_cover_members(cf)
+    assert members == [
+        {"module_address": "8CF5", "channel": 1,
+         "open_time": "40 s", "close_time": "35 s"},
+    ]
+
+
+def test_cf_cover_members_open_only_and_close_only():
+    """Open-only (M02/M06) sets only open_time; close-only (M03/M07) sets
+    only close_time."""
+    cf = {"outputs": [
+        {"module_address": "8CF5", "channel": 1, "mode": "M06 (Open with control time)", "t1": "40 s"},
+        {"module_address": "8CF5", "channel": 2, "mode": "M07 (Close with control time)", "t1": "30 s"},
+    ]}
+    members = cf_cover_members(cf)
+    assert members == [
+        {"module_address": "8CF5", "channel": 1, "open_time": "40 s", "close_time": None},
+        {"module_address": "8CF5", "channel": 2, "open_time": None, "close_time": "30 s"},
+    ]
+
+
+def test_cf_cover_members_detects_roller_by_wording_not_code():
+    """A switch M02/M03 (no open/close wording) is not a roller member and
+    is skipped; only the roller-worded member survives."""
+    cf = {"outputs": [
+        {"module_address": "C1C7", "channel": 1, "mode": "M02 (On + Operating time)", "t1": "0s"},
+        {"module_address": "8CF5", "channel": 2, "mode": "M02 (Open)", "t1": "40 s"},
+    ]}
+    members = cf_cover_members(cf)
+    assert members == [
+        {"module_address": "8CF5", "channel": 2, "open_time": "40 s", "close_time": None},
+    ]
+
+
+def test_cf_cover_members_preserves_order_and_drops_malformed():
+    cf = {"outputs": [
+        {"module_address": "B", "channel": 3, "mode": "M02 (Open)", "t1": None},
+        {"module_address": "A", "channel": 1, "mode": "M02 (Open)", "t1": None},
         "garbage",
-        {"channel": 9, "mode": "M02"},          # no module
-        {"module_address": "8CF5", "mode": "M03"},  # no channel
+        {"channel": 9, "mode": "M02 (Open)"},          # no module
+        {"module_address": "B", "mode": "M03 (Close)"},  # no channel
     ]}
-    assert cf_roller_directions(cf) == {
-        "open": [{"module_address": "8CF5", "channel": 2, "time": "20 s"}]
-    }
+    members = cf_cover_members(cf)
+    assert [(m["module_address"], m["channel"]) for m in members] == [("B", 3), ("A", 1)]
 
 
-def test_cf_roller_directions_empty():
-    assert cf_roller_directions({}) == {}
-    assert cf_roller_directions({"outputs": None}) == {}
+def test_cf_cover_members_empty():
+    assert cf_cover_members({}) == []
+    assert cf_cover_members({"outputs": None}) == []

--- a/tests/test_platform_setup.py
+++ b/tests/test_platform_setup.py
@@ -119,6 +119,46 @@ class TestOutputPlatformSetup(unittest.TestCase):
         self.assertEqual(len(covers), 1)
         self.assertEqual(covers[0]._channel, 1)
 
+    def test_cover_platform_creates_cf_cover_for_pure_roller(self):
+        """A pure-roller CF (all shutter members) becomes a grouped
+        NikobusCFCoverEntity; a mixed/light CF does not."""
+        hass, entry, coord = _entry_and_coord()
+        coord.get_cover_operation_time = MagicMock(return_value=30.0)
+        coord.cf_storage.data = {
+            "nikobus_cf": {
+                # pure roller (M01 toggle) → CF cover
+                "3880CD": {
+                    "pattern": "roller_pair",
+                    "outputs": [
+                        {"module_address": "8CF5", "channel": 1,
+                         "mode": "M01 (Open - stop - close)", "t1": "40 s"},
+                    ],
+                },
+                # mixed (switch + roller) → NOT a CF cover
+                "3880C9": {
+                    "pattern": "nkb_scene",
+                    "outputs": [
+                        {"module_address": "C1C7", "channel": 1, "mode": "M03 (Off + Operating time)"},
+                        {"module_address": "8CF5", "channel": 2, "mode": "M03 (Close)"},
+                    ],
+                },
+            }
+        }
+        added: list = []
+        with patch.object(
+            cover_platform, "register_output_module_devices", MagicMock()
+        ):
+            _run(
+                cover_platform.async_setup_entry(
+                    hass, entry, lambda ents, **kw: added.extend(ents)
+                )
+            )
+        cf_covers = [
+            e for e in added if isinstance(e, cover_platform.NikobusCFCoverEntity)
+        ]
+        self.assertEqual(len(cf_covers), 1)
+        self.assertEqual(cf_covers[0]._attr_unique_id, "nikobus_cf_cover_3880cd")
+
     def test_routing_is_cached_per_entry(self):
         hass, entry, coord = _entry_and_coord()
         added: list = []
@@ -153,20 +193,28 @@ class TestScenePlatformSetup(unittest.TestCase):
                     ],
                     "triggered_by": ["3841AA"],
                 },
-                # A bidirectional roller_pair CF → two directional roller
-                # scenes (Open + Close), NOT a broadcast CF scene.
+                # A pure-roller (all shutter members, by mode wording) CF
+                # becomes a grouped COVER, not a scene → skipped here.
                 "3880CD": {
                     "pattern": "roller_pair",
                     "outputs": [
-                        {"module_address": "8CF5", "channel": 1, "mode": "M02", "t1": "40 s"},
-                        {"module_address": "8CF5", "channel": 1, "mode": "M03", "t1": "40 s"},
+                        {"module_address": "8CF5", "channel": 1, "mode": "M02 (Open)", "t1": "40 s"},
+                        {"module_address": "8CF5", "channel": 1, "mode": "M03 (Close)", "t1": "40 s"},
                     ],
                 },
-                # An M01-toggle roller_pair has no direction → broadcast scene.
+                # An M01-toggle pure-roller CF is also a cover → skipped here.
                 "3880C8": {
                     "pattern": "roller_pair",
                     "outputs": [
-                        {"module_address": "C7C1", "channel": 1, "mode": "M01 (Open-stop-close)"},
+                        {"module_address": "C7C1", "channel": 1, "mode": "M01 (Open - stop - close)"},
+                    ],
+                },
+                # Mixed (switch + roller) CF stays a broadcast CF scene.
+                "3880C9": {
+                    "pattern": "nkb_scene",
+                    "outputs": [
+                        {"module_address": "C1C7", "channel": 1, "mode": "M03 (Off + Operating time)"},
+                        {"module_address": "8CF5", "channel": 2, "mode": "M03 (Close)"},
                     ],
                 },
                 "garbage": "not-a-dict",  # ignored
@@ -186,14 +234,7 @@ class TestScenePlatformSetup(unittest.TestCase):
         cf_scenes = [
             e for e in added if isinstance(e, scene_platform.NikobusCFSceneEntity)
         ]
-        roller_scenes = [
-            e for e in added if isinstance(e, scene_platform.NikobusCFRollerSceneEntity)
-        ]
         self.assertEqual(len(user_scenes), 1)
-        # switch_pair + M01 roller stay broadcast CF scenes.
-        self.assertEqual(sorted(e._bus_address for e in cf_scenes), ["3841AA", "3880C8"])
-        # bidirectional roller → two directional roller scenes (open + close).
-        self.assertEqual(
-            sorted(e._attr_unique_id for e in roller_scenes),
-            ["nikobus_cf_3880cd_close", "nikobus_cf_3880cd_open"],
-        )
+        # switch_pair + mixed CF stay broadcast CF scenes; the two pure-roller
+        # CFs (incl. the M01 toggle) are skipped (they become covers).
+        self.assertEqual(sorted(e._bus_address for e in cf_scenes), ["3841AA", "3880C9"])

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -15,13 +15,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 from custom_components.nikobus.const import DOMAIN
 from custom_components.nikobus.scene import (
-    NikobusCFRollerSceneEntity,
     NikobusCFSceneEntity,
     NikobusSceneEntity,
-    STATE_CLOSE,
-    STATE_OPEN,
-    STATE_STOPPED,
-    _parse_cf_time,
 )
 
 
@@ -152,137 +147,6 @@ class TestCFSceneActivation(unittest.TestCase):
         self.assertEqual(e._device_name, "CloseHouse - Leave")
         self.assertIsNone(e._attr_name)
         self.assertEqual(e._attr_unique_id, "nikobus_cf_c177ce")
-
-
-class TestParseCfTime(unittest.TestCase):
-    def test_seconds_minutes_and_invalid(self):
-        self.assertEqual(_parse_cf_time("40 s"), 40.0)
-        self.assertEqual(_parse_cf_time("30s"), 30.0)
-        self.assertEqual(_parse_cf_time("2 m"), 120.0)
-        self.assertIsNone(_parse_cf_time(None))
-        self.assertIsNone(_parse_cf_time(""))
-        self.assertIsNone(_parse_cf_time("abc"))
-        self.assertIsNone(_parse_cf_time("0 s"))
-
-
-def _make_roller_scene(direction, members=None):
-    if members is None:
-        members = [
-            {"module_address": "8CF5", "channel": 1, "time": "40 s"},
-            {"module_address": "8CF5", "channel": 2, "time": "30 s"},
-            {"module_address": "8CF5", "channel": 3, "time": "30 s"},
-        ]
-    coord = MagicMock()
-    coord.get_cover_operation_time = MagicMock(return_value=30.0)
-    coord.get_module_channel_count = MagicMock(return_value=6)
-    coord.nikobus_module_states = {}
-    coord.set_bytearray_group_state = MagicMock()
-    coord.api.set_output_states_for_module = AsyncMock()
-    coord.async_event_handler = AsyncMock()
-    coord.address_label = MagicMock(side_effect=lambda a: f"name({a})")
-    e = NikobusCFRollerSceneEntity(
-        coord, "3880cd", {"pattern": "roller_pair"}, members, direction
-    )
-    e.hass = MagicMock()
-
-    def _fake_create_task(arg):
-        if asyncio.iscoroutine(arg):
-            arg.close()
-        return MagicMock()
-
-    e.hass.async_create_task = MagicMock(side_effect=_fake_create_task)
-    return e, coord
-
-
-class TestCFRollerScene(unittest.TestCase):
-    def test_naming_and_unique_id(self):
-        e_open, _ = _make_roller_scene("open")
-        e_close, _ = _make_roller_scene("close")
-        self.assertEqual(e_open._attr_unique_id, "nikobus_cf_3880cd_open")
-        self.assertEqual(e_close._attr_unique_id, "nikobus_cf_3880cd_close")
-        self.assertTrue(e_open._attr_name.endswith("Open"))
-        self.assertTrue(e_close._attr_name.endswith("Close"))
-
-    def test_name_from_nkb_import(self):
-        coord = MagicMock()
-        e = NikobusCFRollerSceneEntity(
-            coord, "3880cd",
-            {"pattern": "roller_pair", "name": "Gordijnen keuken"},
-            [{"module_address": "8CF5", "channel": 1, "time": "40 s"}],
-            "close",
-        )
-        # The CF name is the device name; the direction is the entity-name
-        # part, so HA composes "Gordijnen keuken Close".
-        self.assertEqual(e._device_name, "Gordijnen keuken")
-        self.assertEqual(e._attr_name, "Close")
-        # Own device, keyed off the CF (not the bare bus address) and
-        # shared by both directions.
-        self.assertEqual(
-            e._attr_device_info["identifiers"], {(DOMAIN, "cf_3880cd")}
-        )
-
-    def test_close_drives_members_atomically_once_per_module(self):
-        e, coord = _make_roller_scene("close")
-        _run(e._drive())
-        coord.api.set_output_states_for_module.assert_awaited_once_with(address="8CF5")
-        group1_hex = coord.set_bytearray_group_state.call_args_list[0].args[2]
-        self.assertEqual(group1_hex[:6], "020202")  # 0x02 = close, channels 1-3
-        self.assertEqual(len(e._module_tokens), 1)
-
-    def test_open_drives_opening_byte(self):
-        e, coord = _make_roller_scene("open")
-        _run(e._drive())
-        group1_hex = coord.set_bytearray_group_state.call_args_list[0].args[2]
-        self.assertEqual(group1_hex[:6], "010101")  # 0x01 = open
-
-    def test_cross_module_commits_once_per_module(self):
-        members = [
-            {"module_address": "8B9C", "channel": 1, "time": "40 s"},
-            {"module_address": "9418", "channel": 2, "time": "30 s"},
-        ]
-        e, coord = _make_roller_scene("close", members=members)
-        _run(e._drive())
-        self.assertEqual(coord.api.set_output_states_for_module.await_count, 2)
-        addrs = {c.kwargs["address"] for c in coord.api.set_output_states_for_module.await_args_list}
-        self.assertEqual(addrs, {"8B9C", "9418"})
-
-    def test_activate_translates_bus_error(self):
-        from homeassistant.exceptions import HomeAssistantError
-
-        e, coord = _make_roller_scene("close")
-        coord.api.set_output_states_for_module = AsyncMock(
-            side_effect=RuntimeError("bus down")
-        )
-        with self.assertRaises(HomeAssistantError) as cm:
-            _run(e.async_activate())
-        self.assertEqual(cm.exception.translation_key, "communication_error")
-
-    def test_delayed_stop_only_touches_unchanged_channels(self):
-        e, coord = _make_roller_scene("close")
-        sent = bytearray(12)
-        sent[0] = STATE_CLOSE
-        sent[1] = STATE_CLOSE
-        current = bytearray(12)
-        current[0] = STATE_CLOSE   # ch1 still ours
-        current[1] = STATE_OPEN    # ch2 redirected
-        coord.nikobus_module_states = {"8CF5": current}
-        e._module_tokens = {"8CF5": "tok"}
-        with unittest.mock.patch(
-            "custom_components.nikobus.scene.asyncio.sleep", new=AsyncMock()
-        ):
-            _run(e._delayed_roller_stop("8CF5", sent, {0, 1}, 0.0, "tok"))
-        group1_hex = coord.set_bytearray_group_state.call_args_list[-1].args[2]
-        self.assertEqual(group1_hex[:4], "0001")  # ch1 stopped, ch2 left opening
-        _ = STATE_STOPPED  # referenced for clarity
-
-    def test_delayed_stop_aborted_when_token_superseded(self):
-        e, coord = _make_roller_scene("close")
-        e._module_tokens = {"8CF5": "newtok"}
-        with unittest.mock.patch(
-            "custom_components.nikobus.scene.asyncio.sleep", new=AsyncMock()
-        ):
-            _run(e._delayed_roller_stop("8CF5", bytearray(12), {0}, 0.0, "oldtok"))
-        coord.api.set_output_states_for_module.assert_not_awaited()
 
 
 class TestCFSceneAttributes(unittest.TestCase):


### PR DESCRIPTION
Implements roller central functions as **member-driving grouped covers**, with the design spec it's built from. Version `3.8.8` → `3.9.0`.

## Spec (`documentation/scene-mapping.md`)
The agreed mapping, derived from the Nikobus software manual (`PHNikobus_EN.pdf`, page-cited): a CF is an *output group* with a 1/2/4-button operation type; determinism = button-count + mode; **pure-roller groups → cover, scene/preset recalls → scene, mixed → scene**.

## Implementation
A Nikobus CF whose members are **all roller (shutter) channels** — including `M01` "open-stop-close" toggle groups — is now a single **cover** (open/close/stop) under a new **"Central functions"** device category, instead of a broadcast/directional scene. It drives every member channel atomically (`set_output_states_for_module`, one bus frame per module) with a timed stop from the operation times, so it's deterministic even for `M01` (which a broadcast can't be).

- `const.py`: new `CATEGORY_CENTRAL_FUNCTIONS` category.
- `nkbreconcile.py`: `_is_roller_member` (detects roller members by mode **wording** — `open`/`close`/`stop` — since `M02`/`M03` codes are shared with switch modules), `is_pure_roller_cf`, `cf_cover_members` (`M01` → one time both directions).
- `cover.py`: restored `NikobusCFCoverEntity` (atomic per-module commit, group travel calculator, token-guarded timed stop), gated on `is_pure_roller_cf`.
- `scene.py`: skip pure-roller CFs; **removed** the directional `NikobusCFRollerSceneEntity` (superseded). Mixed/light CFs stay scenes.
- `coordinator.py`: pure-roller CFs register `nikobus_cf_cover_<addr>` for orphan-cleanup.

## Validation
Run against a real `nikobus.cfs`: **only** the all-`M01` `ShuttersSalonCuisine` becomes a cover; `CloseHouse - Leave` / `829201` (mixed) and `Scene - TV/Dinner/CosiDinner` (light) stay scenes.

## Testing
Full suite **483 passed**; ruff clean. Tests for the helper, the cover entity (placement + atomic open/close/stop + timed stop), platform routing, and known-IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)