### PR TITLE
feat(nkb): app-style plate index, room fallback, named per-key devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 3.11.0
+
+- **`.nkb` import: button plates now carry the same index as the Nikobus
+  application.** The Niko PC software labels each plate `BP7: Porte
+  buanderie`; the import now applies the index too (`7: Porte buanderie
+  (Room)` — the locale-specific `BP` prefix is dropped, the number is the
+  data), so the HA device list cross-references one-to-one with the Nikobus
+  application. Modules keep their plain names.
+- **`.nkb` import: unnamed plates fall back to their room.** A plate the
+  installer never named (empty label in the Nikobus software) previously
+  kept its generic bus-address name; it now gets its room name so the
+  device stays identifiable.
+- **`.nkb` import: per-key devices renamed from the plate.** Each key of a
+  wall plate is its own HA device, previously stuck with the generated
+  `Push button 1A #N9A43A2` label. Once the parent plate is matched to its
+  `.nkb` name, its keys become `Porte buanderie Key 1A` etc. (the raw bus
+  address stays available in the entity attributes). IR op-points,
+  PC-Logic input keys and your own renames are never touched.
+- As always, import names are **suggested defaults** — any name you set
+  yourself wins, unless you explicitly run the import in overwrite mode.
+  Requires `nikobus-connect >= 0.31.0`.
+
 ## 3.10.3
 
 - **Fix: spurious "Unknown device detected" warnings from corrupted discovery

--- a/custom_components/nikobus/discovery_mixin.py
+++ b/custom_components/nikobus/discovery_mixin.py
@@ -78,6 +78,12 @@ _LOGGER = logging.getLogger(__name__)
 _PROBE_OUTER_ATTEMPTS = 2
 _PROBE_OUTER_DELAY_S = 3.0
 
+#: The library's auto-generated per-key device name ("Push button 1A
+#: #N9A43A2"). Only names matching this are rewritten by the .nkb
+#: import's key pass — IR / PC-Logic input keys and user-set names
+#: never match and are left alone.
+_PUSH_BUTTON_NAME_RE = re.compile(r"^Push button (\S+) #N[0-9A-Fa-f]{6}$")
+
 
 def _output_entity_key(unique_id: str | None) -> tuple[str, int] | None:
     """``(MODULE_ADDR_UPPER, channel)`` for a per-channel output entity's
@@ -1111,7 +1117,11 @@ class NikobusDiscoveryMixin:
                 translation_placeholders={"error": str(err)},
             ) from err
 
-        name_map = data.addresses  # {ADDR: (name, room)}
+        name_map = data.addresses  # {ADDR: (name, room)} — name may be ""
+        # {ADDR: Component.Number} — the index the Niko software shows as
+        # "BP7" / "S1" (prefix is locale UI text, the number is the data).
+        # getattr for older library versions without the field.
+        numbers = getattr(data, "numbers", None) or {}
 
         # Scenes: match each named ``.nkb`` group to an already-discovered
         # Central Function by member set and apply its real name. We only
@@ -1166,7 +1176,29 @@ class NikobusDiscoveryMixin:
         area_reg = ar.async_get(self.hass)
         entry_id = self.config_entry.entry_id
 
-        def _lookup(device: Any) -> tuple[str, str] | None:
+        def _display_for(key: str) -> tuple[str, str, str] | None:
+            """``(display, plain, room)`` for a ``name_map`` address.
+
+            * ``display`` — the suggested device name: ``Name (Room)``,
+              prefixed with the Niko-software index (``7: …``) for
+              button plates (6-hex addresses) so the HA device list
+              stays cross-referenceable with the Nikobus application.
+            * A plate the installer left unnamed falls back to its room
+              (shown bare — no redundant ``Room (Room)``).
+            * ``plain`` — the bare name (no index, no room), used to
+              label the plate's per-key child devices.
+            """
+            name, room = name_map[key]
+            base = name or room
+            if not base:
+                return None
+            display = f"{base} ({room})" if name and room else base
+            number = numbers.get(key)
+            if number and len(key) == 6:
+                display = f"{number}: {display}"
+            return (display, base, room)
+
+        def _lookup(device: Any) -> tuple[str, str, str] | None:
             for domain, ident in device.identifiers:
                 if domain != DOMAIN:
                     continue
@@ -1180,25 +1212,27 @@ class NikobusDiscoveryMixin:
                 if key.startswith("CF_"):
                     cf_name = cf_name_by_addr.get(key[3:])
                     if cf_name:
-                        return (cf_name, "")
+                        return (cf_name, cf_name, "")
                     continue
                 if key in name_map:
-                    return name_map[key]
+                    return _display_for(key)
                 if key in cf_name_by_addr:
-                    return (cf_name_by_addr[key], "")
+                    name = cf_name_by_addr[key]
+                    return (name, name, "")
             return None
 
         do_names = "device_names" in cats
         do_areas = "areas" in cats
         matched: dict[str, str] = {}  # device_id -> display name
+        matched_plain: dict[str, str] = {}  # device_id -> bare name (keys pass)
         devices_named = areas_set = 0
         for device in dr.async_entries_for_config_entry(dev_reg, entry_id):
             hit = _lookup(device)
             if hit is None:
                 continue
-            name, room = hit
-            display = f"{name} ({room})" if room else name
+            display, plain, room = hit
             matched[device.id] = display
+            matched_plain[device.id] = plain
             if do_names:
                 # Non-overwrite sets the integration default (``name``), so a
                 # manual rename (``name_by_user``) still wins; overwrite sets
@@ -1217,6 +1251,35 @@ class NikobusDiscoveryMixin:
                 if device.area_id != area.id:
                     dev_reg.async_update_device(device.id, area_id=area.id)
                     areas_set += 1
+
+        # Per-key child devices. Each op-point of a wall plate is its own
+        # HA device (identifier = the key's bus address) named by the
+        # library's generated "Push button 1A #N9A43A2" pattern — the raw
+        # bus address is essential for identification while the plate is
+        # anonymous, but reads as noise once the parent plate carries its
+        # real .nkb name. Rename those to "<plate> Key <label>" (the
+        # address stays available in the entity attributes for debugging).
+        # The pattern gate means IR op-points, PC-Logic input keys and any
+        # user-set names never match and are left untouched.
+        keys_named = 0
+        if do_names:
+            for device in dr.async_entries_for_config_entry(dev_reg, entry_id):
+                plate = matched_plain.get(device.via_device_id)
+                if not plate or device.id in matched:
+                    continue
+                m = _PUSH_BUTTON_NAME_RE.match(device.name or "")
+                if m is None:
+                    continue
+                key_name = f"{plate} Key {m.group(1)}"
+                if overwrite:
+                    if device.name_by_user != key_name:
+                        dev_reg.async_update_device(
+                            device.id, name_by_user=key_name
+                        )
+                        keys_named += 1
+                elif device.name != key_name:
+                    dev_reg.async_update_device(device.id, name=key_name)
+                    keys_named += 1
 
         entities = list(er.async_entries_for_config_entry(ent_reg, entry_id))
 
@@ -1289,12 +1352,13 @@ class NikobusDiscoveryMixin:
 
         _LOGGER.info(
             "Imported .nkb from %s (overwrite=%s, categories=%s): %d devices, "
-            "%d device-entities, %d channels, %d outputs enabled, %d areas, "
-            "%d scenes named",
+            "%d key devices, %d device-entities, %d channels, %d outputs "
+            "enabled, %d areas, %d scenes named",
             path.name,
             overwrite,
             sorted(cats),
             devices_named,
+            keys_named,
             entities_named,
             channels_named,
             outputs_enabled,
@@ -1313,6 +1377,7 @@ class NikobusDiscoveryMixin:
 
         return {
             "devices": devices_named,
+            "keys": keys_named,
             "entities": entities_named,
             "channels": channels_named,
             "outputs_enabled": outputs_enabled,

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -20,7 +20,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.30.2"
+    "nikobus-connect>=0.31.0"
   ],
-  "version": "3.10.3"
+  "version": "3.11.0"
 }

--- a/tests/test_nkbnames.py
+++ b/tests/test_nkbnames.py
@@ -69,12 +69,13 @@ def _opbtn(bus_address, *outputs):
     }
 
 
-def _device(dev_id, addr, name="old", area_id=None):
+def _device(dev_id, addr, name="old", area_id=None, via_device_id=None):
     d = MagicMock()
     d.id = dev_id
     d.identifiers = {("nikobus", addr)}
     d.name = name
     d.area_id = area_id
+    d.via_device_id = via_device_id
     return d
 
 
@@ -152,7 +153,7 @@ def test_import_names_areas_and_scene_match():
     with _patches(data, devices, entities, dev_reg, ent_reg, area_reg):
         result = _run(coord.async_import_nkb_names())
 
-    assert result == {"devices": 3, "entities": 2, "channels": 0,
+    assert result == {"devices": 3, "keys": 0, "entities": 2, "channels": 0,
                       "outputs_enabled": 0, "areas": 2, "scenes": 1}
     names = {c.args[0]: c.kwargs.get("name")
              for c in dev_reg.async_update_device.call_args_list
@@ -499,3 +500,140 @@ def test_import_no_module_storage_is_safe():
         result = _run(coord.async_import_nkb_names(categories={"channel_names"}))
 
     assert result["outputs_enabled"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# async_import_nkb_names — Niko-app index prefix, room fallback, key devices
+#
+# Feature request from a user who reverse-engineered their .nkb: the plate
+# label shown in the Nikobus PC software is "BP<Number>: <StrUserName>", so
+# import the index (locale-neutral, no BP prefix), fall back to the room for
+# installer-unnamed plates, and give per-key child devices a "<plate> Key
+# <label>" name instead of the generated "Push button 1A #N<addr>".
+# --------------------------------------------------------------------------- #
+def test_import_button_plate_gets_number_prefix():
+    data = NkbData(
+        addresses={"39D7F6": ("Porte buanderie", "Buanderie")},
+        scenes=[],
+        numbers={"39D7F6": 7},
+    )
+    coord = _coord()
+    dev = _device("d1", "39D7F6")
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    with _patches(data, [dev], [], dev_reg, ent_reg, area_reg):
+        _run(coord.async_import_nkb_names(categories={"device_names"}))
+
+    dev_reg.async_update_device.assert_called_once_with(
+        "d1", name="7: Porte buanderie (Buanderie)"
+    )
+
+
+def test_import_module_does_not_get_number_prefix():
+    """Modules (4-hex addresses) keep their plain name — the app-style
+    index is only applied to button plates (6-hex)."""
+    data = NkbData(
+        addresses={"0E6C": ("Dimcontroller", "Centrale")},
+        scenes=[],
+        numbers={"0E6C": 1},
+    )
+    coord = _coord()
+    dev = _device("d1", "0E6C")
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    with _patches(data, [dev], [], dev_reg, ent_reg, area_reg):
+        _run(coord.async_import_nkb_names(categories={"device_names"}))
+
+    dev_reg.async_update_device.assert_called_once_with(
+        "d1", name="Dimcontroller (Centrale)"
+    )
+
+
+def test_import_unnamed_plate_falls_back_to_room():
+    """An installer-unnamed plate (name "" in the .nkb) is labelled with
+    its room — shown bare, not the redundant 'Room (Room)'."""
+    data = NkbData(
+        addresses={"3C1A57": ("", "Chambre 2")},
+        scenes=[],
+        numbers={"3C1A57": 9},
+    )
+    coord = _coord()
+    dev = _device("d1", "3C1A57")
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    with _patches(data, [dev], [], dev_reg, ent_reg, area_reg):
+        _run(coord.async_import_nkb_names(categories={"device_names"}))
+
+    dev_reg.async_update_device.assert_any_call("d1", name="9: Chambre 2")
+
+
+def test_import_renames_key_child_devices():
+    """A per-key child device with the generated 'Push button 1A #N…'
+    name is renamed '<plate> Key 1A' once its parent plate is matched.
+    A child whose name doesn't match the generated pattern (IR /
+    PC-Logic input keys, user-meaningful names) is left alone."""
+    data = NkbData(
+        addresses={"39D7F6": ("Porte buanderie", "")},
+        scenes=[],
+    )
+    coord = _coord()
+    plate = _device("d1", "39D7F6")
+    key_a = _device("d2", "9A43A2", name="Push button 1A #N9A43A2",
+                    via_device_id="d1")
+    key_b = _device("d3", "DA43A2", name="Push button 1B #NDA43A2",
+                    via_device_id="d1")
+    ir_key = _device("d4", "30A111", name="IR 30A on 0D1C80",
+                     via_device_id="d1")
+    orphan = _device("d5", "111111", name="Push button 1A #N111111",
+                     via_device_id="other")  # parent not matched
+    devices = [plate, key_a, key_b, ir_key, orphan]
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    with _patches(data, devices, [], dev_reg, ent_reg, area_reg):
+        result = _run(coord.async_import_nkb_names(categories={"device_names"}))
+
+    assert result["keys"] == 2
+    dev_reg.async_update_device.assert_any_call(
+        "d2", name="Porte buanderie Key 1A"
+    )
+    dev_reg.async_update_device.assert_any_call(
+        "d3", name="Porte buanderie Key 1B"
+    )
+    renamed = {c.args[0] for c in dev_reg.async_update_device.call_args_list}
+    assert "d4" not in renamed  # IR key untouched
+    assert "d5" not in renamed  # unmatched parent untouched
+
+
+def test_import_key_rename_uses_plain_plate_name():
+    """The key label uses the bare plate name — no index prefix, no room
+    suffix — to keep 'Porte buanderie Key 1A' readable."""
+    data = NkbData(
+        addresses={"39D7F6": ("Porte buanderie", "Buanderie")},
+        scenes=[],
+        numbers={"39D7F6": 7},
+    )
+    coord = _coord()
+    plate = _device("d1", "39D7F6")
+    key_a = _device("d2", "9A43A2", name="Push button 2C #N9A43A2",
+                    via_device_id="d1")
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    with _patches(data, [plate, key_a], [], dev_reg, ent_reg, area_reg):
+        _run(coord.async_import_nkb_names(categories={"device_names"}))
+
+    dev_reg.async_update_device.assert_any_call(
+        "d2", name="Porte buanderie Key 2C"
+    )
+
+
+def test_import_key_rename_overwrite_sets_name_by_user():
+    data = NkbData(addresses={"39D7F6": ("Porte buanderie", "")}, scenes=[])
+    coord = _coord()
+    plate = _device("d1", "39D7F6")
+    plate.name_by_user = None
+    key_a = _device("d2", "9A43A2", name="Push button 1A #N9A43A2",
+                    via_device_id="d1")
+    key_a.name_by_user = None
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    with _patches(data, [plate, key_a], [], dev_reg, ent_reg, area_reg):
+        _run(coord.async_import_nkb_names(
+            categories={"device_names"}, overwrite=True))
+
+    dev_reg.async_update_device.assert_any_call(
+        "d2", name_by_user="Porte buanderie Key 1A"
+    )


### PR DESCRIPTION
## Why

Part 2 of 2 for the button-naming feature request on issue #478 (needs library PR fdebrus/nikobus-connect#128, `0.31.0`). Implements the reporter's suggestion after their `.nkb` reverse-engineering — including both robustness points they raised (locale-neutral index, room fallback for empty names).

## What the `.nkb` import now does

1. **Plate index, matching the Nikobus application.** Button plates (6-hex addresses) get the same index the Niko PC software shows: `BP7: Porte buanderie` → `7: Porte buanderie (Room)`. The locale-specific `BP` prefix is dropped — `Component.Number` is the data. Modules (4-hex) keep plain names.
2. **Room fallback for unnamed plates.** A plate the installer never named now gets its room name (shown bare — no redundant `Room (Room)`), instead of keeping the generic bus-address label. On the reporter's own `.nkb`, 4 real plates benefit.
3. **Per-key devices renamed from the plate.** Each key of a wall plate is its own HA device, previously stuck at the generated `Push button 1A #N9A43A2`. Once the parent plate is matched, its keys are renamed `Porte buanderie Key 1A` via the `via_device_id` link — the raw bus address stays available in the entity attributes. A strict pattern gate (`^Push button <key> #N<addr>$`) ensures IR op-points, PC-Logic input keys, and user-set names are **never** touched.

Non-overwrite semantics are unchanged throughout: the import sets the integration default name only, so any name the user set themselves always wins.

The import summary (log + result dict) now reports the key-device count.

## Tests

`test_nkbnames.py` additions:
- index prefix applied to a plate / **not** applied to a module
- unnamed plate → bare room name (with index)
- key children renamed from a matched plate; IR-named child and a child of an unmatched parent left alone; plain plate name used (no index/room in key labels)
- overwrite mode routes key renames to `name_by_user`

Full suite: **510 passed**, ruff clean.

**Requires nikobus-connect#128 (0.31.0) to merge + release first.** Version → **3.11.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_