### PR TITLE
fix(entity): propagate state after a physical button press (issue #469)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 3.9.1
+
+- **Fix: output state stuck after a physical button press (issue #469).**
+  An output toggled from Home Assistant and then changed at the physical
+  wall button could stay frozen on the Home-Assistant value — the module
+  was read correctly (e.g. `000000000000`), but the entity never updated,
+  on the button-driven refresh *or* the poll. The write-diff cache that
+  skips redundant re-renders only tracked coordinator-driven writes, so an
+  optimistic write (turn on/off, button-operation) left it stale; a later
+  update that rendered the same value as the stale cache was wrongly
+  suppressed. The cache now refreshes on every state write regardless of
+  source, so the corrected state always lands. Most visible on serial /
+  PC-Link installs without a feedback module (polling mode).
+
 ## 3.9.0
 
 - **Roller central functions are now grouped covers, not scenes.** A

--- a/custom_components/nikobus/entity.py
+++ b/custom_components/nikobus/entity.py
@@ -126,6 +126,30 @@ class NikobusEntity(CoordinatorEntity[NikobusDataCoordinator]):
             self._last_render = signature
         super()._handle_coordinator_update()
 
+    @callback
+    def async_write_ha_state(self) -> None:
+        """Write state to HA and keep the write-diff cache in sync.
+
+        ``_last_render`` gates ``_handle_coordinator_update`` so a poll
+        that re-reads an unchanged byte doesn't re-render. But the
+        displayed state is *also* moved by optimistic writes
+        (``async_turn_on`` / ``async_turn_off``) and the button-operation
+        handler, which call this method directly. Those paths previously
+        left ``_last_render`` untouched, so it tracked "last
+        coordinator-rendered value" rather than "what's actually on
+        screen". When a later coordinator update happened to render the
+        same value as that stale cache — e.g. the real OFF state after an
+        optimistic ON — the write was suppressed and the entity stayed
+        stuck on the optimistic value (issue #469).
+
+        Refreshing the cache on every write, whatever its source, keeps
+        the diff honest while preserving the redundant-poll optimization.
+        """
+        state = self._render_state()
+        if state is not _NO_DIFF:
+            self._last_render = (self.available, state)
+        super().async_write_ha_state()
+
     @property
     def available(self) -> bool:
         """Return True only when the coordinator is healthy and the connection is live."""

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -22,5 +22,5 @@
     "pyserial-asyncio-fast>=0.16",
     "nikobus-connect>=0.28.0"
   ],
-  "version": "3.9.0"
+  "version": "3.9.1"
 }

--- a/tests/test_state_diffing.py
+++ b/tests/test_state_diffing.py
@@ -10,7 +10,7 @@ change — these pin that for switch (on/off) and dimmer (on/off + level).
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from custom_components.nikobus.light import NikobusDimmerEntity
 from custom_components.nikobus.switch import NikobusRelaySwitchEntity
@@ -80,3 +80,70 @@ def test_dimmer_update_clears_both_optimistic_caches():
     e._handle_coordinator_update()
     assert e._is_on is None
     assert e._optimistic_brightness is None
+
+
+# ---------------------------------------------------------------------------
+# Regression: issue #469
+#
+# The write-diff cache (``_last_render``) is only meaningful if it tracks
+# what's *actually displayed*, not just the last coordinator-driven render.
+# Optimistic writes (``async_turn_on`` / ``async_turn_off``) and the
+# button-operation handler move the displayed state via
+# ``async_write_ha_state`` — those must refresh the cache too. Otherwise a
+# later coordinator update that renders the same value as the stale cache
+# (e.g. the real OFF state after an optimistic ON) is wrongly suppressed,
+# freezing the entity on the optimistic value. ``NikobusEntity`` overrides
+# ``async_write_ha_state`` to keep the cache honest; these pin that.
+#
+# We patch only the underlying HA write so the entity's own override runs
+# (the other tests above replace ``async_write_ha_state`` wholesale, which
+# would bypass exactly the code under test here).
+# ---------------------------------------------------------------------------
+
+
+def test_switch_optimistic_write_unfreezes_later_real_state_issue_469():
+    e, coord = _switch(state=False)
+    del e.async_write_ha_state  # restore the real override (helper stubbed it)
+    with patch(
+        "homeassistant.helpers.update_coordinator."
+        "CoordinatorEntity.async_write_ha_state"
+    ) as raw_write:
+        # 1. Steady OFF — coordinator render writes; cache = (True, off).
+        e._handle_coordinator_update()
+        assert raw_write.call_count == 1
+
+        # 2. User turns it ON from HA — optimistic displayed state. The
+        #    coordinator byte hasn't changed, but the cache must follow.
+        e._is_on = True
+        e.async_write_ha_state()
+        assert raw_write.call_count == 2
+
+        # 3. Physical OFF — coordinator now reads OFF. Pre-fix the cache was
+        #    stale at (True, off) and this write was dropped, leaving the
+        #    entity stuck on the optimistic ON (issue #469).
+        coord.get_switch_state.return_value = False
+        e._handle_coordinator_update()
+        assert raw_write.call_count == 3
+
+
+def test_dimmer_optimistic_write_unfreezes_later_real_state_issue_469():
+    e, coord = _dimmer(level=0)
+    del e.async_write_ha_state
+    with patch(
+        "homeassistant.helpers.update_coordinator."
+        "CoordinatorEntity.async_write_ha_state"
+    ) as raw_write:
+        # 1. Steady OFF — writes; cache = (True, (off, 0)).
+        e._handle_coordinator_update()
+        assert raw_write.call_count == 1
+
+        # 2. Optimistic ON @255 — cache must track the displayed brightness.
+        e._is_on = True
+        e._optimistic_brightness = 255
+        e.async_write_ha_state()
+        assert raw_write.call_count == 2
+
+        # 3. Physical OFF — coordinator reads 0; the OFF write must land.
+        coord.get_light_brightness.return_value = 0
+        e._handle_coordinator_update()
+        assert raw_write.call_count == 3


### PR DESCRIPTION
## Summary

Fixes #469 — an output toggled from Home Assistant and then changed at the physical wall button could freeze on the HA-commanded value. The module was read correctly (e.g. `000000000000`), but the entity never updated, on the button-driven refresh *or* the 120 s poll. Most visible on serial / PC-Link installs without a feedback module (polling mode).

This branch is based on the **3.9.0** commit (per request) with the fix on top; manifest is bumped to **3.9.1**.

## Root cause

`NikobusEntity` has a write-diff cache (`_last_render`) that suppresses redundant re-renders on the poll. It was only updated inside `_handle_coordinator_update`. Optimistic writes (`async_turn_on` / `async_turn_off`) and the button-operation handler move the *displayed* state via `async_write_ha_state()` without touching the cache, so it tracked "last coordinator-rendered value" rather than "what's actually on screen". After an HA-commanded ON, the real OFF state read back from the module rendered the same value as the stale cache and was wrongly suppressed, leaving the entity stuck.

## Fix

Override `async_write_ha_state()` in `NikobusEntity` to refresh `_last_render` on every write regardless of source. This keeps the diff honest while preserving the redundant-poll optimization.

## Changes

- `custom_components/nikobus/entity.py` — override `async_write_ha_state()` to keep the diff cache in sync with every state write.
- `tests/test_state_diffing.py` — regression tests for the switch and dimmer optimistic-ON → real-OFF path (confirmed they fail without the fix, pass with it).
- `custom_components/nikobus/manifest.json` — version `3.9.0` → `3.9.1`.
- `CHANGELOG.md` — 3.9.1 entry.

## Verification

- Full test suite: 485 passed.
- `ruff check` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRnjKSqWAEBzKs4yZzHKS1)_