### PR TITLE
feat(ux): child Area inheritance, diagnostic press entities, entity-class labels (3.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 3.13.0
+
+- **Key and IR child devices now inherit their plate's Area.** Every key
+  of a plate is its own HA device, and none of them ever got an Area
+  from the `.nkb` import — on a real install that left ~150 of ~215
+  Nikobus devices invisible to Area views and the auto-generated
+  dashboard. The Areas import now propagates the plate's room to all
+  its children (IR op-points included). Manually-assigned Areas are
+  preserved unless Overwrite is ticked.
+- **Press-simulation buttons and press sensors are now *diagnostic*
+  entities.** They're automation signals and tools, not day-to-day room
+  controls — the lights, covers, and switches are. On device pages they
+  move to the collapsed Diagnostic section, and auto-generated
+  dashboards stop listing ~150 of them as controls. Automations,
+  scripts, and manual dashboard cards that use them are unaffected.
+- **New import category: Labels.** The `.nkb` import can now apply
+  entity-class labels — `Nikobus Output`, `Nikobus Button`,
+  `Nikobus Scene` — for one-click filtering in HA's tables and target
+  pickers. Additive only: your own labels are never touched, and
+  removing one of ours sticks until you re-run the labels import.
+
 ## 3.12.0
 
 - **Button plates get the Nikobus application's numbering straight from

--- a/custom_components/nikobus/__init__.py
+++ b/custom_components/nikobus/__init__.py
@@ -5,21 +5,27 @@ import logging
 from typing import Any, Final
 
 import voluptuous as vol
-
-from homeassistant.config_entries import ConfigEntryState
-from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse, SupportsResponse
-from homeassistant.helpers import config_validation as cv, device_registry as dr, entity_registry as er
-from homeassistant.helpers.typing import ConfigType
-from homeassistant.exceptions import ConfigEntryNotReady, ServiceValidationError
 from homeassistant.components import (
-    switch,
-    light,
-    cover,
     binary_sensor,
     button,
+    cover,
+    light,
     scene,
     sensor,
+    switch,
 )
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import (
+    HomeAssistant,
+    ServiceCall,
+    ServiceResponse,
+    SupportsResponse,
+)
+from homeassistant.exceptions import ConfigEntryNotReady, ServiceValidationError
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.typing import ConfigType
 
 from .const import CONFIG_ENTRY_VERSION, DOMAIN, HUB_IDENTIFIER
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator

--- a/custom_components/nikobus/binary_sensor.py
+++ b/custom_components/nikobus/binary_sensor.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import Any
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.const import EntityCategory
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -51,9 +52,16 @@ class NikobusButtonBinarySensor(NikobusEntity, BinarySensorEntity):
 
     One entity per ``(physical_address, key_label)`` pair; grouped under the
     physical-button device in the registry.
+
+    Categorised DIAGNOSTIC (3.13.0), like the press-simulation buttons:
+    press pulses are automation signals, not room controls — keeping
+    them out of the Controls sections and auto-dashboards leaves the
+    real outputs as the visible surface. Automations targeting these
+    sensors are unaffected.
     """
 
     _attr_entity_registry_enabled_default = False
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
         self,

--- a/custom_components/nikobus/binary_sensor.py
+++ b/custom_components/nikobus/binary_sensor.py
@@ -16,8 +16,8 @@ from homeassistant.helpers.event import async_call_later
 from .button import op_point_display_name, register_wall_button_devices
 from .const import DOMAIN, press_signal
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
-from .router import iter_operation_points
 from .entity import NikobusEntity
+from .router import iter_operation_points
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -174,4 +174,3 @@ class NikobusButtonBinarySensor(NikobusEntity, BinarySensorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Ignore coordinator updates as this sensor is event-driven."""
-        pass

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -603,7 +603,16 @@ class NikobusButtonEntity(NikobusEntity, ButtonEntity):
 
     One entity per ``(physical_address, key_label)`` pair; grouped under the
     physical-button device in the registry.
+
+    Categorised DIAGNOSTIC (3.13.0): a press-simulation is a tool, not a
+    day-to-day control — the lights/covers/switches are. On a real
+    install these ~150 entities drowned out the ~50 actual outputs on
+    device pages and auto-generated dashboards. Diagnostic entities
+    stay fully usable (device page, automations, scripts); they're just
+    no longer auto-placed as controls.
     """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
         self,

--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -330,7 +330,7 @@ class NikobusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 await _test_connection(self.hass, conn_str)
             except ValueError:
                 errors["base"] = "cannot_connect"
-            except Exception:  # noqa: BLE001
+            except Exception:
                 _LOGGER.exception("Unexpected error during Nikobus connection test")
                 errors["base"] = "unknown"
             else:
@@ -404,7 +404,7 @@ class NikobusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
             except ValueError:
                 errors["base"] = "cannot_connect"
-            except Exception:  # noqa: BLE001
+            except Exception:
                 _LOGGER.exception("Unexpected error during Nikobus reconfigure test")
                 errors["base"] = "unknown"
             else:
@@ -575,7 +575,7 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
             with process_uploaded_file(hass, file_id) as src:
                 try:
                     parse_nkb(src)  # parses → it's a usable .nkb
-                except Exception as err:  # noqa: BLE001 — surface as flow error
+                except Exception as err:
                     raise _NkbUploadError("invalid_nkb") from err
                 shutil.copyfile(src, dest)
 
@@ -583,7 +583,7 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
             await hass.async_add_executor_job(_validate_and_save)
         except _NkbUploadError:
             raise
-        except Exception as err:  # noqa: BLE001
+        except Exception as err:
             _LOGGER.exception("Failed to save uploaded .nkb file")
             raise _NkbUploadError("upload_failed") from err
 

--- a/custom_components/nikobus/const.py
+++ b/custom_components/nikobus/const.py
@@ -136,11 +136,16 @@ DISCOVERY_WEIGHT_REGISTER_SCAN: Final[int] = 65
 DISCOVERY_WEIGHT_FINALIZING: Final[int] = 5
 
 #: The selectable ``.nkb`` import categories (all applied by default).
+#: ``labels`` isn't .nkb data — it applies the integration's own
+#: entity-class labels (Nikobus Output / Button / Scene) — but the
+#: import flow is the one "organise my install" entry point, so it
+#: lives here alongside the other organisational passes.
 NKB_IMPORT_CATEGORIES: Final[tuple[str, ...]] = (
     "device_names",
     "channel_names",
     "areas",
     "scenes",
+    "labels",
 )
 
 #: Config-entry options remembering the last-used ``.nkb`` import

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -6,7 +6,7 @@ import asyncio
 import contextlib
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, ClassVar
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -15,7 +15,6 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-
 from nikobus_connect import (
     CoordinatorProtocol,
     NikobusAPI,
@@ -24,12 +23,16 @@ from nikobus_connect import (
     NikobusEventListener,
 )
 from nikobus_connect.discovery import (
-    NikobusDiscovery,
     InventoryQueryType,
+    NikobusDiscovery,
     find_module,
     find_operation_point,
 )
-from nikobus_connect.exceptions import NikobusConnectionError, NikobusDataError, NikobusError
+from nikobus_connect.exceptions import (
+    NikobusConnectionError,
+    NikobusDataError,
+    NikobusError,
+)
 
 from .const import (
     CONF_CONNECTION_STRING,
@@ -38,7 +41,6 @@ from .const import (
     CONF_PRIOR_GEN3,
     CONF_REFRESH_INTERVAL,
     DEFAULT_PRESS_REPEAT,
-    PRESS_REPEAT_DELAY,
     DEVICE_ADDRESS_INVENTORY,
     DEVICE_INVENTORY_ANSWER,
     DISCOVERY_PHASE_ERROR,
@@ -56,6 +58,7 @@ from .const import (
     DISCOVERY_SUB_PHASE_REGISTER_SCAN,
     DOMAIN,
     ISSUE_NO_BUTTONS_CONFIGURED,
+    PRESS_REPEAT_DELAY,
     RECONNECT_DELAY_INITIAL,
     RECONNECT_DELAY_MAX,
 )
@@ -448,7 +451,7 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
             )
         except asyncio.CancelledError:
             raise
-        except Exception as err:
+        except Exception as err:  # noqa: BLE001 - defensive: callback must never kill the listener
             _LOGGER.error("Feedback callback failed: %s", err)
 
     async def _inventory_callback(self, message: str, discovery_active: bool) -> None:
@@ -539,7 +542,7 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
     # Phase-aware progress (consumes nikobus-connect 0.3.5+ on_progress)
     # ------------------------------------------------------------------
 
-    _SUB_TO_LEGACY_PHASE: dict[str, str] = {
+    _SUB_TO_LEGACY_PHASE: ClassVar[dict[str, str]] = {
         DISCOVERY_SUB_PHASE_IDLE: DISCOVERY_PHASE_IDLE,
         DISCOVERY_SUB_PHASE_INVENTORY: DISCOVERY_PHASE_PC_LINK,
         DISCOVERY_SUB_PHASE_IDENTITY: DISCOVERY_PHASE_PC_LINK,
@@ -721,7 +724,7 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
                 registers_done=registers_done,
                 registers_total=effective_register_total,
             )
-        except Exception as err:  # pragma: no cover - defensive
+        except Exception as err:  # noqa: BLE001 # pragma: no cover - defensive
             _LOGGER.debug("Discovery progress handler failed: %s", err)
 
     # ------------------------------------------------------------------
@@ -739,7 +742,7 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
         so the integration self-heals.
         """
         if self.discovery_running:
-            return None
+            return
         polled = 0
         failures = 0
         try:
@@ -750,7 +753,7 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
                     )
                     polled += polled_n
                     failures += failed_n
-            return None
+            return
         except NikobusDataError as err:
             _LOGGER.error("Failed to fetch Nikobus data: %s", err)
             raise UpdateFailed(f"Data refresh failed: {err}") from err
@@ -813,7 +816,7 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
                         failed += 1
                 except asyncio.CancelledError:
                     raise
-                except Exception as err:
+                except Exception as err:  # noqa: BLE001 - defensive: per-group failures are counted, not fatal
                     failed += 1
                     # Per-group failures are noise on installs that
                     # hit periodic bus-silent windows (issue #337) —
@@ -1488,7 +1491,7 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
 
 def _implements_coordinator_protocol(
     coordinator: NikobusDataCoordinator,
-) -> "CoordinatorProtocol":
+) -> CoordinatorProtocol:
     """mypy-time structural check: the coordinator satisfies the library's
     ``CoordinatorProtocol`` (nikobus-connect 0.27.0+). Never called at
     runtime — if a contract member is removed from this class, this

--- a/custom_components/nikobus/cover.py
+++ b/custom_components/nikobus/cover.py
@@ -213,7 +213,7 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
     @property
     def current_cover_position(self) -> int:
         """Return the current position of the cover (0-100)."""
-        return int(round(self._position))
+        return round(self._position)
 
     @property
     def is_opening(self) -> bool:
@@ -256,10 +256,11 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
     async def async_added_to_hass(self) -> None:
         """Restore state and listen for Nikobus bus events."""
         await super().async_added_to_hass()
-        if last_state := await self.async_get_last_state():
-            if (pos := last_state.attributes.get(ATTR_CURRENT_POSITION)) is not None:
-                self._position = float(pos)
-                self._calculator.set_position(self._position)
+        if (last_state := await self.async_get_last_state()) and (
+            pos := last_state.attributes.get(ATTR_CURRENT_POSITION)
+        ) is not None:
+            self._position = float(pos)
+            self._calculator.set_position(self._position)
 
         # Per-address signal keyed by this cover's module address: only
         # this module's covers are woken on a press, instead of a global
@@ -503,13 +504,11 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
                 await asyncio.sleep(0.5)
         except asyncio.CancelledError:
             pass
-        except Exception as err:
-            _LOGGER.error(
-                "Cover %s ch%d motion loop failed — forcing stop: %s",
+        except Exception:
+            _LOGGER.exception(
+                "Cover %s ch%d motion loop failed — forcing stop",
                 self._address,
                 self._channel,
-                err,
-                exc_info=True,
             )
             await self._stop(send_stop=False)
 
@@ -665,7 +664,7 @@ class NikobusCFCoverEntity(NikobusEntity, CoverEntity):
     @property
     def current_cover_position(self) -> int:
         """Return the current group position (0-100)."""
-        return int(round(self._position))
+        return round(self._position)
 
     @property
     def is_opening(self) -> bool:
@@ -842,7 +841,7 @@ class NikobusCFCoverEntity(NikobusEntity, CoverEntity):
             await self._commit_module(module_id, stop_state)
         except asyncio.CancelledError:
             raise
-        except Exception as err:
+        except Exception as err:  # noqa: BLE001 - defensive: one module's failure must not abort the CF stop
             _LOGGER.error("CF cover %s: timed stop failed for %s: %s", self._bus_address, module_id, err)
 
     async def _stop(self) -> None:

--- a/custom_components/nikobus/diagnostics.py
+++ b/custom_components/nikobus/diagnostics.py
@@ -60,7 +60,7 @@ def _per_module_decode_metrics(
         op_points = phys.get("operation_points") or {}
         if not isinstance(op_points, dict):
             continue
-        for key_label, op in op_points.items():
+        for op in op_points.values():
             if not isinstance(op, dict):
                 continue
             for link in op.get("linked_modules") or []:
@@ -92,7 +92,7 @@ def _per_module_decode_metrics(
 
     # Resolve channel counts from dict_module_data
     channel_counts: dict[str, int] = {}
-    for _bucket, modules in (coordinator.dict_module_data or {}).items():
+    for modules in (coordinator.dict_module_data or {}).values():
         if not isinstance(modules, dict):
             continue
         for addr, meta in modules.items():

--- a/custom_components/nikobus/discovery_mixin.py
+++ b/custom_components/nikobus/discovery_mixin.py
@@ -1107,9 +1107,14 @@ class NikobusDiscoveryMixin:
         * ``"channel_names"`` — the per-output **entity** names (the
           light / cover / switch the user actually toggles, e.g.
           ``Appliques Salon``, ``Terrasse``).
-        * ``"areas"`` — each device into a Home Assistant Area = its room.
+        * ``"areas"`` — each device into a Home Assistant Area = its
+          room; per-key / IR child devices inherit their plate's Area.
         * ``"scenes"`` — name already-discovered Central Function scenes
           from the ``.nkb`` (never creates a scene from a button trigger).
+        * ``"labels"`` — apply the integration's entity-class labels
+          (``Nikobus Output`` / ``Nikobus Button`` / ``Nikobus Scene``)
+          for one-click filtering. Additive only — user labels are
+          never removed.
 
         ``overwrite`` forces a name/Area even where the user has set their
         own; default off (suggested, never clobbers a manual rename).
@@ -1245,6 +1250,7 @@ class NikobusDiscoveryMixin:
         do_areas = "areas" in cats
         matched: dict[str, str] = {}  # device_id -> display name
         matched_plain: dict[str, str] = {}  # device_id -> bare name (keys pass)
+        matched_room: dict[str, str] = {}  # device_id -> room (child Areas)
         devices_named = areas_set = 0
         for device in dr.async_entries_for_config_entry(dev_reg, entry_id):
             hit = _lookup(device)
@@ -1253,6 +1259,7 @@ class NikobusDiscoveryMixin:
             display, plain, room = hit
             matched[device.id] = display
             matched_plain[device.id] = plain
+            matched_room[device.id] = room
             if do_names:
                 # Non-overwrite sets the integration default (``name``), so a
                 # manual rename (``name_by_user``) still wins; overwrite sets
@@ -1271,6 +1278,27 @@ class NikobusDiscoveryMixin:
                 if device.area_id != area.id:
                     dev_reg.async_update_device(device.id, area_id=area.id)
                     areas_set += 1
+
+        # Child devices inherit the parent plate's Area. Every key / IR
+        # op-point of a plate is its own HA device, and none of them got
+        # an Area from the pass above (their identifiers aren't in the
+        # .nkb) — on a real install that left ~150 of ~215 Nikobus
+        # devices outside the Area system entirely, invisible to Area
+        # views and the auto-generated dashboard. A key lives where its
+        # plate lives, so propagate the plate's room to all its children
+        # (name-agnostic: IR op-points and renamed keys inherit too).
+        if do_areas:
+            for device in dr.async_entries_for_config_entry(dev_reg, entry_id):
+                room = matched_room.get(device.via_device_id)
+                if not room or device.id in matched:
+                    continue
+                if overwrite or device.area_id is None:
+                    area = area_reg.async_get_area_by_name(
+                        room
+                    ) or area_reg.async_create(room)
+                    if device.area_id != area.id:
+                        dev_reg.async_update_device(device.id, area_id=area.id)
+                        areas_set += 1
 
         # Per-key child devices. Each op-point of a wall plate is its own
         # HA device (identifier = the key's bus address) named by the
@@ -1470,6 +1498,51 @@ class NikobusDiscoveryMixin:
                 await self.module_storage.async_save()
                 self._rebuild_dict_module_data()
 
+        # Labels — one-click filtering by entity class in every HA table
+        # and target picker. Purely additive: a label is only ever added
+        # (never removed), so user-applied labels are untouched and
+        # removing one of ours by hand sticks until the next labels
+        # import. Latch switches and the bridge's own entities are
+        # deliberately unlabelled — they fit none of the three classes.
+        labels_set = 0
+        if "labels" in cats:
+            from homeassistant.helpers import label_registry as lr
+
+            label_reg = lr.async_get(self.hass)
+            label_ids: dict[str, str] = {}
+
+            def _label_id(label_name: str) -> str:
+                cached = label_ids.get(label_name)
+                if cached is None:
+                    entry = label_reg.async_get_label_by_name(
+                        label_name
+                    ) or label_reg.async_create(label_name)
+                    cached = entry.label_id
+                    label_ids[label_name] = cached
+                return cached
+
+            for ent in entities:
+                domain = ent.entity_id.split(".", 1)[0]
+                uid = str(ent.unique_id or "")
+                if uid.startswith("nikobus_push_button_") or domain == "binary_sensor":
+                    label_name = "Nikobus Button"
+                elif domain == "scene":
+                    label_name = "Nikobus Scene"
+                elif domain in ("light", "cover") or (
+                    domain == "switch"
+                    and not uid.startswith("nikobus_input_switch_")
+                ):
+                    label_name = "Nikobus Output"
+                else:
+                    continue
+                label_id = _label_id(label_name)
+                current = set(ent.labels or ())
+                if label_id not in current:
+                    ent_reg.async_update_entity(
+                        ent.entity_id, labels=current | {label_id}
+                    )
+                    labels_set += 1
+
         _LOGGER.info(
             "Imported .nkb from %s (overwrite=%s, categories=%s): %d devices, "
             "%d key devices, %d device-entities, %d channels, %d outputs "
@@ -1503,5 +1576,6 @@ class NikobusDiscoveryMixin:
             "outputs_enabled": outputs_enabled,
             "areas": areas_set,
             "scenes": len(cf_name_by_addr),
+            "labels": labels_set,
         }
 

--- a/custom_components/nikobus/discovery_mixin.py
+++ b/custom_components/nikobus/discovery_mixin.py
@@ -25,7 +25,6 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-
 from nikobus_connect.discovery import InventoryQueryType
 
 from .const import (
@@ -60,7 +59,6 @@ from .nkbreconcile import (
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
-
     from nikobus_connect import NikobusCommandHandler
     from nikobus_connect.discovery import NikobusDiscovery
 
@@ -480,7 +478,7 @@ class NikobusDiscoveryMixin:
             )
 
         # --- Button bucketing ----------------------------------------
-        remaining = {str(a).upper() for a in modules.keys()}
+        remaining = {str(a).upper() for a in modules}
         bucket_counts = {
             "active": 0,
             "legacy_orphan": 0,
@@ -970,7 +968,7 @@ class NikobusDiscoveryMixin:
             changed = await async_apply_manual_config(
                 self.hass, self.module_storage, self.dict_button_data
             )
-        except Exception:  # noqa: BLE001
+        except Exception:
             _LOGGER.exception("Manual inventory import failed")
             return False
         if changed:
@@ -1038,7 +1036,7 @@ class NikobusDiscoveryMixin:
                     continue
                 if isinstance(modules, dict):
                     self._discovery_module_order.extend(
-                        str(addr).upper() for addr in modules.keys()
+                        str(addr).upper() for addr in modules
                     )
             _LOGGER.debug(
                 "Module scan (all) — buckets=%s, queue=%s",

--- a/custom_components/nikobus/exceptions.py
+++ b/custom_components/nikobus/exceptions.py
@@ -1,6 +1,6 @@
 """Nikobus exceptions — re-exported from the nikobus_connect library."""
 
-from nikobus_connect.exceptions import (  # noqa: F401
+from nikobus_connect.exceptions import (
     NikobusConnectionError,
     NikobusDataError,
     NikobusError,

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -22,5 +22,5 @@
     "pyserial-asyncio-fast>=0.16",
     "nikobus-connect>=0.33.0"
   ],
-  "version": "3.12.0"
+  "version": "3.13.0"
 }

--- a/custom_components/nikobus/nkbactuator.py
+++ b/custom_components/nikobus/nkbactuator.py
@@ -345,6 +345,11 @@ class NikobusActuator:
                 m_group: str = group,
                 m_press_id: str = press_id,
                 m_requires_long_press: bool = requires_long_press,
+                # Bound at definition time like the others — the
+                # finally-block below runs after awaits, when the
+                # enclosing loop variable may already have moved on
+                # to another module's key (ruff B023).
+                m_cache_key: str = cache_key,
             ) -> None:
                 try:
                     # STEP 1: Immediate UI Update (Skip for dimmers)
@@ -366,7 +371,7 @@ class NikobusActuator:
                                 await self._coordinator.async_event_handler("nikobus_refreshed", {"impacted_module_address": m_addr})
                         except asyncio.CancelledError:
                             raise
-                        except Exception as err:
+                        except Exception as err:  # noqa: BLE001 - defensive: keep the refresh loop alive
                             _LOGGER.debug("[%s] Immediate refresh of module %s failed: %s", m_press_id, m_addr, err)
 
                     # Read again once the outputs have settled.
@@ -388,12 +393,12 @@ class NikobusActuator:
                 except asyncio.CancelledError:
                     _LOGGER.debug("[%s] Refresh of module %s cancelled by a newer press", m_press_id, m_addr)
                     return
-                except Exception as err:
+                except Exception as err:  # noqa: BLE001 - defensive: keep the refresh loop alive
                     _LOGGER.error("[%s] Failed to refresh module %s group %s: %s", m_press_id, m_addr, m_group, err)
                 finally:
                     # Clean up the task reference when done
-                    if self._module_refresh_tasks.get(cache_key) == asyncio.current_task():
-                        self._module_refresh_tasks.pop(cache_key, None)
+                    if self._module_refresh_tasks.get(m_cache_key) == asyncio.current_task():
+                        self._module_refresh_tasks.pop(m_cache_key, None)
 
             # Schedule the newly requested refresh
             self._module_refresh_tasks[cache_key] = self._hass.async_create_task(_refresh_task())

--- a/custom_components/nikobus/nkbconfig.py
+++ b/custom_components/nikobus/nkbconfig.py
@@ -43,13 +43,13 @@ class NikobusConfig:
             return {}
 
         except json.JSONDecodeError as err:
-            _LOGGER.error("Failed to decode JSON in %s file: %s", data_type, err, exc_info=True)
+            _LOGGER.exception("Failed to decode JSON in %s file", data_type)
             raise NikobusDataError(f"Failed to decode JSON in {data_type} file: {err}") from err
 
         except asyncio.CancelledError:
             raise
         except Exception as err:
-            _LOGGER.error("Failed to load %s data: %s", data_type, err, exc_info=True)
+            _LOGGER.exception("Failed to load %s data", data_type)
             raise NikobusDataError(f"Failed to load {data_type} data: {err}") from err
 
     async def save_json_data(
@@ -69,7 +69,7 @@ class NikobusConfig:
                 await file.write(json.dumps(data, indent=4, ensure_ascii=False))
             await asyncio.to_thread(os.replace, tmp_path, file_path)
         except OSError as err:
-            _LOGGER.error("Failed to save %s data: %s", data_type, err, exc_info=True)
+            _LOGGER.exception("Failed to save %s data", data_type)
             raise NikobusDataError(f"Failed to save {data_type} data: {err}") from err
 
     def _handle_file_not_found(self, file_path: str, data_type: str) -> None:

--- a/custom_components/nikobus/nkbmanual.py
+++ b/custom_components/nikobus/nkbmanual.py
@@ -73,7 +73,7 @@ async def _generate_manual_files_from_nkb(hass: HomeAssistant) -> bool:
 
     try:
         config = await hass.async_add_executor_job(build_config_from_nkb, str(nkb))
-    except Exception:  # noqa: BLE001
+    except Exception:
         _LOGGER.exception(
             "Could not build config from %s — leaving it for a PC-Link scan",
             nkb.name,
@@ -565,9 +565,7 @@ def _is_consolidation_candidate(entry: dict[str, Any]) -> bool:
     if entry.get("channels") != 1:
         return False
     ops = entry.get("operation_points")
-    if not isinstance(ops, dict) or list(ops.keys()) != ["1A"]:
-        return False
-    return True
+    return isinstance(ops, dict) and list(ops) == ["1A"]
 
 
 def _common_description_prefix(descriptions: list[str]) -> str:
@@ -738,14 +736,14 @@ async def async_apply_manual_config(
         await _generate_manual_files_from_nkb(hass)
     except asyncio.CancelledError:
         raise
-    except Exception:  # noqa: BLE001
+    except Exception:
         _LOGGER.exception("Manual config: .nkb bootstrap failed")
 
     try:
         modules_loaded, module_path = await _apply_module_config(hass, module_store)
     except asyncio.CancelledError:
         raise
-    except Exception:  # noqa: BLE001
+    except Exception:
         _LOGGER.exception(
             "Manual config: failed to apply %s — module store left unchanged",
             MANUAL_MODULE_CONFIG_FILENAME,
@@ -759,7 +757,7 @@ async def async_apply_manual_config(
         )
     except asyncio.CancelledError:
         raise
-    except Exception:  # noqa: BLE001
+    except Exception:
         _LOGGER.exception(
             "Manual config: failed to apply %s — button store left unchanged",
             MANUAL_BUTTON_CONFIG_FILENAME,

--- a/custom_components/nikobus/nkbnames.py
+++ b/custom_components/nikobus/nkbnames.py
@@ -18,15 +18,17 @@ from nikobus_connect.nkb import (
     NkbData,
     SceneDef,
     find_nkb_file,
-    mode_code as _mode_code,
     parse_nkb,
+)
+from nikobus_connect.nkb import (
+    mode_code as _mode_code,
 )
 
 __all__ = [
     "CANONICAL_NKB_FILENAME",
     "NkbData",
     "SceneDef",
+    "_mode_code",
     "find_nkb_file",
     "parse_nkb",
-    "_mode_code",
 ]

--- a/custom_components/nikobus/repairs.py
+++ b/custom_components/nikobus/repairs.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, ClassVar
 
 import voluptuous as vol
 from homeassistant.components.repairs import RepairsFlow
@@ -147,7 +147,7 @@ class LegacyUndecodedButtonsRepairFlow(RepairsFlow):
             bits.append(description)
         return " — ".join(bits)
 
-    _REASON_LABELS = {
+    _REASON_LABELS: ClassVar[dict[str, str]] = {
         "legacy_undecoded": "no decoded links",
         "legacy_orphan": "residue / stale links",
     }

--- a/custom_components/nikobus/router.py
+++ b/custom_components/nikobus/router.py
@@ -19,7 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 def register_output_module_devices(
     hass: HomeAssistant,
     entry: ConfigEntry,
-    specs: Iterable["EntitySpec"],
+    specs: Iterable[EntitySpec],
 ) -> None:
     """Register one device per physical output module address.
 

--- a/custom_components/nikobus/scene.py
+++ b/custom_components/nikobus/scene.py
@@ -468,7 +468,7 @@ class NikobusSceneEntity(NikobusEntity, Scene):
             await self._apply_module_state(module_id, stop_state)
         except asyncio.CancelledError:
             raise
-        except Exception as err:
+        except Exception as err:  # noqa: BLE001 - defensive: timed stop is best-effort
             _LOGGER.error("Failed to send timed stop for module %s: %s", module_id, err)
 
     def _state_to_byte(self, module_type: str | None, state: Any) -> int | None:
@@ -502,4 +502,3 @@ class NikobusSceneEntity(NikobusEntity, Scene):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Stateless scene: Ignore general coordinator updates."""
-        pass

--- a/custom_components/nikobus/sensor.py
+++ b/custom_components/nikobus/sensor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, ClassVar
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -47,7 +47,7 @@ class NikobusConnectionSensor(CoordinatorEntity[NikobusDataCoordinator], SensorE
     _attr_translation_key = "connection"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_device_class = SensorDeviceClass.ENUM
-    _attr_options = [_CONNECTED, _RECONNECTING, _DISCONNECTED]
+    _attr_options: ClassVar[list[str]] = [_CONNECTED, _RECONNECTING, _DISCONNECTED]
 
     def __init__(self, coordinator: NikobusDataCoordinator) -> None:
         """Initialize the sensor."""

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -271,7 +271,8 @@
           "channel_names": "Channel names (lights, covers, switches)",
           "areas": "Areas (from rooms)",
           "scenes": "Scenes (light + shutter/master)",
-          "overwrite": "Overwrite names/Areas I've already set"
+          "overwrite": "Overwrite names/Areas I've already set",
+          "labels": "Labels (Nikobus: outputs / buttons / scenes)"
         }
       },
       "manage_scenes": {

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -140,7 +140,8 @@
           "channel_names": "Noms des canaux (lumières, volets, interrupteurs)",
           "areas": "Zones (depuis les pièces)",
           "scenes": "Scènes (lumière + volets/maître)",
-          "overwrite": "Écraser les noms/zones que j'ai déjà définis"
+          "overwrite": "Écraser les noms/zones que j'ai déjà définis",
+          "labels": "Étiquettes (Nikobus : sorties / boutons / scènes)"
         }
       },
       "manage_scenes": {

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -140,7 +140,8 @@
           "channel_names": "Kanaalnamen (lichten, rolluiken, schakelaars)",
           "areas": "Gebieden (uit kamers)",
           "scenes": "Scènes (licht + rolluik/master)",
-          "overwrite": "Namen/gebieden die ik al heb ingesteld overschrijven"
+          "overwrite": "Namen/gebieden die ik al heb ingesteld overschrijven",
+          "labels": "Labels (Nikobus: uitgangen / knoppen / scènes)"
         }
       },
       "manage_scenes": {

--- a/scripts/nkb_scene_buckets.py
+++ b/scripts/nkb_scene_buckets.py
@@ -37,7 +37,6 @@ from pathlib import Path
 
 from nikobus_connect.nkb import find_nkb_file, mode_code, parse_nkb
 
-
 # --- the two pure helpers the integration uses, copied verbatim so this
 # --- script needs only nikobus-connect, not the HA custom component ----------
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,6 +198,9 @@ _mod("homeassistant.helpers.entity_registry", async_get=lambda hass: None)
 # homeassistant.helpers.area_registry
 _mod("homeassistant.helpers.area_registry", async_get=lambda hass: None)
 
+# homeassistant.helpers.label_registry (labels import category)
+_mod("homeassistant.helpers.label_registry", async_get=lambda hass: None)
+
 # homeassistant.helpers.issue_registry — used by coordinator.refresh_repair_issues
 class _IssueSeverity:
     WARNING = "warning"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,8 @@ import importlib.machinery
 import importlib.util
 import sys
 import types
-from datetime import datetime, timezone as _tz
+from datetime import datetime
+from datetime import timezone as _tz
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -433,7 +434,7 @@ _mod(
     "serial_asyncio",
     open_serial_connection=AsyncMock(return_value=(AsyncMock(), AsyncMock())),
 )
-_mod("aiofiles", **{"open": AsyncMock()})
+_mod("aiofiles", open=AsyncMock())
 
 # ---------------------------------------------------------------------------
 # Nikobus package skeleton (bypass __init__.py which requires voluptuous/HA)

--- a/tests/test_bridge_buttons.py
+++ b/tests/test_bridge_buttons.py
@@ -109,3 +109,18 @@ def test_import_button_ignores_unknown_stored_categories():
     coord.async_import_nkb_names.assert_awaited_once_with(
         categories={"device_names"}, overwrite=False
     )
+
+
+# --------------------------------------------------------------------------- #
+# Press-simulation entities are DIAGNOSTIC (3.13.0): tools, not room
+# controls — keeps ~150 of them out of Controls sections and
+# auto-dashboards while staying fully usable in automations.
+# --------------------------------------------------------------------------- #
+def test_press_entities_are_diagnostic():
+    from custom_components.nikobus.binary_sensor import NikobusButtonBinarySensor
+    from custom_components.nikobus.button import NikobusButtonEntity
+
+    assert NikobusButtonEntity._attr_entity_category == "diagnostic"
+    assert NikobusButtonBinarySensor._attr_entity_category == "diagnostic"
+    # Press sensors additionally stay disabled by default.
+    assert NikobusButtonBinarySensor._attr_entity_registry_enabled_default is False

--- a/tests/test_button_press_repeat.py
+++ b/tests/test_button_press_repeat.py
@@ -11,8 +11,8 @@ import asyncio
 import unittest
 from unittest.mock import AsyncMock, patch
 
-from custom_components.nikobus.coordinator import NikobusDataCoordinator
 from custom_components.nikobus.const import DEFAULT_PRESS_REPEAT
+from custom_components.nikobus.coordinator import NikobusDataCoordinator
 
 
 def _coord(press_repeat=DEFAULT_PRESS_REPEAT):

--- a/tests/test_category_for_button_type.py
+++ b/tests/test_category_for_button_type.py
@@ -34,9 +34,12 @@ def _ensure_stubs() -> None:
     # also references CONFIG on its inventory-trigger button.
     for mod_name in ("homeassistant.const", "homeassistant.helpers.entity"):
         mod = sys.modules.get(mod_name)
-        if mod is not None and hasattr(mod, "EntityCategory"):
-            if not hasattr(mod.EntityCategory, "CONFIG"):
-                mod.EntityCategory.CONFIG = "config"
+        if (
+            mod is not None
+            and hasattr(mod, "EntityCategory")
+            and not hasattr(mod.EntityCategory, "CONFIG")
+        ):
+            mod.EntityCategory.CONFIG = "config"
 
 
 def _load_button_module():

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -86,12 +86,12 @@ class TestConfigFlowUser(unittest.TestCase):
         flow = _flow()
         # unique_id is the lower-cased connection string.
         flow._configured_unique_ids = {"192.168.2.50:9999"}
-        with patch(_TEST_CONN, new=AsyncMock()):
-            with self.assertRaises(AbortFlow) as ctx:
-                _run(
-                    flow.async_step_user(
-                        {CONF_CONNECTION_STRING: "192.168.2.50:9999"}
-                    )
+        with patch(_TEST_CONN, new=AsyncMock()), \
+                self.assertRaises(AbortFlow) as ctx:
+            _run(
+                flow.async_step_user(
+                    {CONF_CONNECTION_STRING: "192.168.2.50:9999"}
+                )
                 )
         self.assertEqual(ctx.exception.reason, "already_configured")
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -249,6 +249,7 @@ class TestOptionsFlow(unittest.TestCase):
                 "channel_names": False,
                 "areas": True,
                 "scenes": False,
+                "labels": False,
                 "overwrite": True,
             },
         )
@@ -262,6 +263,7 @@ class TestOptionsFlow(unittest.TestCase):
                 "channel_names": True,
                 "areas": True,
                 "scenes": True,
+                "labels": True,
                 "overwrite": False,
             },
         )

--- a/tests/test_config_flow_helpers.py
+++ b/tests/test_config_flow_helpers.py
@@ -12,14 +12,14 @@ import unittest
 import voluptuous as vol
 
 from custom_components.nikobus.config_flow import (
-    _validate_optional_hex6,
-    _module_type_order,
+    _coerce_int,
     _make_default_channel,
     _module_label,
+    _module_type_order,
+    _needs_polling,
     _set_or_drop,
     _set_time_or_drop,
-    _coerce_int,
-    _needs_polling,
+    _validate_optional_hex6,
 )
 from custom_components.nikobus.const import CONF_HAS_FEEDBACK_MODULE, CONF_PRIOR_GEN3
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -13,7 +13,6 @@ from custom_components.nikobus.const import (
 )
 from custom_components.nikobus.coordinator import NikobusDataCoordinator
 
-
 # ---------------------------------------------------------------------------
 # Minimal coordinator-like object for testing pure state methods
 # ---------------------------------------------------------------------------
@@ -1682,9 +1681,8 @@ class TestUnifiedStep1Discovery(unittest.IsolatedAsyncioTestCase):
         with patch(
             "custom_components.nikobus.nkbmanual.async_apply_manual_config",
             new_callable=AsyncMock, return_value=False,
-        ):
-            with self.assertRaises(HomeAssistantError):
-                await coord.start_pc_link_inventory(auto_reload=False)
+        ), self.assertRaises(HomeAssistantError):
+            await coord.start_pc_link_inventory(auto_reload=False)
 
 
 class TestSurfaceLegacyUndecodedButtons(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -17,14 +17,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from custom_components.nikobus.const import CATEGORY_CENTRAL_FUNCTIONS, DOMAIN
 from custom_components.nikobus.cover import (
+    STATE_CLOSING,
+    STATE_ERROR,
+    STATE_OPENING,
+    STATE_STOPPED,
     NikobusCFCoverEntity,
     NikobusCoverEntity,
     _parse_cf_time,
     _parse_operation_time,
-    STATE_STOPPED,
-    STATE_OPENING,
-    STATE_CLOSING,
-    STATE_ERROR,
 )
 from custom_components.nikobus.nkbtravelcalculator import NikobusTravelCalculator
 
@@ -602,7 +602,7 @@ class TestCFCoverConstruction(unittest.TestCase):
     def test_unparseable_time_falls_back_to_module_config(self):
         members = [{"module_address": "8CF5", "channel": 1,
                     "open_time": None, "close_time": None}]
-        ent, coord = _make_cf_cover(members=members)
+        ent, _coord = _make_cf_cover(members=members)
         # _parse_cf_time(None) → coordinator.get_cover_operation_time (30.0)
         self.assertEqual(ent._members[0]["open_time"], 30.0)
         self.assertEqual(ent._members[0]["close_time"], 30.0)

--- a/tests/test_discovery_progress_vendor_aligned.py
+++ b/tests/test_discovery_progress_vendor_aligned.py
@@ -13,7 +13,6 @@ import asyncio
 from dataclasses import dataclass
 from unittest.mock import MagicMock
 
-
 # Conftest sets up the coordinator stubs; we just need to import the
 # coordinator module after conftest has run.
 
@@ -339,13 +338,13 @@ def test_frame_counter_only_counts_during_inventory_subphase() -> None:
 
 
 class _AsyncNoop:
-    def __call__(self, *args):  # noqa: D102
+    def __call__(self, *args):
         async def _noop():
             return None
         return _noop()
 
 
-from nikobus_connect.discovery import InventoryQueryType as _IQT  # noqa: E402
+from nikobus_connect.discovery import InventoryQueryType as _IQT
 
 _PCLINK = _IQT.PC_LINK
 

--- a/tests/test_input_latch_switch.py
+++ b/tests/test_input_latch_switch.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import unittest
 from unittest.mock import MagicMock
 
-from custom_components.nikobus.switch import input_ab_addresses
 from custom_components.nikobus.coordinator import NikobusDataCoordinator
+from custom_components.nikobus.switch import input_ab_addresses
 
 
 class TestInputABAddresses(unittest.TestCase):

--- a/tests/test_input_module_naming.py
+++ b/tests/test_input_module_naming.py
@@ -30,9 +30,12 @@ def _ensure_stubs() -> None:
 
     for mod_name in ("homeassistant.const", "homeassistant.helpers.entity"):
         mod = sys.modules.get(mod_name)
-        if mod is not None and hasattr(mod, "EntityCategory"):
-            if not hasattr(mod.EntityCategory, "CONFIG"):
-                mod.EntityCategory.CONFIG = "config"
+        if (
+            mod is not None
+            and hasattr(mod, "EntityCategory")
+            and not hasattr(mod.EntityCategory, "CONFIG")
+        ):
+            mod.EntityCategory.CONFIG = "config"
 
 
 def _load_button_module():

--- a/tests/test_inventory_parsing.py
+++ b/tests/test_inventory_parsing.py
@@ -5,7 +5,11 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from nikobus_connect.discovery import DecodedCommand, InventoryResult, NikobusDiscovery
-from nikobus_connect.discovery.protocol import DecoderContext, normalize_payload, reverse_hex
+from nikobus_connect.discovery.protocol import (
+    DecoderContext,
+    normalize_payload,
+    reverse_hex,
+)
 from nikobus_connect.discovery.shutter_decoder import decode as shutter_decode
 
 

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -15,9 +15,9 @@ from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.nikobus.const import operation_signal
 from custom_components.nikobus.light import (
+    NikobusCoverLightEntity,
     NikobusDimmerEntity,
     NikobusRelayEntity,
-    NikobusCoverLightEntity,
 )
 
 

--- a/tests/test_manual_config.py
+++ b/tests/test_manual_config.py
@@ -39,7 +39,7 @@ class _AsyncFileContext:
         self._fh = None
 
     async def __aenter__(self):
-        self._fh = open(self._path, self._mode)
+        self._fh = open(self._path, self._mode)  # noqa: ASYNC230, SIM115 - aiofiles test double keeps the handle open
         return self
 
     async def __aexit__(self, exc_type, exc, tb):
@@ -1276,7 +1276,7 @@ class TestMultiKeyNkbButtons(unittest.TestCase):
     def test_builder_multikey_loads_into_op_points(self):
         try:
             from nikobus_connect.nkb import build_config
-        except Exception as exc:  # pragma: no cover - lib not on path
+        except Exception as exc:  # noqa: BLE001 # pragma: no cover - lib not on path
             self.skipTest(f"nikobus_connect not importable: {exc}")
 
         # A 4-button plate (faces A/B/C/D) + a 2-button plate (A/B).
@@ -1322,7 +1322,7 @@ class TestMultiKeyNkbButtons(unittest.TestCase):
     def test_builder_eight_button_loads_all_faces(self):
         try:
             from nikobus_connect.nkb import build_config
-        except Exception as exc:  # pragma: no cover
+        except Exception as exc:  # noqa: BLE001 # pragma: no cover
             self.skipTest(f"nikobus_connect not importable: {exc}")
 
         faces = ["1A", "1B", "1C", "1D", "2A", "2B", "2C", "2D"]

--- a/tests/test_nkb_upload.py
+++ b/tests/test_nkb_upload.py
@@ -67,9 +67,9 @@ def test_save_uploaded_nkb_invalid_rejected_and_not_saved(tmp_path):
     with patch("homeassistant.components.file_upload.process_uploaded_file",
                _uploaded(str(src))), \
          patch("custom_components.nikobus.nkbnames.parse_nkb",
-               side_effect=ValueError("not a .nkb")):
-        with pytest.raises(_NkbUploadError) as ei:
-            _run(flow._save_uploaded_nkb("file-id"))
+               side_effect=ValueError("not a .nkb")), \
+         pytest.raises(_NkbUploadError) as ei:
+        _run(flow._save_uploaded_nkb("file-id"))
 
     assert ei.value.key == "invalid_nkb"
     # the canonical file must NOT be written when validation fails

--- a/tests/test_nkbnames.py
+++ b/tests/test_nkbnames.py
@@ -88,6 +88,7 @@ def _entity(eid, device_id, name=None, original_name=None, unique_id=None):
     e.name = name
     e.original_name = original_name
     e.unique_id = unique_id
+    e.labels = []
     return e
 
 
@@ -104,12 +105,19 @@ def _patches(data, devices, entities, dev_reg, ent_reg, area_reg):
 
     @contextlib.contextmanager
     def ctx():
+        label_reg = MagicMock()
+        label_reg.async_get_label_by_name.side_effect = lambda n: None
+        label_reg.async_create.side_effect = (
+            lambda n: MagicMock(label_id=f"label_{n.lower().replace(' ', '_')}")
+        )
         with patch("custom_components.nikobus.nkbnames.find_nkb_file",
                    return_value=Path("/cfg/nikobus.nkb")), \
              patch("custom_components.nikobus.nkbnames.parse_nkb",
                    return_value=data), \
              patch("homeassistant.helpers.area_registry.async_get",
                    return_value=area_reg, create=True), \
+             patch("homeassistant.helpers.label_registry.async_get",
+                   return_value=label_reg, create=True), \
              patch("custom_components.nikobus.discovery_mixin.dr.async_get",
                    return_value=dev_reg), \
              patch("custom_components.nikobus.discovery_mixin.er.async_get",
@@ -155,8 +163,11 @@ def test_import_names_areas_and_scene_match():
     with _patches(data, devices, entities, dev_reg, ent_reg, area_reg):
         result = _run(coord.async_import_nkb_names())
 
+    # labels: light.a + light.b (Output), binary_sensor.btn (Button),
+    # scene.de4e2c (Scene) = 4 labelled entities.
     assert result == {"devices": 3, "keys": 0, "entities": 2, "channels": 0,
-                      "outputs_enabled": 0, "areas": 2, "scenes": 1}
+                      "outputs_enabled": 0, "areas": 2, "scenes": 1,
+                      "labels": 4}
     names = {c.args[0]: c.kwargs.get("name")
              for c in dev_reg.async_update_device.call_args_list
              if "name" in c.kwargs}
@@ -811,3 +822,126 @@ def test_reimport_key_heal_leaves_foreign_registry_names_alone():
         if "name" in c.kwargs
     }
     assert "d2" not in renamed
+
+
+# --------------------------------------------------------------------------- #
+# Child-device Area inheritance + entity-class labels (3.12.0)
+#
+# Live audit of a 215-device install: plates and modules got Areas from
+# the import, but all ~150 key / IR child devices had none — invisible
+# to Area views and the auto-dashboard. Children now inherit their
+# plate's Area (name-agnostic, so IR op-points and renamed keys
+# qualify). The new "labels" category applies Nikobus Output / Button /
+# Scene labels, additively.
+# --------------------------------------------------------------------------- #
+def test_children_inherit_plate_area():
+    data = NkbData(
+        addresses={"39D7F6": ("Porte buanderie", "Buanderie")},
+        scenes=[],
+    )
+    coord = _coord()
+    plate = _device("d1", "39D7F6")
+    key = _device("d2", "9A43A2", name="Push button 1A #N9A43A2",
+                  via_device_id="d1")
+    ir = _device("d3", "30A111", name="IR 30A on 39D7F6",
+                 via_device_id="d1")
+    orphan = _device("d4", "111111", name="Push button 1A #N111111",
+                     via_device_id="other")
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    area = MagicMock()
+    area.id = "area_buanderie"
+    area_reg.async_get_area_by_name.return_value = area
+    with _patches(data, [plate, key, ir, orphan], [], dev_reg, ent_reg, area_reg):
+        result = _run(coord.async_import_nkb_names(categories={"areas"}))
+
+    area_calls = {c.args[0]: c.kwargs["area_id"]
+                  for c in dev_reg.async_update_device.call_args_list
+                  if "area_id" in c.kwargs}
+    # Plate + BOTH children (key and IR — name-agnostic); orphan's
+    # parent is unmatched, so it stays untouched.
+    assert area_calls == {"d1": "area_buanderie", "d2": "area_buanderie",
+                          "d3": "area_buanderie"}
+    assert result["areas"] == 3
+
+
+def test_child_area_not_overwritten_without_overwrite():
+    data = NkbData(
+        addresses={"39D7F6": ("Porte buanderie", "Buanderie")}, scenes=[]
+    )
+    coord = _coord()
+    plate = _device("d1", "39D7F6")
+    key = _device("d2", "9A43A2", name="Push button 1A #N9A43A2",
+                  via_device_id="d1", area_id="area_custom")
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    area = MagicMock()
+    area.id = "area_buanderie"
+    area_reg.async_get_area_by_name.return_value = area
+    with _patches(data, [plate, key], [], dev_reg, ent_reg, area_reg):
+        _run(coord.async_import_nkb_names(categories={"areas"}))
+
+    moved = {c.args[0] for c in dev_reg.async_update_device.call_args_list
+             if "area_id" in c.kwargs}
+    assert "d2" not in moved  # user-chosen Area preserved
+
+    dev_reg.async_update_device.reset_mock()
+    with _patches(data, [plate, key], [], dev_reg, ent_reg, area_reg):
+        _run(coord.async_import_nkb_names(
+            categories={"areas"}, overwrite=True))
+    moved = {c.args[0] for c in dev_reg.async_update_device.call_args_list
+             if "area_id" in c.kwargs}
+    assert "d2" in moved  # overwrite forces the plate's room
+
+
+def test_labels_classify_by_entity_class():
+    data = NkbData(addresses={}, scenes=[])
+    coord = _coord()
+    ents = [
+        _entity("light.salon", "d1", unique_id="nikobus_light_dimmer_0E6C_1"),
+        _entity("cover.volet", "d1", unique_id="nikobus_cover_roller_9105_2"),
+        _entity("switch.prise", "d1", unique_id="nikobus_switch_relay_switch_C9A5_3"),
+        _entity("switch.latch", "d2", unique_id="nikobus_input_switch_64a061"),
+        _entity("button.key_1a", "d3", unique_id="nikobus_push_button_9A43A2"),
+        _entity("binary_sensor.key_1a", "d3", unique_id="nikobus_bs_9A43A2"),
+        _entity("scene.tv", "d4", unique_id="nikobus_scene_de4e2c"),
+        _entity("sensor.bridge_status", "d5", unique_id="nikobus_discovery_status"),
+        _entity("button.bridge", "d5", unique_id="nikobus_import_nkb_names_button"),
+    ]
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    with _patches(data, [], ents, dev_reg, ent_reg, area_reg):
+        result = _run(coord.async_import_nkb_names(categories={"labels"}))
+
+    labelled = {c.args[0]: c.kwargs["labels"]
+                for c in ent_reg.async_update_entity.call_args_list
+                if "labels" in c.kwargs}
+    assert labelled["light.salon"] == {"label_nikobus_output"}
+    assert labelled["cover.volet"] == {"label_nikobus_output"}
+    assert labelled["switch.prise"] == {"label_nikobus_output"}
+    assert labelled["button.key_1a"] == {"label_nikobus_button"}
+    assert labelled["binary_sensor.key_1a"] == {"label_nikobus_button"}
+    assert labelled["scene.tv"] == {"label_nikobus_scene"}
+    # Latch switches and bridge entities fit none of the classes.
+    assert "switch.latch" not in labelled
+    assert "sensor.bridge_status" not in labelled
+    assert "button.bridge" not in labelled
+    assert result["labels"] == 6
+
+
+def test_labels_are_additive_and_idempotent():
+    data = NkbData(addresses={}, scenes=[])
+    coord = _coord()
+    mine = _entity("light.salon", "d1", unique_id="nikobus_light_dimmer_0E6C_1")
+    mine.labels = ["user_label"]
+    done = _entity("cover.volet", "d1", unique_id="nikobus_cover_roller_9105_2")
+    done.labels = ["label_nikobus_output"]
+    dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
+    with _patches(data, [], [mine, done], dev_reg, ent_reg, area_reg):
+        result = _run(coord.async_import_nkb_names(categories={"labels"}))
+
+    labelled = {c.args[0]: c.kwargs["labels"]
+                for c in ent_reg.async_update_entity.call_args_list
+                if "labels" in c.kwargs}
+    # User label kept, ours added alongside.
+    assert labelled["light.salon"] == {"user_label", "label_nikobus_output"}
+    # Already labelled — untouched.
+    assert "cover.volet" not in labelled
+    assert result["labels"] == 1

--- a/tests/test_nkbnames.py
+++ b/tests/test_nkbnames.py
@@ -306,9 +306,8 @@ def test_import_raises_when_no_file():
 
     coord = _coord()
     with patch("custom_components.nikobus.nkbnames.find_nkb_file",
-               return_value=None):
-        with pytest.raises(HomeAssistantError):
-            _run(coord.async_import_nkb_names())
+               return_value=None), pytest.raises(HomeAssistantError):
+        _run(coord.async_import_nkb_names())
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_platform_setup.py
+++ b/tests/test_platform_setup.py
@@ -10,10 +10,9 @@ out (``register_output_module_devices``).
 from __future__ import annotations
 
 import asyncio
+import importlib
 import unittest
 from unittest.mock import MagicMock, patch
-
-import importlib
 
 # ``from custom_components.nikobus import light`` would resolve to the
 # *homeassistant.components.light* stub: the package __init__ imports the
@@ -78,7 +77,7 @@ def _entry_and_coord():
 
 class TestOutputPlatformSetup(unittest.TestCase):
     def _setup(self, platform):
-        hass, entry, coord = _entry_and_coord()
+        hass, entry, _coord = _entry_and_coord()
         added: list = []
         with patch.object(
             platform, "register_output_module_devices", MagicMock()
@@ -160,7 +159,7 @@ class TestOutputPlatformSetup(unittest.TestCase):
         self.assertEqual(cf_covers[0]._attr_unique_id, "nikobus_cf_cover_3880cd")
 
     def test_routing_is_cached_per_entry(self):
-        hass, entry, coord = _entry_and_coord()
+        hass, entry, _coord = _entry_and_coord()
         added: list = []
         with patch.object(
             light_platform, "register_output_module_devices", MagicMock()

--- a/tests/test_reconnect.py
+++ b/tests/test_reconnect.py
@@ -4,9 +4,8 @@ import asyncio
 import unittest
 from unittest.mock import AsyncMock, MagicMock
 
-from custom_components.nikobus.coordinator import NikobusDataCoordinator
 from custom_components.nikobus.const import RECONNECT_DELAY_INITIAL, RECONNECT_DELAY_MAX
-
+from custom_components.nikobus.coordinator import NikobusDataCoordinator
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -6,11 +6,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
 
+from custom_components.nikobus.const import DOMAIN, HUB_IDENTIFIER
 from custom_components.nikobus.sensor import (
     NikobusConnectionSensor,
     NikobusDiscoveryStatusSensor,
 )
-from custom_components.nikobus.const import DOMAIN, HUB_IDENTIFIER
 
 _ICONS_JSON = (
     Path(__file__).parent.parent

--- a/tests/test_state_diffing.py
+++ b/tests/test_state_diffing.py
@@ -55,7 +55,7 @@ def test_availability_flip_writes_even_if_state_same():
 
 
 def test_update_clears_optimistic_state_before_diffing():
-    e, coord = _switch(state=False)
+    e, _coord = _switch(state=False)
     e._is_on = True                          # stale optimistic 'on'
     e._handle_coordinator_update()           # cleared, real state is off
     assert e._is_on is None
@@ -74,7 +74,7 @@ def test_dimmer_diffs_on_brightness():
 
 
 def test_dimmer_update_clears_both_optimistic_caches():
-    e, coord = _dimmer(level=0)
+    e, _coord = _dimmer(level=0)
     e._is_on = True
     e._optimistic_brightness = 180
     e._handle_coordinator_update()

--- a/tests/test_switch_entities.py
+++ b/tests/test_switch_entities.py
@@ -13,8 +13,8 @@ from unittest.mock import AsyncMock, MagicMock
 from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.nikobus.switch import (
-    NikobusRelaySwitchEntity,
     NikobusCoverSwitchEntity,
+    NikobusRelaySwitchEntity,
 )
 
 


### PR DESCRIPTION
## Summary

v3.13.0 — the findability pass driven by a live audit of the maintainer's install (215 Nikobus devices = 43% of the whole HA registry, ~390 entities). This work was originally pushed to the #482 branch after that PR had merged; rebased onto the released 3.12.0 and re-versioned here.

### 1. Key / IR child devices inherit their plate's Area

Every op-point of a plate is its own HA device, and none of them ever got an Area from the `.nkb` import — the audit found **~150 of ~215 devices with no Area at all** (every plate organised, none of its keys), invisible to Area views and the auto-generated dashboard. The Areas import now propagates the plate's room to all its children. Name-agnostic, so IR op-points (`IR 13A on 0D1C80`) and previously-renamed keys inherit too; a manually assigned Area is preserved unless Overwrite is ticked.

### 2. Press-simulation buttons + press sensors → `EntityCategory.DIAGNOSTIC`

They're tools and automation signals, not day-to-day room controls. The ~150 press entities move to the collapsed Diagnostic section on device pages and disappear from auto-generated dashboard controls — the ~50 real outputs become the visible surface. Automations, scripts, and manual cards are unaffected (the audited install has renamed press sensors wired into automations — untouched). The category is integration-owned, so existing entities reclassify on the first restart.

### 3. New "Labels" import category

Applies entity-class labels — `Nikobus Output` / `Nikobus Button` / `Nikobus Scene` — via the label registry, for one-click filtering in HA's tables and target pickers. Checkbox in the import form (default on, en/fr/nl translated), replayed by the bridge button like the other categories. **Additive and idempotent**: user labels are never removed, already-labelled entities are skipped, and latch switches / bridge entities are deliberately unlabelled (they fit none of the classes).

## Tests

- 4 new tests in `test_nkbnames.py` (child inheritance incl. IR + orphan-parent exclusion, no-overwrite preservation, label classification, additive/idempotent labelling)
- Diagnostic-category assertions in `test_bridge_buttons.py`
- conftest gains a `label_registry` stub; options-flow default tests extended for the new checkbox
- Full suite: **534 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_