### PR TITLE
fix(nkb): enable hidden output channels from .nkb import; pull CRC fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 3.10.3
+
+- **Fix: spurious "Unknown device detected" warnings from corrupted discovery
+  frames.** Discovery/inventory frames (`$18`/`$2E`/`$1E`) were forwarded to
+  the device classifier without a CRC check, unlike every other frame class
+  the library handles. A bit error on the wire — cable, connector, USB-serial
+  adapter noise — could sail through and be logged as a new "unknown device
+  type" (sometimes seeding a phantom module/button), even though the bus
+  data itself was fine. Requires `nikobus-connect >= 0.30.2`.
+- **Fix: `.nkb` import can now enable output channels the bus scan left
+  hidden, not just rename ones that already have an entity.** The register
+  scan reads link records, never channel names — Nikobus modules don't store
+  per-channel text on the bus — so every output channel starts as the
+  internal `"not_in_use output_N"` placeholder, and no entity is created for
+  it. Previously the `.nkb` import could only **rename an entity that
+  already existed**, so a channel with none stayed hidden forever with no
+  way out except manually using **"Customize a module."** The import now
+  writes the `.nkb`'s real output name straight into the channel (when no
+  entity exists for it yet) and reloads, so the entity is created directly.
+  A user's own "Customize a module" changes (including explicitly disabled
+  channels) are never touched. The import button's log line now reports how
+  many outputs were newly enabled.
+
 ## 3.10.2
 
 - **Fix: wrong bus addresses on `.nkb`-bootstrapped multi-key buttons.** The

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -529,10 +529,11 @@ class NikobusImportNkbNamesButton(ButtonEntity):
         result = await self._coordinator.async_import_nkb_names()
         _LOGGER.info(
             "Nikobus .nkb import done: %s devices, %s entities, %s channels, "
-            "%s areas, %s scenes named",
+            "%s outputs enabled, %s areas, %s scenes named",
             result["devices"],
             result["entities"],
             result.get("channels", 0),
+            result.get("outputs_enabled", 0),
             result["areas"],
             result["scenes"],
         )

--- a/custom_components/nikobus/discovery_mixin.py
+++ b/custom_components/nikobus/discovery_mixin.py
@@ -1247,23 +1247,66 @@ class NikobusDiscoveryMixin:
                 if nm and _apply_entity_name(ent_reg, ent, nm, overwrite):
                     channels_named += 1
 
+        # Enable outputs the bus scan left hidden. The register scan reads
+        # link records, never per-channel text — Nikobus modules don't
+        # store channel names on the bus at all — so every channel starts
+        # as the ``"not_in_use output_N"`` placeholder router.py uses to
+        # skip entity creation. The rename loop above can only rename an
+        # entity that already exists, so a channel with no entity yet had
+        # no way to ever leave that state short of the manual "Customize a
+        # module" flow — the .nkb already carries the real name here
+        # (``data.outputs``), so use it to unlock the channel directly
+        # rather than only relabelling something already visible.
+        outputs_enabled = 0
+        module_storage_changed = False
+        if "channel_names" in cats and data.outputs and self.module_storage is not None:
+            modules = self.module_storage.data.get("nikobus_module")
+            if isinstance(modules, dict):
+                for (addr, ch), nm in data.outputs.items():
+                    if not nm:
+                        continue
+                    module = modules.get(addr)
+                    if not isinstance(module, dict):
+                        continue
+                    channels = module.get("channels")
+                    if not isinstance(channels, list) or not (1 <= ch <= len(channels)):
+                        continue
+                    channel_info = channels[ch - 1]
+                    if not isinstance(channel_info, dict):
+                        continue
+                    if channel_info.get("entity_type") == "disabled":
+                        continue  # user explicitly hid this channel — leave it
+                    if not str(channel_info.get("description", "")).startswith(
+                        "not_in_use"
+                    ):
+                        continue  # already enabled — the rename loop above covers it
+                    channel_info["description"] = nm
+                    outputs_enabled += 1
+                    module_storage_changed = True
+            if module_storage_changed:
+                await self.module_storage.async_save()
+                self._rebuild_dict_module_data()
+
         _LOGGER.info(
             "Imported .nkb from %s (overwrite=%s, categories=%s): %d devices, "
-            "%d device-entities, %d channels, %d areas, %d scenes named",
+            "%d device-entities, %d channels, %d outputs enabled, %d areas, "
+            "%d scenes named",
             path.name,
             overwrite,
             sorted(cats),
             devices_named,
             entities_named,
             channels_named,
+            outputs_enabled,
             areas_set,
             len(cf_name_by_addr),
         )
 
-        # The surfaced-scene set changed — reload so entities are rebuilt:
+        # The surfaced entity set changed — reload so platforms rebuild:
         # names just applied surface previously-hidden (unnamed) button-backed
-        # light-scenes, and purging stale duplicates tears theirs down.
-        if purged_nkb_scenes or names_persisted:
+        # light-scenes, purging stale duplicates tears theirs down, and newly
+        # enabled outputs need their entities created for the first time.
+        if purged_nkb_scenes or names_persisted or module_storage_changed:
             self.hass.async_create_task(
                 self.hass.config_entries.async_reload(self.config_entry.entry_id)
             )
@@ -1272,6 +1315,7 @@ class NikobusDiscoveryMixin:
             "devices": devices_named,
             "entities": entities_named,
             "channels": channels_named,
+            "outputs_enabled": outputs_enabled,
             "areas": areas_set,
             "scenes": len(cf_name_by_addr),
         }

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -20,7 +20,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.30.1"
+    "nikobus-connect>=0.30.2"
   ],
-  "version": "3.10.2"
+  "version": "3.10.3"
 }

--- a/tests/test_nkbnames.py
+++ b/tests/test_nkbnames.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -19,7 +19,7 @@ from custom_components.nikobus.nkbnames import NkbData, SceneDef
 # --------------------------------------------------------------------------- #
 # coordinator.async_import_nkb_names — names, areas, scene match
 # --------------------------------------------------------------------------- #
-def _coord(cf=None, button_data=None):
+def _coord(cf=None, button_data=None, modules=None):
     from custom_components.nikobus.coordinator import NikobusDataCoordinator
 
     c = NikobusDataCoordinator.__new__(NikobusDataCoordinator)
@@ -33,6 +33,7 @@ def _coord(cf=None, button_data=None):
     c.config_entry = MagicMock()
     c.config_entry.entry_id = "E1"
     c.dict_button_data = button_data or {}
+    c.dict_module_data = {}
     c.cf_storage = None
     if cf is not None:
         c.cf_storage = MagicMock()
@@ -42,6 +43,12 @@ def _coord(cf=None, button_data=None):
             return None
 
         c.cf_storage.async_save = _save
+
+    c.module_storage = None
+    if modules is not None:
+        c.module_storage = MagicMock()
+        c.module_storage.data = {"nikobus_module": modules}
+        c.module_storage.async_save = AsyncMock()
     return c
 
 
@@ -145,8 +152,8 @@ def test_import_names_areas_and_scene_match():
     with _patches(data, devices, entities, dev_reg, ent_reg, area_reg):
         result = _run(coord.async_import_nkb_names())
 
-    assert result == {"devices": 3, "entities": 2, "channels": 0, "areas": 2,
-                      "scenes": 1}
+    assert result == {"devices": 3, "entities": 2, "channels": 0,
+                      "outputs_enabled": 0, "areas": 2, "scenes": 1}
     names = {c.args[0]: c.kwargs.get("name")
              for c in dev_reg.async_update_device.call_args_list
              if "name" in c.kwargs}
@@ -377,3 +384,118 @@ def test_import_no_overwrite_keeps_user_set_channel_name():
 
     assert result["channels"] == 0
     ent_reg.async_update_entity.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# async_import_nkb_names — enabling previously-hidden output channels
+#
+# The register scan never learns channel *names* (Nikobus modules don't
+# store per-channel text on the bus), so every channel starts as the
+# "not_in_use output_N" placeholder router.py checks to skip entity
+# creation. Before this fix, the .nkb import could only rename an entity
+# that already existed — a channel with none stayed hidden forever, with
+# no way out short of the manual "Customize a module" flow. These pin the
+# fix: the import now writes the .nkb's real output name straight into
+# module storage so router.py creates the entity on the next reload.
+# --------------------------------------------------------------------------- #
+def test_import_enables_previously_hidden_output_channel():
+    data = NkbData(
+        addresses={}, scenes=[], outputs={("0E6C", 4): "Appliques Salon"},
+    )
+    modules = {"0E6C": {
+        "module_type": "switch_module",
+        "description": "Switch S1",
+        "channels": [
+            {"description": "not_in_use output_1"},
+            {"description": "not_in_use output_2"},
+            {"description": "not_in_use output_3"},
+            {"description": "not_in_use output_4"},
+        ],
+    }}
+    coord = _coord(modules=modules)
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    with _patches(data, [], [], dev_reg, ent_reg, area_reg):
+        result = _run(coord.async_import_nkb_names(categories={"channel_names"}))
+
+    assert result["outputs_enabled"] == 1
+    assert modules["0E6C"]["channels"][3]["description"] == "Appliques Salon"
+    # untouched siblings stay hidden
+    assert modules["0E6C"]["channels"][0]["description"] == "not_in_use output_1"
+    coord.module_storage.async_save.assert_awaited_once()
+    # the entity set changed -> a reload is scheduled so it's created
+    coord.hass.async_create_task.assert_called_once()
+
+
+def test_import_does_not_touch_already_enabled_channel():
+    """A channel that already has a real description (an entity already
+    exists for it) is left to the rename loop — this path only unlocks
+    channels that are still ``not_in_use``."""
+    data = NkbData(
+        addresses={}, scenes=[], outputs={("0E6C", 1): "Appliques Salon"},
+    )
+    modules = {"0E6C": {
+        "module_type": "switch_module",
+        "channels": [{"description": "Already Named"}],
+    }}
+    coord = _coord(modules=modules)
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    with _patches(data, [], [], dev_reg, ent_reg, area_reg):
+        result = _run(coord.async_import_nkb_names(categories={"channel_names"}))
+
+    assert result["outputs_enabled"] == 0
+    assert modules["0E6C"]["channels"][0]["description"] == "Already Named"
+    coord.module_storage.async_save.assert_not_awaited()
+    coord.hass.async_create_task.assert_not_called()
+
+
+def test_import_does_not_enable_explicitly_disabled_channel():
+    """A channel the user hid via "Customize a module" (entity_type =
+    'disabled') must stay hidden even though the .nkb has a name for it."""
+    data = NkbData(
+        addresses={}, scenes=[], outputs={("0E6C", 1): "Appliques Salon"},
+    )
+    modules = {"0E6C": {
+        "module_type": "switch_module",
+        "channels": [{"description": "not_in_use output_1",
+                      "entity_type": "disabled"}],
+    }}
+    coord = _coord(modules=modules)
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    with _patches(data, [], [], dev_reg, ent_reg, area_reg):
+        result = _run(coord.async_import_nkb_names(categories={"channel_names"}))
+
+    assert result["outputs_enabled"] == 0
+    assert modules["0E6C"]["channels"][0]["description"] == "not_in_use output_1"
+    coord.module_storage.async_save.assert_not_awaited()
+
+
+def test_import_enable_skipped_when_channel_names_category_excluded():
+    data = NkbData(
+        addresses={}, scenes=[], outputs={("0E6C", 1): "Appliques Salon"},
+    )
+    modules = {"0E6C": {
+        "module_type": "switch_module",
+        "channels": [{"description": "not_in_use output_1"}],
+    }}
+    coord = _coord(modules=modules)
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    with _patches(data, [], [], dev_reg, ent_reg, area_reg):
+        result = _run(coord.async_import_nkb_names(categories={"device_names"}))
+
+    assert result["outputs_enabled"] == 0
+    assert modules["0E6C"]["channels"][0]["description"] == "not_in_use output_1"
+
+
+def test_import_no_module_storage_is_safe():
+    """No module_storage configured (shouldn't happen in practice, but the
+    coordinator's cf_storage sibling is defensively None-checked the same
+    way) — the import must not crash."""
+    data = NkbData(
+        addresses={}, scenes=[], outputs={("0E6C", 1): "Appliques Salon"},
+    )
+    coord = _coord()  # module_storage stays None
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    with _patches(data, [], [], dev_reg, ent_reg, area_reg):
+        result = _run(coord.async_import_nkb_names(categories={"channel_names"}))
+
+    assert result["outputs_enabled"] == 0


### PR DESCRIPTION
## Bugs (issue #478)

Two independent problems reported: spurious "Unknown device detected" warnings, and output channels that never leave `not_in_use` even after a full discovery + `.nkb` import.

## Fix 1 — output channels stuck `not_in_use` (root cause confirmed)

Traced end to end:
- The register scan reads **link records**, never channel names — Nikobus modules don't store per-channel text on the bus at all — so every channel starts as the `"not_in_use output_N"` placeholder.
- `router.py` gates entity creation purely on that placeholder: `if channel_description.startswith("not_in_use"): continue`.
- The `.nkb` import's channel-naming step only **renamed entities that already existed** in the HA entity registry — it never wrote to `module_storage`. So a channel with no entity yet had nothing to rename, and could never leave `not_in_use` short of the manual **"Customize a module"** flow.

`async_import_nkb_names` now also writes the `.nkb`'s real output name directly into `module_storage` for any channel that's still `not_in_use` and not explicitly `disabled`, saves storage, and schedules a reload so the entity is created. Already-enabled channels and ones the user explicitly disabled are left untouched — this only unlocks channels with **no** entity yet, the exact complement of what the existing rename loop already covers.

The import result dict and the import button's log line now report `outputs_enabled` alongside the existing counts.

## Fix 2 — "Unknown device detected" false positives

Root-caused and fixed in the library: fdebrus/nikobus-connect#127. Discovery frames (`$18`/`$2E`/`$1E`) were dispatched with no CRC check, unlike every other frame class — a bit error on the wire could be misclassified as a new device type. This PR pulls the fix (`nikobus-connect >= 0.30.2`).

## Tests

- `test_import_enables_previously_hidden_output_channel` — a `not_in_use` channel with a matching `.nkb` output name gets enabled, storage saved, reload scheduled.
- `test_import_does_not_touch_already_enabled_channel` — a channel that already has a real description is left to the existing rename loop.
- `test_import_does_not_enable_explicitly_disabled_channel` — a user-disabled channel stays hidden even with a `.nkb` name available.
- `test_import_enable_skipped_when_channel_names_category_excluded` / `test_import_no_module_storage_is_safe` — category gating and defensive `module_storage is None` handling.
- Existing `test_import_names_areas_and_scene_match` updated for the new `outputs_enabled` key.
- Full suite: **504 passed**, ruff clean.

**Requires nikobus-connect#127 (0.30.2) to merge + release first.** Version → **3.10.3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_