### PR TITLE
fix(nkb): correct multi-key button addresses (pull nikobus-connect 0.30.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 3.10.2
+
+- **Fix: wrong bus addresses on `.nkb`-bootstrapped multi-key buttons.** The
+  per-key addresses generated in 3.10.1 didn't match what the bus actually
+  emits on a press, so the keys appeared but automations/press-events never
+  fired. They're now derived exactly as a PC-Link inventory would
+  (`convert_nikobus_address` + key offset). Requires
+  `nikobus-connect >= 0.30.1`. Re-run **"Bestaande installatie laden"** after
+  updating to regenerate the button file with the correct addresses.
+
 ## 3.10.1
 
 - **`.nkb` bootstrap: multi-key wall plates are expanded to all their keys.**

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -20,7 +20,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.30.0"
+    "nikobus-connect>=0.30.1"
   ],
-  "version": "3.10.1"
+  "version": "3.10.2"
 }


### PR DESCRIPTION
## Bug

On `.nkb`-bootstrapped no-PC-Link installs, the multi-key buttons added in 3.10.1 had **wrong per-key bus addresses** — the keys appeared, but presses/automations never matched, because the addresses weren't what the bus emits on a press.

## Fix

The fix lives in the library (**nikobus-connect#126, `0.30.1`**): per-key addresses are now derived exactly as a PC-Link inventory does (`convert_nikobus_address` + key-face offset), verified byte-for-byte against `merge_discovered_buttons`. No integration code change — just the version pin.

- Pin **`nikobus-connect >= 0.30.1`**, version → **3.10.2**.

## After updating

Re-run **"Bestaande installatie laden"** (scan) to regenerate `nikobus_button_config.json` with the correct addresses.

**Requires nikobus-connect#126 (0.30.1) to merge + release first.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_