### PR TITLE
chore: nikobus-connect >= 0.34.0 — 05-206 input fix + HACS license skip (3.13.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,11 @@ jobs:
       - uses: hacs/action@main
         with:
           category: integration
-          # Not (yet) in home-assistant/brands; skip that check so a valid
-          # custom integration isn't failed for it.
-          ignore: brands
+          # brands: not (yet) in home-assistant/brands; skip that check so
+          # a valid custom integration isn't failed for it.
+          # license: the repo ships the PolyForm Noncommercial 1.0.0
+          # LICENSE, but GitHub's license detection only knows the
+          # choosealicense.com set (all of which permit commercial use)
+          # — a noncommercial license can never be "identified", so the
+          # check would stay red forever by design, not by accident.
+          ignore: brands license

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 3.13.1
+
+- **Fix: Modular Interface (05-206) inputs never updated their A/B
+  sensors and latch switch** (#485). The 05-206 computes its input bus
+  addresses with a different firmware scheme than the Logic Module
+  (05-201), but discovery applied the Logic-Module formula to both —
+  so the integration listened on addresses the hardware never emits.
+  Hardware captures from the reporter's install pinned the real 05-206
+  scheme (and re-validated the 05-201 one on a third unit). Requires
+  `nikobus-connect >= 0.34.0`. After updating, press **1. Load Project
+  Overview** once — the corrected input entries replace the stale ones
+  automatically.
+- CI: skip the HACS license check — the repository's PolyForm
+  Noncommercial license is real but not in GitHub's detection dataset
+  (which contains no noncommercial license at all), so the check can
+  never pass by design.
+
 ## 3.13.0
 
 - **Key and IR child devices now inherit their plate's Area.** Every key

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -20,7 +20,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.33.0"
+    "nikobus-connect>=0.34.0"
   ],
-  "version": "3.13.0"
+  "version": "3.13.1"
 }


### PR DESCRIPTION
## Summary

v3.13.1 — companion to fdebrus/nikobus-connect#131, fixing #485.

### The fix

The Modular Interface (05-206) computes its input bus addresses with a **different firmware scheme** than the Logic Module (05-201), but input synthesis applied the Logic-Module formula to both — the integration listened on addresses the 05-206 never emits, so its inputs' A/B sensors and latch switches never moved. Hardware captures from the reporter's install pinned the real 05-206 scheme (confirmed on two slots, one predicted in advance) and re-validated the 05-201 scheme on a third unit. It also worked before the 3.x storage migration because the reporter's pre-3.0 manual config file carried the *real* addresses captured off the wire — the store rebuild replaced them with formula-synthesized wrong ones.

Pin bumped to `nikobus-connect >= 0.34.0`. After updating, affected users press **1. Load Project Overview** once — the library purges the stale synthesized entries and creates corrected ones automatically.

### Also re-lands: HACS license-check skip

The `ci: skip the HACS license check` commit was pushed to the #483 branch minutes after that PR merged and got stranded. Re-landed here: the repository's PolyForm Noncommercial license is real, but GitHub's detection dataset contains **no noncommercial license at all**, so the "license identified" check can never pass by design — ignored deliberately, like the existing `brands` ignore. With it, CI should be fully green.

## Merge order

Merge and **release nikobus-connect 0.34.0 first** so the pin resolves, then release 3.13.1.

## Tests

Full suite: **534 passed** against the 0.34.0 library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_