### PR TITLE
feat(discovery): bootstrap inventory from a .nkb when no PC-Link/config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 3.10.0
+
+- **Bootstrap from a `.nkb` when there's no PC-Link (and no config files).**
+  Discovery now has a third inventory fallback: after (1) probing for a
+  PC-Link and (2) reading `nikobus_module_config.json` /
+  `nikobus_button_config.json`, it will (3) generate those two files from a
+  Nikobus **`.nkb`** project export dropped in your config dir. Every module
+  (address, model, channel names) and every button (address, name) is read
+  straight from the `.nkb` and written to disk **as a backup**, then loaded
+  normally. Existing config files are never overwritten. Roller run-times
+  default to `40` (the `.nkb` doesn't store the per-shutter value) and
+  button→output links still come from **"Scan all modules"**. Requires
+  `nikobus-connect >= 0.29.0`.
+
 ## 3.9.3
 
 - **Fix: named scenes disappeared after a module re-scan (regression in

--- a/custom_components/nikobus/discovery_mixin.py
+++ b/custom_components/nikobus/discovery_mixin.py
@@ -853,9 +853,9 @@ class NikobusDiscoveryMixin:
                 self._update_discovery_state(
                     phase=DISCOVERY_PHASE_ERROR,
                     message=(
-                        "No PC-Link detected and no manual config files "
-                        "found. Install a PC-Link or create "
-                        "nikobus_module_config.json in your config dir."
+                        "No PC-Link detected and no inventory source found. "
+                        "Install a PC-Link, drop your Nikobus .nkb export in "
+                        "the config dir, or create nikobus_module_config.json."
                     ),
                     error="no_inventory_source",
                 )

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -20,7 +20,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.28.0"
+    "nikobus-connect>=0.29.0"
   ],
-  "version": "3.9.3"
+  "version": "3.10.0"
 }

--- a/custom_components/nikobus/nkbmanual.py
+++ b/custom_components/nikobus/nkbmanual.py
@@ -43,6 +43,65 @@ from .nkbstorage import NikobusModuleStorage
 _LOGGER = logging.getLogger(__name__)
 
 
+async def _generate_manual_files_from_nkb(hass: HomeAssistant) -> bool:
+    """Create the manual config files from a ``.nkb`` when none exist yet.
+
+    Third inventory fallback (after "probe PC-Link" and "read manual files"):
+    an install with no PC-Link and no hand-written config files can still be
+    bootstrapped from its Nikobus PC-software project export. We write the
+    generated files to ``/config`` as a durable backup and let the normal
+    manual-config loader pick them up.
+
+    Never overwrites existing files — if either config file is already
+    present, the user's own copy wins and we do nothing. Returns ``True``
+    only when files were freshly generated.
+    """
+    from nikobus_connect.nkb import build_config_from_nkb, find_nkb_file
+
+    module_path = hass.config.path(MANUAL_MODULE_CONFIG_FILENAME)
+    button_path = hass.config.path(MANUAL_BUTTON_CONFIG_FILENAME)
+    if await hass.async_add_executor_job(os.path.exists, module_path) or (
+        await hass.async_add_executor_job(os.path.exists, button_path)
+    ):
+        return False
+
+    nkb = await hass.async_add_executor_job(
+        find_nkb_file, hass.config.path("")
+    )
+    if nkb is None:
+        return False
+
+    try:
+        config = await hass.async_add_executor_job(build_config_from_nkb, str(nkb))
+    except Exception:  # noqa: BLE001
+        _LOGGER.exception(
+            "Could not build config from %s — leaving it for a PC-Link scan",
+            nkb.name,
+        )
+        return False
+
+    async def _write(path: str, payload: dict[str, Any]) -> None:
+        async with aio_open(path, mode="w") as fh:
+            await fh.write(json.dumps(payload, indent=2, ensure_ascii=False))
+
+    await _write(module_path, config.module_config)
+    await _write(button_path, config.button_config)
+
+    module_count = sum(len(v) for v in config.module_config.values())
+    button_count = len(config.button_config.get("nikobus_button", []))
+    _LOGGER.info(
+        "No PC-Link and no manual config files — generated %s (%d modules) and "
+        "%s (%d buttons) from %s. Edit these to adjust names / roller times; "
+        "run 'Scan all modules' to fill in the button→output links.",
+        MANUAL_MODULE_CONFIG_FILENAME,
+        module_count,
+        MANUAL_BUTTON_CONFIG_FILENAME,
+        button_count,
+        nkb.name,
+    )
+    return True
+
+
 async def legacy_config_files_present(hass: HomeAssistant) -> list[str]:
     """Return which legacy manual-config filenames exist in the config dir.
 
@@ -670,7 +729,18 @@ async def async_apply_manual_config(
     parseable (so the coordinator should persist the result). Errors
     on either file are logged and swallowed so the integration still
     comes up.
+
+    When neither config file exists, a ``.nkb`` project export in the
+    config dir is used to generate them first (no-PC-Link bootstrap) —
+    the files are written to disk as a backup, then loaded normally.
     """
+    try:
+        await _generate_manual_files_from_nkb(hass)
+    except asyncio.CancelledError:
+        raise
+    except Exception:  # noqa: BLE001
+        _LOGGER.exception("Manual config: .nkb bootstrap failed")
+
     try:
         modules_loaded, module_path = await _apply_module_config(hass, module_store)
     except asyncio.CancelledError:

--- a/tests/test_manual_config.py
+++ b/tests/test_manual_config.py
@@ -1294,5 +1294,114 @@ class TestLegacyConfigFilesPresent(unittest.TestCase):
         )
 
 
+class TestNkbBootstrap(unittest.TestCase):
+    """Third fallback: with no PC-Link and no manual files, generate them
+    from a ``.nkb`` in the config dir and write them as a backup."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.config_dir = self._tmp.name
+        self.hass = _FakeHass(self.config_dir)
+
+        # Inject a fake ``nikobus_connect.nkb`` exposing the two functions
+        # ``_generate_manual_files_from_nkb`` imports (the real library isn't
+        # a test dependency here).
+        from types import ModuleType, SimpleNamespace
+
+        self._nkb_path = Path(self.config_dir) / "nikobus.nkb"
+
+        def _find_nkb_file(config_dir):
+            return self._nkb_path if self._nkb_path.exists() else None
+
+        def _build_config_from_nkb(_path):
+            return SimpleNamespace(
+                module_config={
+                    "switch_module": [{
+                        "description": "Switch S1", "model": "05-000-02",
+                        "address": "C966",
+                        "channels": [{"description": "Hal"}],
+                    }],
+                    "dimmer_module": [],
+                    "roller_module": [],
+                },
+                button_config={"nikobus_button": [
+                    {"address": "1CB502", "description": "4BP - Kitchen"},
+                ]},
+            )
+
+        self._saved = {
+            k: sys.modules.get(k)
+            for k in ("nikobus_connect", "nikobus_connect.nkb")
+        }
+        parent = ModuleType("nikobus_connect")
+        child = ModuleType("nikobus_connect.nkb")
+        child.find_nkb_file = _find_nkb_file
+        child.build_config_from_nkb = _build_config_from_nkb
+        parent.nkb = child
+        sys.modules["nikobus_connect"] = parent
+        sys.modules["nikobus_connect.nkb"] = child
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = v
+        self._tmp.cleanup()
+
+    def _exists(self, name):
+        return os.path.exists(os.path.join(self.config_dir, name))
+
+    def test_generates_files_when_nkb_present_and_none_exist(self):
+        self._nkb_path.write_bytes(b"dummy")
+
+        created = _run(nkbmanual._generate_manual_files_from_nkb(self.hass))
+
+        self.assertTrue(created)
+        self.assertTrue(self._exists("nikobus_module_config.json"))
+        self.assertTrue(self._exists("nikobus_button_config.json"))
+        with open(os.path.join(self.config_dir, "nikobus_module_config.json")) as fh:
+            mc = json.load(fh)
+        self.assertEqual(mc["switch_module"][0]["address"], "C966")
+        with open(os.path.join(self.config_dir, "nikobus_button_config.json")) as fh:
+            bc = json.load(fh)
+        self.assertEqual(bc["nikobus_button"][0]["address"], "1CB502")
+
+    def test_no_nkb_returns_false(self):
+        # no .nkb file created
+        created = _run(nkbmanual._generate_manual_files_from_nkb(self.hass))
+        self.assertFalse(created)
+        self.assertFalse(self._exists("nikobus_module_config.json"))
+
+    def test_does_not_overwrite_existing_files(self):
+        self._nkb_path.write_bytes(b"dummy")
+        existing = os.path.join(self.config_dir, "nikobus_module_config.json")
+        with open(existing, "w") as fh:
+            json.dump({"switch_module": [{"address": "USER"}]}, fh)
+
+        created = _run(nkbmanual._generate_manual_files_from_nkb(self.hass))
+
+        self.assertFalse(created)
+        with open(existing) as fh:
+            self.assertEqual(json.load(fh)["switch_module"][0]["address"], "USER")
+        # button file not fabricated alongside the user's module file
+        self.assertFalse(self._exists("nikobus_button_config.json"))
+
+    def test_apply_manual_config_uses_nkb_bootstrap(self):
+        """End-to-end: async_apply_manual_config bootstraps from the .nkb,
+        then loads the generated files (returns True, store populated)."""
+        self._nkb_path.write_bytes(b"dummy")
+        store = _InMemoryModuleStore()
+        button_data = {"nikobus_button": {}}
+
+        changed = _run(
+            nkbmanual.async_apply_manual_config(self.hass, store, button_data)
+        )
+
+        self.assertTrue(changed)
+        self.assertTrue(self._exists("nikobus_module_config.json"))
+        self.assertIn("C966", store.data["nikobus_module"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Why

Part 2 of 2 (needs library PR fdebrus/nikobus-connect#124). Lets an install with **no PC-Link and no manual config files** bootstrap its inventory straight from its Nikobus **`.nkb`** project export — and keep the generated files as a backup.

## What

Discovery's inventory step now has a **third fallback**:

1. Probe for a PC-Link → use it.
2. Read `nikobus_module_config.json` / `nikobus_button_config.json` → use them.
3. **New:** generate those two files from a `.nkb` in the config dir, write them to disk, then load them.

`_generate_manual_files_from_nkb()` runs at the start of `async_apply_manual_config`:
- Locates the `.nkb` via the library's `find_nkb_file` (canonical `nikobus.nkb`, or the sole `*.nkb`).
- Builds both payloads with nikobus-connect's `build_config_from_nkb` — modules (address / model / channel names) and buttons (address / name) read from the `.nkb`.
- **Writes `nikobus_module_config.json` + `nikobus_button_config.json` to `/config` as a durable backup**, then the existing loader applies them.
- **Never overwrites** an existing config file — the user's own copy always wins.

Roller `operation_time` defaults to `40` (the `.nkb` stores only the option list, not the per-shutter value), and **button→output link records still come from "Scan all modules"** (matching the manual-file contract — the `.nkb` doesn't carry them). The no-inventory-source error message now points users at the `.nkb` option.

## Usage for a no-PC-Link user

1. Drop the Nikobus `.nkb` in `/config` (as `nikobus.nkb`, or the only `.nkb` there).
2. Press **"Discover modules"** → the two JSON files are generated + loaded.
3. Press **"Scan all modules"** → button→output links populate.

## Tests

`test_manual_config.py` (`TestNkbBootstrap`): generation when a `.nkb` is present and no files exist; no-`.nkb` → no-op; **does-not-overwrite** existing files; and the end-to-end `async_apply_manual_config` bootstrap-then-load path. **Full suite: 497 passed**, ruff clean.

Version → **3.10.0**; pins `nikobus-connect >= 0.29.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_