### PR TITLE
fix(scene): carry .nkb names across a re-scan (scenes vanished on 3.9.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 3.9.3
+
+- **Fix: named scenes disappeared after a module re-scan (regression in
+  3.9.2).** A plain module re-scan overwrites the stored Central Functions
+  with the freshly discovered ones, which carry no name — the `.nkb` names
+  live only on the stored records. Since 3.9.2 stopped surfacing *unnamed*
+  button-driven scenes, that name wipe silently dropped every named scene on
+  the next re-scan. Re-scan now **carries the `.nkb` names over** to the
+  matching CF (by address, then by member set), so named scenes survive a
+  re-scan. Re-importing the `.nkb` also now reloads immediately, so scenes
+  reappear without a restart. **If your scenes vanished: re-import the
+  `.nkb` once to restore the names.**
+
 ## 3.9.2
 
 - **Unnamed "phantom" scenes are no longer surfaced.** A button-driven

--- a/custom_components/nikobus/discovery_mixin.py
+++ b/custom_components/nikobus/discovery_mixin.py
@@ -297,15 +297,46 @@ class NikobusDiscoveryMixin:
 
         flat = flatten_cf_broadcasts(broadcasts)
 
-        # Drop any stale ``.nkb``-sourced scenes a previous import created.
-        # Those were per-button duplicates (a named group fired by a real
-        # button surfaced as its own scene); we no longer create them, so a
-        # re-scan clears them out rather than carrying them forward.
+        # Carry ``.nkb`` names across a re-scan. Discovery never produces
+        # names — they are applied by the ``.nkb`` import afterward and
+        # persisted onto the CF record. Freshly discovered broadcasts have
+        # none, so overwriting storage with ``flat`` would wipe every name.
+        # That matters now that an *unnamed* button-backed light-scene is no
+        # longer surfaced (see ``is_surfaced_cf_scene``): losing the name
+        # would silently drop the user's named scenes on a plain re-scan.
+        # Re-apply each prior name to the matching fresh CF — by canonical
+        # address first, then by member set (stable even if the canonical
+        # trigger address shifts between scans).
+        old = self.cf_storage.data.get("nikobus_cf") or {}
+        name_by_addr: dict[str, str] = {}
+        name_by_members: dict[frozenset[tuple[str, int, str]], str] = {}
+        for prev_addr, prev in old.items():
+            if not isinstance(prev, dict):
+                continue
+            nm = prev.get("name")
+            if isinstance(nm, str) and nm.strip():
+                name_by_addr[str(prev_addr).upper()] = nm.strip()
+                name_by_members.setdefault(cf_member_set(prev), nm.strip())
+        carried = 0
+        for addr, cf in flat.items():
+            if not isinstance(cf, dict):
+                continue
+            existing = cf.get("name")
+            if isinstance(existing, str) and existing.strip():
+                continue
+            name = name_by_addr.get(str(addr).upper()) or name_by_members.get(
+                cf_member_set(cf)
+            )
+            if name:
+                cf["name"] = name
+                carried += 1
+
         self.cf_storage.data["nikobus_cf"] = flat
         await self.cf_storage.async_save()
         _LOGGER.info(
-            "CF broadcasts persisted: %d discovered (%s)",
+            "CF broadcasts persisted: %d discovered, %d names carried over (%s)",
             len(flat),
+            carried,
             sorted(flat.keys()),
         )
 
@@ -1096,6 +1127,7 @@ class NikobusDiscoveryMixin:
         # Only runs when the "scenes" category is selected.
         cf_name_by_addr: dict[str, str] = {}
         purged_nkb_scenes = False
+        names_persisted = False
         if "scenes" in cats and self.cf_storage is not None:
             cf_store = self.cf_storage.data.get("nikobus_cf", {})
             # Migration: drop any button-duplicating scenes a previous
@@ -1114,7 +1146,6 @@ class NikobusDiscoveryMixin:
             purged_nkb_scenes = bool(stale)
 
             scene_by_members = {sc.members: sc.name for sc in data.scenes}
-            names_persisted = False
             for cf_addr, cf in cf_store.items():
                 hit = scene_by_members.get(cf_member_set(cf))
                 if hit:
@@ -1229,9 +1260,10 @@ class NikobusDiscoveryMixin:
             len(cf_name_by_addr),
         )
 
-        # Removing stale button-duplicating scenes changes the entity set —
-        # reload so the now-deleted scene entities are torn down.
-        if purged_nkb_scenes:
+        # The surfaced-scene set changed — reload so entities are rebuilt:
+        # names just applied surface previously-hidden (unnamed) button-backed
+        # light-scenes, and purging stale duplicates tears theirs down.
+        if purged_nkb_scenes or names_persisted:
             self.hass.async_create_task(
                 self.hass.config_entries.async_reload(self.config_entry.entry_id)
             )

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -22,5 +22,5 @@
     "pyserial-asyncio-fast>=0.16",
     "nikobus-connect>=0.28.0"
   ],
-  "version": "3.9.2"
+  "version": "3.9.3"
 }

--- a/tests/test_cf_ingest.py
+++ b/tests/test_cf_ingest.py
@@ -172,6 +172,58 @@ class TestIngestCFBroadcasts(unittest.TestCase):
         self.assertEqual(coord.cf_storage.data["nikobus_cf"], existing)
         coord.cf_storage.async_save.assert_not_called()
 
+    def test_nkb_name_carried_over_across_rescan_by_address(self):
+        """A plain module re-scan overwrites storage with freshly discovered
+        broadcasts, which carry no name. The ``.nkb`` name a prior import
+        applied must be re-applied to the matching fresh CF (by address),
+        else an unnamed button-backed light-scene is dropped from the
+        surfaced scene list on every re-scan (regression: 'lost all
+        scenes')."""
+        coord = _make_coord_with_cf_storage(
+            {
+                "0D1C9E": _stub_cf_broadcast(
+                    "0D1C9E", "light_scene",
+                    [_stub_cf_member("0E6C", 1, "M04 (Light scene on)")],
+                )
+            }
+        )
+        coord.cf_storage.data = {"nikobus_cf": {
+            "0D1C9E": {"bus_address": "0D1C9E", "pattern": "light_scene",
+                       "name": "Scene - TV",
+                       "outputs": [{"module_address": "0E6C", "channel": 1,
+                                    "mode": "M04 (Light scene on)"}]},
+        }}
+
+        _run(coord._ingest_cf_broadcasts())
+
+        self.assertEqual(
+            coord.cf_storage.data["nikobus_cf"]["0D1C9E"]["name"], "Scene - TV")
+
+    def test_nkb_name_carried_over_across_rescan_by_member_set(self):
+        """The canonical trigger address can shift between scans; the name is
+        still recovered by matching the ``(module, channel, mode)`` member
+        set, so a name isn't lost just because the key changed."""
+        coord = _make_coord_with_cf_storage(
+            {
+                "BBBBBB": _stub_cf_broadcast(
+                    "BBBBBB", "light_scene",
+                    [_stub_cf_member("0E6C", 1, "M04 (Light scene on)")],
+                )
+            }
+        )
+        coord.cf_storage.data = {"nikobus_cf": {
+            "AAAAAA": {"bus_address": "AAAAAA", "pattern": "light_scene",
+                       "name": "Dinner",
+                       "outputs": [{"module_address": "0E6C", "channel": 1,
+                                    "mode": "M04 (Light scene on)"}]},
+        }}
+
+        _run(coord._ingest_cf_broadcasts())
+
+        stored = coord.cf_storage.data["nikobus_cf"]
+        self.assertNotIn("AAAAAA", stored)  # old key replaced by fresh scan
+        self.assertEqual(stored["BBBBBB"]["name"], "Dinner")
+
     def test_no_discovery_object_is_safe(self):
         coord = MagicMock(spec=NikobusDataCoordinator)
         coord.nikobus_discovery = None


### PR DESCRIPTION
## Regression this fixes

After 3.9.2, a user reported **"I have lost all the scenes"** following a module re-scan. Confirmed root cause:

- A plain module re-scan runs `_ingest_cf_broadcasts`, which replaces `nikobus_cf` storage with the **freshly discovered** broadcasts.
- Discovery never produces names — the `.nkb` names are applied by the import *afterward* and live **only** on the stored records.
- So a re-scan **wipes every `.nkb` name**. Before 3.9.2 that was cosmetic (scenes showed unnamed). **3.9.2 stopped surfacing *unnamed* button-driven scenes**, so the name wipe silently **dropped every named scene** on the next re-scan. Users whose scenes are IR/button-driven (the common case) lost *all* of them.

## Fix

1. **Carry `.nkb` names across a re-scan.** `_ingest_cf_broadcasts` now re-applies each prior name to the matching fresh CF — **by canonical address first, then by member set** (stable even if the canonical trigger address shifts between scans). Named scenes survive a re-scan; genuinely-never-named button light-scenes stay hidden as intended.
2. **Reload after the `.nkb` import applies names** (previously only on stale-duplicate purge), so newly-named — hence newly-surfaced — scenes get their entities rebuilt **without a manual restart**. This makes re-importing the `.nkb` the one-click recovery for anyone already hit by the 3.9.2 wipe.

## Recovery for affected users

**Re-import the `.nkb` once** — it re-applies the names (the CF records are still in storage, just nameless) and now reloads immediately, so the scenes reappear.

## Tests

- `test_cf_ingest.py`: name carried over across a re-scan **by address** and **by member set** (canonical address changed).
- Algorithm validated end-to-end offline against the real `flatten_cf_broadcasts` + `cf_member_set` (full HA test env can't build in this sandbox — `PyRIC` wheel). `ruff` + `py_compile` clean.

Version → **3.9.3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_