### PR TITLE
fix(scene): drop unnamed button-backed light-scenes (phantom scenes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 3.9.2
+
+- **Unnamed "phantom" scenes are no longer surfaced.** A button-driven
+  light-scene (fired by a real wall button or IR input, e.g. addresses such
+  as `829201` / `AA2481` / `84DFFC`) is only surfaced as a Home Assistant
+  scene once the `.nkb` import has matched and **named** it. An unnamed one
+  is just a button you already have on the bus — surfacing it as a nameless
+  scene only duplicated that button. Named scenes from your Nikobus project
+  (e.g. *Scene - TV*, *CloseHouse - Leave*) are unaffected and still appear,
+  and the bare `38xx` central functions always appear. Any phantom scene
+  entities a previous version created are cleaned up on the next
+  scan / restart. A plain module re-scan is enough to apply this.
+
 ## 3.9.1
 
 - **Fix: output state stuck after a physical button press (issue #469).**

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -1398,12 +1398,18 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
         if self.cf_storage is not None:
             cf_entries = self.cf_storage.data.get("nikobus_cf", {})
             if isinstance(cf_entries, dict):
-                from .nkbreconcile import is_pure_roller_cf
+                from .nkbreconcile import is_pure_roller_cf, is_surfaced_cf_scene
                 for cf_addr, cf in cf_entries.items():
+                    if not isinstance(cf, dict):
+                        continue
                     addr_lower = str(cf_addr).lower()
-                    if isinstance(cf, dict) and is_pure_roller_cf(cf):
+                    if is_pure_roller_cf(cf):
                         known.add(f"nikobus_cf_cover_{addr_lower}")
-                    else:
+                    elif is_surfaced_cf_scene(cf):
+                        # An unnamed button-backed light-scene is not
+                        # surfaced (see is_surfaced_cf_scene); leaving its
+                        # id out of the known set lets orphan cleanup evict
+                        # any entity a prior version created for it.
                         known.add(f"nikobus_cf_{addr_lower}")
         known.add(f"{DOMAIN}_connection_status")
         known.add(f"{DOMAIN}_discovery_status")

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -22,5 +22,5 @@
     "pyserial-asyncio-fast>=0.16",
     "nikobus-connect>=0.28.0"
   ],
-  "version": "3.9.1"
+  "version": "3.9.2"
 }

--- a/custom_components/nikobus/nkbreconcile.py
+++ b/custom_components/nikobus/nkbreconcile.py
@@ -278,6 +278,47 @@ def is_pure_roller_cf(cf: dict[str, Any]) -> bool:
     return all(_is_roller_member(o.get("mode")) for o in members)
 
 
+# CF patterns whose activation address is a real wall button / IR input,
+# as opposed to the bare ``38xx`` PC-Logic central-function broadcasts.
+# The library emits these for op-points it read out of the button store,
+# so there is always a physical control behind them.
+_BUTTON_BACKED_SCENE_PATTERNS: tuple[str, ...] = ("light_scene", "nkb_scene")
+
+
+def is_button_backed_cf(cf: dict[str, Any]) -> bool:
+    """True if this CF is a light-scene fired by a real button / IR input.
+
+    These carry a bus trigger address (a wall button or IR code); the
+    bare ``38xx`` central functions (``switch_pair`` / ``roller_pair`` /
+    ``cf_other``) do not. In Nikobus such a button is an ordinary control
+    that happens to drive several outputs — not a distinct "scene" object.
+    """
+    return str((cf or {}).get("pattern") or "") in _BUTTON_BACKED_SCENE_PATTERNS
+
+
+def is_surfaced_cf_scene(cf: dict[str, Any]) -> bool:
+    """True if a CF should be surfaced as an HA *scene* entity.
+
+    Single source of truth shared by the scene platform (what it creates)
+    and the coordinator's known-id set (what orphan cleanup keeps), so the
+    two can't drift.
+
+    A button-backed light-scene is only surfaced once it has been **named**
+    by a matching named group in the ``.nkb`` project file. An unnamed one
+    is just a button the user already has on the bus — surfacing it as a
+    scene would duplicate that button (issue: unnamed phantom scenes such
+    as ``829201`` after a plain module scan). The bare ``38xx`` central
+    functions always surface (named or not).
+
+    Pure-roller CFs are handled separately — they become grouped covers,
+    not scenes — so callers must apply :func:`is_pure_roller_cf` first.
+    """
+    if is_button_backed_cf(cf):
+        name = (cf or {}).get("name")
+        return isinstance(name, str) and bool(name.strip())
+    return True
+
+
 def cf_cover_members(cf: dict[str, Any]) -> list[dict[str, Any]]:
     """Collapse a roller CF's outputs into distinct grouped-cover members.
 

--- a/custom_components/nikobus/scene.py
+++ b/custom_components/nikobus/scene.py
@@ -21,7 +21,7 @@ from .const import (
 )
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity, command_error
-from .nkbreconcile import is_pure_roller_cf
+from .nkbreconcile import is_pure_roller_cf, is_surfaced_cf_scene
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -90,6 +90,12 @@ async def async_setup_entry(
         # A pure-roller CF becomes a grouped cover (cover platform), not a
         # scene/broadcast — skip it here.
         if is_pure_roller_cf(cf):
+            continue
+        # A button-backed light-scene (fired by a real wall button / IR)
+        # is only a scene once the .nkb import has named it; an unnamed one
+        # is just a button the user already has and is not surfaced as a
+        # (phantom, unnamed) scene. The bare 38xx CFs always surface.
+        if not is_surfaced_cf_scene(cf):
             continue
         entities.append(
             NikobusCFSceneEntity(

--- a/tests/test_known_entity_cf_scenes.py
+++ b/tests/test_known_entity_cf_scenes.py
@@ -24,8 +24,13 @@ def _coord_with_cfs(cf_addrs):
     coord.dict_button_data = {}
     coord.dict_scene_data = {}
     coord.cf_storage = MagicMock()
+    # Named light-scenes (matched to a .nkb group) are surfaced scenes; an
+    # unnamed button-backed light-scene is not (see the dedicated test).
     coord.cf_storage.data = {
-        "nikobus_cf": {addr: {"pattern": "light_scene", "outputs": []} for addr in cf_addrs}
+        "nikobus_cf": {
+            addr: {"pattern": "light_scene", "outputs": [], "name": f"Scene {addr}"}
+            for addr in cf_addrs
+        }
     }
     return coord
 
@@ -39,6 +44,21 @@ class TestKnownEntityIdsIncludeCFScenes(unittest.TestCase):
         # Must match scene.py: f"nikobus_cf_{addr.lower()}"
         self.assertIn("nikobus_cf_0d1c9e", known)
         self.assertIn("nikobus_cf_0ffec8", known)
+
+    def test_unnamed_button_backed_light_scene_is_not_known(self):
+        """A button-backed light-scene with no .nkb name is not surfaced as
+        a scene (it duplicates a button the user already has), so its id must
+        be absent from the known set — that lets orphan cleanup evict any
+        phantom scene entity a prior version created (e.g. ``829201``)."""
+        coord = _coord_with_cfs([])
+        coord.cf_storage.data = {"nikobus_cf": {
+            "829201": {"pattern": "light_scene", "outputs": [
+                {"module_address": "9105", "channel": 3, "mode": "M04 (Light scene on)"},
+            ]},
+        }}
+        known = coord.get_known_entity_unique_ids()
+        self.assertNotIn("nikobus_cf_829201", known)
+        self.assertNotIn("nikobus_cf_cover_829201", known)
 
     def test_nkb_sourced_scene_unique_ids_are_known(self):
         """.nkb-sourced (source='nkb') scenes live in cf_storage too, so the
@@ -84,11 +104,13 @@ class TestKnownEntityIdsIncludeCFScenes(unittest.TestCase):
         self.assertNotIn("nikobus_cf_3880c8", known)
 
     def test_mixed_cf_stays_a_broadcast_scene_id(self):
-        """A mixed (switch + roller) CF is not pure-roller, so it stays a
-        broadcast CF scene — register the plain scene id, not a cover id."""
+        """A mixed (switch + roller) 38xx CF is not pure-roller, so it stays a
+        broadcast CF scene — register the plain scene id, not a cover id. As a
+        bare 38xx central function (not button-backed) it surfaces even
+        without a .nkb name."""
         coord = _coord_with_cfs([])
         coord.cf_storage.data = {"nikobus_cf": {
-            "3880C9": {"pattern": "nkb_scene", "outputs": [
+            "3880C9": {"pattern": "cf_other", "outputs": [
                 {"module_address": "C1C7", "channel": 1, "mode": "M03 (Off + Operating time)"},
                 {"module_address": "8CF5", "channel": 2, "mode": "M03 (Close)"},
             ]},

--- a/tests/test_nkbreconcile.py
+++ b/tests/test_nkbreconcile.py
@@ -14,7 +14,9 @@ from custom_components.nikobus.nkbreconcile import (
     collect_button_outputs,
     flatten_cf_broadcasts,
     has_pc_logic_module,
+    is_button_backed_cf,
     is_pure_roller_cf,
+    is_surfaced_cf_scene,
     member_set_from_outputs,
 )
 
@@ -363,3 +365,56 @@ def test_cf_cover_members_preserves_order_and_drops_malformed():
 def test_cf_cover_members_empty():
     assert cf_cover_members({}) == []
     assert cf_cover_members({"outputs": None}) == []
+
+
+# ---------------------------------------------------------------------------
+# is_button_backed_cf / is_surfaced_cf_scene — which CFs become scenes.
+#
+# A button-backed light-scene (fired by a real wall button / IR input) is
+# only surfaced as a scene once the .nkb import has named it; unnamed ones
+# are ordinary buttons and must not appear as phantom scenes. The bare 38xx
+# central functions always surface.
+# ---------------------------------------------------------------------------
+
+
+def _lscene(name=None, pattern="light_scene"):
+    cf = {"pattern": pattern,
+          "outputs": [{"module_address": "9105", "channel": 3,
+                       "mode": "M04 (Light scene on)"}]}
+    if name is not None:
+        cf["name"] = name
+    return cf
+
+
+def test_is_button_backed_cf():
+    assert is_button_backed_cf(_lscene()) is True
+    assert is_button_backed_cf(_lscene(pattern="nkb_scene")) is True
+    assert is_button_backed_cf({"pattern": "switch_pair"}) is False
+    assert is_button_backed_cf({"pattern": "roller_pair"}) is False
+    assert is_button_backed_cf({"pattern": "cf_other"}) is False
+    assert is_button_backed_cf({}) is False
+
+
+def test_unnamed_button_backed_light_scene_is_not_surfaced():
+    assert is_surfaced_cf_scene(_lscene()) is False
+    assert is_surfaced_cf_scene(_lscene(name="")) is False
+    assert is_surfaced_cf_scene(_lscene(name="   ")) is False
+    assert is_surfaced_cf_scene(_lscene(pattern="nkb_scene")) is False
+
+
+def test_named_button_backed_light_scene_is_surfaced():
+    assert is_surfaced_cf_scene(_lscene(name="Scene - TV")) is True
+    assert is_surfaced_cf_scene(_lscene(name="ShuttersUp", pattern="nkb_scene")) is True
+
+
+def test_bare_38xx_cf_always_surfaces():
+    # switch_pair / roller_pair / cf_other are genuine central functions
+    # (no button behind them) — surfaced whether named or not.
+    for pat in ("switch_pair", "roller_pair", "cf_other", "unknown"):
+        cf = {"pattern": pat, "outputs": [
+            {"module_address": "8110", "channel": 1, "mode": "M02 (on)"}]}
+        assert is_surfaced_cf_scene(cf) is True, pat
+        cf["name"] = "Named"
+        assert is_surfaced_cf_scene(cf) is True, pat
+    # missing pattern is treated as not-button-backed → surfaced
+    assert is_surfaced_cf_scene({"outputs": []}) is True

--- a/tests/test_platform_setup.py
+++ b/tests/test_platform_setup.py
@@ -136,7 +136,7 @@ class TestOutputPlatformSetup(unittest.TestCase):
                 },
                 # mixed (switch + roller) → NOT a CF cover
                 "3880C9": {
-                    "pattern": "nkb_scene",
+                    "pattern": "cf_other",
                     "outputs": [
                         {"module_address": "C1C7", "channel": 1, "mode": "M03 (Off + Operating time)"},
                         {"module_address": "8CF5", "channel": 2, "mode": "M03 (Close)"},
@@ -209,12 +209,30 @@ class TestScenePlatformSetup(unittest.TestCase):
                         {"module_address": "C7C1", "channel": 1, "mode": "M01 (Open - stop - close)"},
                     ],
                 },
-                # Mixed (switch + roller) CF stays a broadcast CF scene.
+                # Mixed (switch + roller) 38xx CF stays a broadcast CF scene
+                # (bare central function — surfaces even without a .nkb name).
                 "3880C9": {
-                    "pattern": "nkb_scene",
+                    "pattern": "cf_other",
                     "outputs": [
                         {"module_address": "C1C7", "channel": 1, "mode": "M03 (Off + Operating time)"},
                         {"module_address": "8CF5", "channel": 2, "mode": "M03 (Close)"},
+                    ],
+                },
+                # A button-backed light-scene with no .nkb name is NOT
+                # surfaced — it duplicates a button the user already has.
+                "829201": {
+                    "pattern": "light_scene",
+                    "outputs": [
+                        {"module_address": "9105", "channel": 3, "mode": "M04 (Light scene on)"},
+                    ],
+                },
+                # ...but a NAMED button-backed light-scene (matched to a .nkb
+                # group, e.g. "Scene - TV") IS surfaced.
+                "9E4E2C": {
+                    "pattern": "light_scene",
+                    "name": "Scene - TV",
+                    "outputs": [
+                        {"module_address": "9105", "channel": 4, "mode": "M04 (Light scene on)"},
                     ],
                 },
                 "garbage": "not-a-dict",  # ignored
@@ -235,6 +253,11 @@ class TestScenePlatformSetup(unittest.TestCase):
             e for e in added if isinstance(e, scene_platform.NikobusCFSceneEntity)
         ]
         self.assertEqual(len(user_scenes), 1)
-        # switch_pair + mixed CF stay broadcast CF scenes; the two pure-roller
-        # CFs (incl. the M01 toggle) are skipped (they become covers).
-        self.assertEqual(sorted(e._bus_address for e in cf_scenes), ["3841AA", "3880C9"])
+        # switch_pair + mixed 38xx CF stay broadcast CF scenes; the two
+        # pure-roller CFs (incl. the M01 toggle) are skipped (they become
+        # covers); the NAMED button-backed light-scene (9E4E2C "Scene - TV")
+        # surfaces; the UNNAMED button-backed light-scene (829201) is dropped.
+        self.assertEqual(
+            sorted(e._bus_address for e in cf_scenes),
+            ["3841AA", "3880C9", "9E4E2C"],
+        )


### PR DESCRIPTION
## What & why

Some entries in the **Scenes** list are unnamed "phantom" scenes (e.g. `829201`, `AA2481`, `84DFFC`). These come from `_classify_cf_scenes_from_command_mapping` in **nikobus-connect**, which promotes every button/IR op-point wired to an output in a *light-scene / preset* mode into a `pattern == "light_scene"` CF. By construction, **every one of those has a real wall button or IR input behind it** — so surfacing them as scenes just duplicates a button the user already has, with no name.

PR #468 already fixed the `.nkb`-*import* path (it no longer fabricates scenes from button triggers). This PR fixes the **plain module-scan** path, which is where the phantom scenes actually originate.

## The rule (as agreed)

A button-backed light-scene is surfaced as an HA scene **only once the `.nkb` import has matched and named it** (a genuine project scene like *Scene - TV* / *CloseHouse - Leave*). An **unnamed** one is just a button → not surfaced. The bare `38xx` central functions (`switch_pair` / `roller_pair` / `cf_other` — no button behind them) **always** surface, named or not.

| CF | Before | After |
|----|--------|-------|
| `829201` / `AA2481` / `84DFFC` (button, no name) | unnamed scene | **dropped** |
| `Scene - TV` / `Dinner` / `CosiDinner` (button, `.nkb`-named) | scene | scene ✓ |
| `CloseHouse - Leave` (`.nkb`-named) | scene | scene ✓ |
| `38xx` central functions | scene | scene ✓ |
| pure-roller CFs | grouped cover | grouped cover ✓ |

## Implementation

- **`nkbreconcile.is_surfaced_cf_scene()`** — single source of truth (alongside `is_pure_roller_cf`): a button-backed CF (`light_scene` / `nkb_scene`) surfaces only if it has a non-empty `name`; everything else surfaces as before.
- **`scene.py` setup** skips a CF that fails `is_surfaced_cf_scene`.
- **`coordinator.get_known_entity_unique_ids`** excludes the dropped CFs from the known-id set, so `_async_cleanup_orphan_entities` evicts any phantom scene entity a prior version created.
- The library still emits the `light_scene` records so the `.nkb` import can match/name them — **no `nikobus-connect` change needed**.

## Notes

- **A plain module re-scan (or restart) applies the fix** and cleans up existing phantom scene entities.
- Version → **3.9.2**.

## Tests

- New predicate tests in `test_nkbreconcile.py` (truth table across patterns / named / unnamed / blank).
- `test_platform_setup.py` — named light-scene surfaces, unnamed one dropped.
- `test_known_entity_cf_scenes.py` — unnamed button-backed scene id absent from the known set (so it's cleaned up); named ones present.
- Predicate validated end-to-end offline (full HA test env can't build in this sandbox — `PyRIC` wheel); `ruff` clean, `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_