### PR TITLE
fix(scene): .nkb import no longer surfaces an existing button as a scene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 3.9.1
+
+- **`.nkb` import no longer surfaces an existing button as a scene.** A
+  named Central Function group in the `.nkb` is realised through its
+  trigger input, so a group that isn't already a discovered CF broadcast
+  is fired by a real button on the bus. The import used to create a
+  separate `nkb_scene` for those groups, duplicating a button you already
+  have. Now the import only **names** scenes that already exist as
+  discovered CF broadcasts (the `3880xx` / `3841xx` PC-Logic addresses)
+  from the `.nkb`; button-triggered groups are left as the buttons they
+  are, and groups with no on-bus trigger at all (nothing to activate) are
+  not fabricated. Any button-duplicating scenes a previous import created
+  are removed on the next import or re-discovery.
+
 ## 3.9.0
 
 - **Roller central functions are now grouped covers, not scenes.** A

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -529,13 +529,12 @@ class NikobusImportNkbNamesButton(ButtonEntity):
         result = await self._coordinator.async_import_nkb_names()
         _LOGGER.info(
             "Nikobus .nkb import done: %s devices, %s entities, %s channels, "
-            "%s areas, %s scenes named, %s scenes created",
+            "%s areas, %s scenes named",
             result["devices"],
             result["entities"],
             result.get("channels", 0),
             result["areas"],
             result["scenes"],
-            result.get("scenes_created", 0),
         )
 
 

--- a/custom_components/nikobus/discovery_mixin.py
+++ b/custom_components/nikobus/discovery_mixin.py
@@ -52,7 +52,6 @@ from .const import (
     SIGNAL_DISCOVERY_STATE,
 )
 from .nkbreconcile import (
-    build_routing_graph,
     cf_member_set,
     classify_button_status,
     flatten_cf_broadcasts,
@@ -298,20 +297,16 @@ class NikobusDiscoveryMixin:
 
         flat = flatten_cf_broadcasts(broadcasts)
 
-        # Preserve any .nkb-sourced scenes (added by async_import_nkb_names);
-        # discovery never produces them, so a re-scan must not wipe them.
-        preserved = {
-            addr: entry
-            for addr, entry in (self.cf_storage.data.get("nikobus_cf") or {}).items()
-            if isinstance(entry, dict) and entry.get("source") == "nkb"
-        }
-        self.cf_storage.data["nikobus_cf"] = {**preserved, **flat}
+        # Drop any stale ``.nkb``-sourced scenes a previous import created.
+        # Those were per-button duplicates (a named group fired by a real
+        # button surfaced as its own scene); we no longer create them, so a
+        # re-scan clears them out rather than carrying them forward.
+        self.cf_storage.data["nikobus_cf"] = flat
         await self.cf_storage.async_save()
         _LOGGER.info(
-            "CF broadcasts persisted: %d discovered + %d nkb-sourced (%s)",
+            "CF broadcasts persisted: %d discovered (%s)",
             len(flat),
-            len(preserved),
-            sorted({**preserved, **flat}.keys()),
+            sorted(flat.keys()),
         )
 
     async def async_activate_cf_broadcast(self, bus_address: str) -> None:
@@ -1056,7 +1051,8 @@ class NikobusDiscoveryMixin:
           light / cover / switch the user actually toggles, e.g.
           ``Appliques Salon``, ``Terrasse``).
         * ``"areas"`` — each device into a Home Assistant Area = its room.
-        * ``"scenes"`` — match / create the Central Function scene entities.
+        * ``"scenes"`` — name already-discovered Central Function scenes
+          from the ``.nkb`` (never creates a scene from a button trigger).
 
         ``overwrite`` forces a name/Area even where the user has set their
         own; default off (suggested, never clobbers a manual rename).
@@ -1086,20 +1082,43 @@ class NikobusDiscoveryMixin:
 
         name_map = data.addresses  # {ADDR: (name, room)}
 
-        # Scenes: match named groups to existing CFs (light scenes) and
-        # create entities for the rest (shutter / master groups) — only if
-        # the "scenes" category is selected.
+        # Scenes: match each named ``.nkb`` group to an already-discovered
+        # Central Function by member set and apply its real name. We only
+        # ever NAME an existing CF scene here — we never CREATE one.
+        #
+        # A named group's membership lives on its trigger input (the parser
+        # resolves group → trigger → that input's output links → members),
+        # so a group that isn't already a discovered CF broadcast is fired
+        # by a real button on the bus. Surfacing it as a scene would just
+        # duplicate a button the user already has, so we leave the button
+        # untouched. A group with no on-bus trigger at all has no address to
+        # activate, so there is nothing faithful to create for it either.
+        # Only runs when the "scenes" category is selected.
         cf_name_by_addr: dict[str, str] = {}
-        scenes_created = 0
+        purged_nkb_scenes = False
         if "scenes" in cats and self.cf_storage is not None:
+            cf_store = self.cf_storage.data.get("nikobus_cf", {})
+            # Migration: drop any button-duplicating scenes a previous
+            # import created (``source == "nkb"``). Earlier versions turned
+            # every named group fired by a real button into its own
+            # ``nkb_scene`` CF, surfacing that button a second time as a
+            # scene. We no longer create those, so clear out the stale ones
+            # too — re-importing makes the duplication go away.
+            stale = [
+                addr
+                for addr, cf in cf_store.items()
+                if isinstance(cf, dict) and cf.get("source") == "nkb"
+            ]
+            for addr in stale:
+                del cf_store[addr]
+            purged_nkb_scenes = bool(stale)
+
             scene_by_members = {sc.members: sc.name for sc in data.scenes}
-            matched_scene_members: set[frozenset[tuple[str, int, str]]] = set()
             names_persisted = False
-            for cf_addr, cf in self.cf_storage.data.get("nikobus_cf", {}).items():
+            for cf_addr, cf in cf_store.items():
                 hit = scene_by_members.get(cf_member_set(cf))
                 if hit:
                     cf_name_by_addr[str(cf_addr).upper()] = hit
-                    matched_scene_members.add(cf_member_set(cf))
                     # Persist the name onto the CF itself. The scene entity
                     # lives on its own ``cf_<addr>`` device (so it isn't
                     # merged into the trigger button's device), which the
@@ -1108,32 +1127,7 @@ class NikobusDiscoveryMixin:
                     if cf.get("name") != hit:
                         cf["name"] = hit
                         names_persisted = True
-            graph = build_routing_graph(self.dict_button_data)
-            existing = self.cf_storage.data.setdefault("nikobus_cf", {})
-            new_entries: dict[str, dict[str, Any]] = {}
-            for sc in data.scenes:
-                if sc.members in matched_scene_members or not sc.members:
-                    continue
-                hit = graph.get(sc.members)
-                if hit is None:
-                    continue
-                addrs, outputs = hit
-                canonical = addrs[0]
-                if canonical in existing or canonical in new_entries:
-                    continue
-                new_entries[canonical] = {
-                    "bus_address": canonical,
-                    "pattern": "nkb_scene",
-                    "outputs": outputs,
-                    "triggered_by": addrs,
-                    "source": "nkb",
-                    "name": sc.name,
-                }
-                cf_name_by_addr[canonical] = sc.name
-            if new_entries:
-                existing.update(new_entries)
-                scenes_created = len(new_entries)
-            if new_entries or names_persisted:
+            if names_persisted or purged_nkb_scenes:
                 await self.cf_storage.async_save()
 
         dev_reg = dr.async_get(self.hass)
@@ -1224,8 +1218,7 @@ class NikobusDiscoveryMixin:
 
         _LOGGER.info(
             "Imported .nkb from %s (overwrite=%s, categories=%s): %d devices, "
-            "%d device-entities, %d channels, %d areas, %d scenes named, "
-            "%d scenes created",
+            "%d device-entities, %d channels, %d areas, %d scenes named",
             path.name,
             overwrite,
             sorted(cats),
@@ -1233,11 +1226,12 @@ class NikobusDiscoveryMixin:
             entities_named,
             channels_named,
             areas_set,
-            len(cf_name_by_addr) - scenes_created,
-            scenes_created,
+            len(cf_name_by_addr),
         )
 
-        if scenes_created:
+        # Removing stale button-duplicating scenes changes the entity set —
+        # reload so the now-deleted scene entities are torn down.
+        if purged_nkb_scenes:
             self.hass.async_create_task(
                 self.hass.config_entries.async_reload(self.config_entry.entry_id)
             )
@@ -1247,7 +1241,6 @@ class NikobusDiscoveryMixin:
             "entities": entities_named,
             "channels": channels_named,
             "areas": areas_set,
-            "scenes": len(cf_name_by_addr) - scenes_created,
-            "scenes_created": scenes_created,
+            "scenes": len(cf_name_by_addr),
         }
 

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -22,5 +22,5 @@
     "pyserial-asyncio-fast>=0.16",
     "nikobus-connect>=0.28.0"
   ],
-  "version": "3.9.0"
+  "version": "3.9.1"
 }

--- a/custom_components/nikobus/scene.py
+++ b/custom_components/nikobus/scene.py
@@ -126,10 +126,10 @@ class NikobusCFSceneEntity(NikobusEntity, Scene):
         outputs = cf_config.get("outputs") or []
         member_count = len(outputs) if isinstance(outputs, list) else 0
 
-        # A name imported from the .nkb (nkb-sourced scenes — shutter /
-        # master groups that carry their real project name) wins outright.
-        # Otherwise build a default from what we know on the bus; the user
-        # can still rename via the standard HA flow.
+        # A name applied from the .nkb (the import names discovered CF
+        # broadcasts with their real project name) wins outright. Otherwise
+        # build a default from what we know on the bus; the user can still
+        # rename via the standard HA flow.
         imported = cf_config.get("name")
         if isinstance(imported, str) and imported.strip():
             name = imported.strip()

--- a/scripts/nkb_scene_buckets.py
+++ b/scripts/nkb_scene_buckets.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Preview how the .nkb scenes import will bucket YOUR named groups.
+
+Runs entirely on your machine against your own files — nothing is sent
+anywhere. It classifies every named Central Function group in your .nkb
+into the three buckets the new import logic uses:
+
+  A  matches an already-discovered CF broadcast  -> KEPT, named from .nkb
+  B  fired only by a real button on the bus      -> SKIPPED (left as the button)
+  C  no on-bus trigger at all                     -> SKIPPED (nothing to activate)
+
+Bucket B is the behavior change: those groups used to be created as a
+separate scene that duplicated a button; now they're skipped. This tells
+you, before merging, how many of your named scenes that affects.
+
+Requirements:
+    pip install nikobus-connect      # the same parser the integration uses
+
+Usage:
+    python nkb_scene_buckets.py /path/to/homeassistant/config
+
+    # config dir is where your .nkb lives and which has a .storage/ folder
+    # with nikobus.cfs and nikobus.buttons. You can also pass paths
+    # explicitly:
+    python nkb_scene_buckets.py \
+        --nkb /path/to/project.nkb \
+        --cfs /path/to/.storage/nikobus.cfs \
+        --buttons /path/to/.storage/nikobus.buttons
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from nikobus_connect.nkb import find_nkb_file, mode_code, parse_nkb
+
+
+# --- the two pure helpers the integration uses, copied verbatim so this
+# --- script needs only nikobus-connect, not the HA custom component ----------
+
+def member_set_from_outputs(outputs):
+    out = set()
+    for o in outputs or []:
+        if not isinstance(o, dict):
+            continue
+        mod = o.get("module_address")
+        ch = o.get("channel")
+        code = mode_code(o.get("mode"))
+        if isinstance(mod, str) and isinstance(ch, int) and code:
+            out.add((mod.upper(), ch, code))
+    return frozenset(out)
+
+
+def cf_member_set(cf):
+    return member_set_from_outputs((cf or {}).get("outputs"))
+
+
+def build_routing_graph(button_data):
+    graph = {}
+    buttons = (button_data or {}).get("nikobus_button", {})
+    if not isinstance(buttons, dict):
+        return {}
+    for phys in buttons.values():
+        if not isinstance(phys, dict):
+            continue
+        for op in (phys.get("operation_points") or {}).values():
+            if not isinstance(op, dict):
+                continue
+            addr = op.get("bus_address")
+            if not isinstance(addr, str) or not addr:
+                continue
+            outputs, seen = [], set()
+            for link in op.get("linked_modules") or []:
+                if not isinstance(link, dict):
+                    continue
+                mod = link.get("module_address")
+                if not isinstance(mod, str):
+                    continue
+                for o in link.get("outputs") or []:
+                    if not isinstance(o, dict):
+                        continue
+                    ch, m = o.get("channel"), o.get("mode")
+                    if not (isinstance(ch, int) and isinstance(m, str)):
+                        continue
+                    key = (mod.upper(), ch, m)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    outputs.append({"module_address": mod.upper(), "channel": ch, "mode": m})
+            members = member_set_from_outputs(outputs)
+            if not members:
+                continue
+            graph.setdefault(members, ([], outputs))[0].append(addr.upper())
+    return {m: (sorted(set(a)), o) for m, (a, o) in graph.items()}
+
+
+def _load_store(path: Path):
+    """Read an HA .storage file ({"data": {...}}) or a bare dict."""
+    if not path or not path.exists():
+        return {}
+    raw = json.loads(path.read_text())
+    return raw.get("data", raw) if isinstance(raw, dict) else {}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("config_dir", nargs="?", help="HA config dir (holds the .nkb and .storage/)")
+    ap.add_argument("--nkb", help="explicit path to the .nkb")
+    ap.add_argument("--cfs", help="explicit path to .storage/nikobus.cfs")
+    ap.add_argument("--buttons", help="explicit path to .storage/nikobus.buttons")
+    args = ap.parse_args()
+
+    cfg = Path(args.config_dir) if args.config_dir else None
+    nkb_path = Path(args.nkb) if args.nkb else (find_nkb_file(str(cfg)) if cfg else None)
+    if not nkb_path or not Path(nkb_path).exists():
+        print("ERROR: could not find a .nkb — pass --nkb or a config dir.", file=sys.stderr)
+        return 2
+    cfs_path = Path(args.cfs) if args.cfs else (cfg / ".storage" / "nikobus.cfs" if cfg else None)
+    btn_path = Path(args.buttons) if args.buttons else (cfg / ".storage" / "nikobus.buttons" if cfg else None)
+
+    data = parse_nkb(Path(nkb_path))
+    cf_store = _load_store(cfs_path) if cfs_path else {}
+    btn_store = _load_store(btn_path) if btn_path else {}
+
+    cf_member_sets = {
+        cf_member_set(cf)
+        for cf in (cf_store.get("nikobus_cf", {}) or {}).values()
+        if isinstance(cf, dict)
+    }
+    graph = build_routing_graph(btn_store)
+
+    A, B, C = [], [], []
+    for sc in data.scenes:
+        if not sc.members:
+            continue
+        if sc.members in cf_member_sets:
+            A.append(sc.name)
+        elif sc.members in graph:
+            B.append((sc.name, graph[sc.members][0]))
+        else:
+            C.append(sc.name)
+
+    print(f"\n.nkb           : {nkb_path}")
+    print(f"CF store       : {cfs_path}  ({'found' if cfs_path and cfs_path.exists() else 'MISSING'})")
+    print(f"Button store   : {btn_path}  ({'found' if btn_path and btn_path.exists() else 'MISSING'})")
+    print(f"Named groups   : {len(data.scenes)}\n")
+
+    print(f"A — KEPT & named (matches a discovered CF) : {len(A)}")
+    for n in sorted(A):
+        print(f"      • {n}")
+    print(f"\nB — SKIPPED (button-fired; was a duplicate): {len(B)}")
+    for n, addrs in sorted(B):
+        print(f"      • {n}   [trigger(s): {', '.join(addrs)}]")
+    print(f"\nC — SKIPPED (no on-bus trigger)            : {len(C)}")
+    for n in sorted(C):
+        print(f"      • {n}")
+
+    if not cf_store:
+        print("\nNOTE: CF store missing/empty — every group will look like B/C. "
+              "Run a discovery first so nikobus.cfs is populated, or pass --cfs.")
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_nkbnames.py
+++ b/tests/test_nkbnames.py
@@ -146,7 +146,7 @@ def test_import_names_areas_and_scene_match():
         result = _run(coord.async_import_nkb_names())
 
     assert result == {"devices": 3, "entities": 2, "channels": 0, "areas": 2,
-                      "scenes": 1, "scenes_created": 0}
+                      "scenes": 1}
     names = {c.args[0]: c.kwargs.get("name")
              for c in dev_reg.async_update_device.call_args_list
              if "name" in c.kwargs}
@@ -165,10 +165,10 @@ def test_import_names_areas_and_scene_match():
     assert {c.args[0] for c in area_calls} == {"d1", "d2"}
 
 
-def test_import_creates_nkb_sourced_shutter_scene():
-    """A named group with no matching CF (shutter scene — no light-scene
-    mode) is created in cf_storage, keyed on the address that fires its
-    member set, sourced 'nkb' with its real name."""
+def test_import_does_not_surface_button_fired_group_as_scene():
+    """A named group fired by real buttons on the bus is NOT turned into a
+    scene: that would duplicate a button the user already has. The buttons
+    are left untouched and no CF is created."""
     data = NkbData(
         addresses={},
         scenes=[SceneDef("ShuttersSalonCuisine",
@@ -185,36 +185,52 @@ def test_import_creates_nkb_sourced_shutter_scene():
     with _patches(data, [], [], dev_reg, ent_reg, area_reg):
         result = _run(coord.async_import_nkb_names())
 
-    assert result["scenes_created"] == 1
-    cf = coord.cf_storage.data["nikobus_cf"]
-    # canonical = sorted-first of {AB1234, CD5678}
-    assert "AB1234" in cf
-    entry = cf["AB1234"]
-    assert entry["source"] == "nkb"
-    assert entry["name"] == "ShuttersSalonCuisine"
-    assert entry["triggered_by"] == ["AB1234", "CD5678"]
-    assert {(o["module_address"], o["channel"]) for o in entry["outputs"]} == \
-        {("9105", 3), ("9105", 5)}
-    # a reload is scheduled so the scene platform creates the entity
-    coord.hass.async_create_task.assert_called_once()
-
-
-def test_import_skips_triggerless_group():
-    """A group whose member set no op-point drives (no on-bus trigger) is
-    not created."""
-    data = NkbData(addresses={},
-                   scenes=[SceneDef("ShuttersUp",
-                                    frozenset({("9105", 1, "M02")}))])
-    coord = _coord(cf={}, button_data={"nikobus_button": {}})  # empty graph
-    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
-    with _patches(data, [], [], dev_reg, ent_reg, area_reg):
-        result = _run(coord.async_import_nkb_names())
-    assert result["scenes_created"] == 0
+    assert result["scenes"] == 0
+    # nothing created, the buttons are left as-is
     assert coord.cf_storage.data["nikobus_cf"] == {}
 
 
-def test_ingest_preserves_nkb_sourced_scenes():
-    """A re-discovery must not wipe nkb-sourced scenes."""
+def test_import_names_existing_discovered_cf_scene():
+    """A named group that matches an already-discovered CF broadcast (no
+    physical button — a 3880/3841 PC-Logic address) is NAMED from the .nkb,
+    not recreated. The name is persisted onto the CF record."""
+    data = NkbData(
+        addresses={},
+        scenes=[SceneDef("CloseHouse",
+                         frozenset({("9105", 1, "M03")}))],
+    )
+    coord = _coord(cf={"3880AA": {
+        "bus_address": "3880AA", "pattern": "roller_pair",
+        "outputs": [{"module_address": "9105", "channel": 1,
+                     "mode": "M03 (Close)"}]}})
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    with _patches(data, [], [], dev_reg, ent_reg, area_reg):
+        result = _run(coord.async_import_nkb_names())
+
+    assert result["scenes"] == 1
+    assert coord.cf_storage.data["nikobus_cf"]["3880AA"]["name"] == "CloseHouse"
+
+
+def test_import_purges_stale_nkb_sourced_scene():
+    """Migration: a button-duplicating scene a previous import created
+    (source='nkb') is removed on the next import, and a reload is scheduled
+    so the now-dead scene entity is torn down."""
+    data = NkbData(addresses={}, scenes=[])
+    coord = _coord(cf={
+        "AB1234": {"bus_address": "AB1234", "pattern": "nkb_scene",
+                   "outputs": [], "source": "nkb", "name": "ShuttersUp"},
+    })
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    with _patches(data, [], [], dev_reg, ent_reg, area_reg):
+        _run(coord.async_import_nkb_names())
+
+    assert coord.cf_storage.data["nikobus_cf"] == {}
+    coord.hass.async_create_task.assert_called_once()
+
+
+def test_ingest_drops_stale_nkb_sourced_scenes():
+    """A re-discovery clears stale nkb-sourced scenes (per-button duplicates
+    we no longer create), keeping only freshly discovered broadcasts."""
     from unittest.mock import AsyncMock
 
     coord = _coord(cf={
@@ -234,7 +250,7 @@ def test_ingest_preserves_nkb_sourced_scenes():
     _run(coord._ingest_cf_broadcasts())
 
     cf = coord.cf_storage.data["nikobus_cf"]
-    assert "AB1234" in cf and cf["AB1234"]["source"] == "nkb"  # preserved
+    assert "AB1234" not in cf  # stale nkb-sourced scene dropped
     assert "DE4E2C" in cf  # discovered, freshly ingested
 
 


### PR DESCRIPTION
## Problem

A named Central Function "scene" group in the `.nkb` is realised **through its trigger input** — the parser resolves `group → trigger → that input's output links → members`. So a group that isn't already a discovered CF broadcast is, by construction, fired by a **real button on the bus**.

The scenes import used to resolve that trigger via the routing graph and create a separate `nkb_scene` CF **at the button's own address**, duplicating a button the user already has — surfacing the same physical control twice (once as a button, once as a scene).

## Change

The scenes import now only ever **names** scenes that already exist; it never creates one from a button trigger.

| Situation | Before | After |
|---|---|---|
| **A** — group matches an already-discovered CF broadcast (`3880xx`/`3841xx`) | named | named (unchanged) |
| **B** — group fired only by a real button | duplicate `nkb_scene` created | **skipped** — left as the button |
| **C** — group with no on-bus trigger at all | skipped | skipped (nothing to activate; a member-driving software scene would be lossy per `documentation/scene-mapping.md`) |

### Migration
Any button-duplicating `source="nkb"` scenes a previous import created are **purged** on the next import (with a reload so the dead scene entities are torn down) and **dropped** on the next re-discovery (`_ingest_cf_broadcasts` no longer carries them forward).

## Notes / consequences
- For a skipped **B** group, the `.nkb` group name is **not** transferred onto the button (the trigger keeps its own device name). This follows the "leave the button untouched" decision — one group maps to many trigger addresses and one keypad device to many keys, so auto-renaming a button to a group name is ambiguous.
- A button-fired **roller** group no longer becomes a grouped cover via the `.nkb` path; grouped covers still come from discovered `3880xx` broadcasts.

## Diagnostic
`scripts/nkb_scene_buckets.py` is a standalone, offline tool that classifies a real `.nkb`'s named groups into the A/B/C buckets above (reads the user's `.nkb` + `nikobus.cfs` + `nikobus.buttons`), so the impact can be previewed before relying on the new behavior.

## Tests
- The two tests that encoded the old "create a scene from a button trigger" behavior are replaced with tests for the new behavior: button-fired group **not** surfaced, discovered CF gets named, stale `source="nkb"` entries purged on import and dropped on re-discovery.
- Full suite: `472 passed`; the 12 `test_actuator_burst.py` failures are pre-existing (missing `pytest-asyncio` plugin) and fail identically on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYYLpsjcRjj4pc4NabPv3n

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYYLpsjcRjj4pc4NabPv3n)_