### PR TITLE
fix(switch): input latch reads its A/B addresses from storage (3.13.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 3.13.2
+
+- **Fix: the A/B latch switch of Modular Interface inputs stayed frozen
+  even after 3.13.1** (#485 follow-up). 3.13.1 fixed the input
+  *addresses*, and the A/B press sensors started pulsing — but the
+  latch switch computed its own addresses instead of reading them from
+  storage, still using the old Logic-Module formula. It now uses the
+  exact same addresses the sensors listen on (and falls back to a
+  type-aware derivation only for malformed entries), so it latches on
+  the A signal and clears on the B signal as designed. Its on/off
+  commands also transmit the correct addresses now. Logic-Module
+  latches were unaffected.
+
 ## 3.13.1
 
 - **Fix: Modular Interface (05-206) inputs never updated their A/B

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -22,5 +22,5 @@
     "pyserial-asyncio-fast>=0.16",
     "nikobus-connect>=0.34.0"
   ],
-  "version": "3.13.1"
+  "version": "3.13.2"
 }

--- a/custom_components/nikobus/switch.py
+++ b/custom_components/nikobus/switch.py
@@ -43,17 +43,31 @@ def input_ab_addresses(phys: Mapping[str, Any]) -> tuple[str, str] | None:
     """Return ``(addr_1A, addr_1B)`` bus addresses for a synthesized
     PC-Logic / Modular-Interface input, or ``None``.
 
-    A PC-Logic logical input emits two bus events — its 1A and 1B
-    forms. Validated against two installs (and the library's own
-    derivation note):
+    Primary source: the entry's own stored operation points — the merge
+    layer computed those with the correct per-module-type address
+    scheme, so reading them back can never drift from what the A/B
+    binary sensors listen on. Issue #485 follow-up: this function used
+    to re-derive the physical from parent + slot WITHOUT the module
+    type, silently recomputing pc_logic-formula addresses for
+    interface_module inputs — the latch then listened (and transmitted)
+    on addresses the 05-206 never uses, while the sensors, fed from the
+    store, pulsed correctly.
 
-      * ``1A = convert_nikobus_address(physical)``
-      * ``1B`` = ``1A`` with the first hex nibble incremented by 4
-
-    The physical address is re-derived from the input's
-    ``pc_logic_parent_address`` + ``pc_logic_slot_index`` provenance so
-    this doesn't depend on the button-store key format.
+    Fallback for a malformed entry without usable op points: re-derive
+    from the ``pc_logic_parent_address`` + ``pc_logic_slot_index``
+    provenance, passing the parent module type through to the library
+    (``1A = convert(physical)``, ``1B`` = first nibble + 4 — validated
+    on three pc_logic installs and the #485 interface_module).
     """
+
+    ops = phys.get("operation_points")
+    if isinstance(ops, Mapping):
+        op_a, op_b = ops.get("1A"), ops.get("1B")
+        if isinstance(op_a, Mapping) and isinstance(op_b, Mapping):
+            addr_a = str(op_a.get("bus_address") or "").upper()
+            addr_b = str(op_b.get("bus_address") or "").upper()
+            if len(addr_a) == 6 and len(addr_b) == 6:
+                return addr_a, addr_b
 
     if convert_nikobus_address is None or derive_pc_logic_input_physicals is None:
         return None
@@ -64,7 +78,11 @@ def input_ab_addresses(phys: Mapping[str, Any]) -> tuple[str, str] | None:
     try:
         # Deriving exactly ``slot`` physicals yields the slot we want at
         # ``[slot - 1]``; the library raises for an out-of-range slot.
-        physical = derive_pc_logic_input_physicals(parent, slot)[slot - 1]
+        physical = derive_pc_logic_input_physicals(
+            parent,
+            slot,
+            module_type=str(phys.get("pc_logic_parent_type") or "pc_logic"),
+        )[slot - 1]
     except (ValueError, IndexError):  # pragma: no cover - defensive
         return None
     addr_1a = convert_nikobus_address(physical)

--- a/tests/test_input_latch_switch.py
+++ b/tests/test_input_latch_switch.py
@@ -35,13 +35,55 @@ class TestInputABAddresses(unittest.TestCase):
         self.assertEqual(int(b[0], 16), (int(a[0], 16) + 4) % 16)
         self.assertEqual(a[1:], b[1:])
 
-    def test_interface_module_uses_same_derivation(self):
-        # interface_module inputs derive identically (the library uses
-        # the same helper for both types).
+    def test_interface_module_uses_its_own_derivation(self):
+        # Issue #485: the 05-206 uses a DIFFERENT firmware scheme
+        # (0x180000 + addr + slot). The previous revision of this test
+        # asserted identical derivation for both types — that
+        # assumption is exactly what broke interface latches.
         self.assertEqual(
             input_ab_addresses(self._phys(1, ptype="interface_module")),
-            ("21814B", "61814B"),
+            ("2C0A46", "6C0A46"),
         )
+
+    def test_interface_module_0548_fallback_matches_captured_frames(self):
+        # The #485 install's Interface Module: hardware emits
+        # 24A806/64A806 for input 1 — the type-aware fallback must
+        # reproduce that.
+        self.assertEqual(
+            input_ab_addresses(
+                self._phys(1, parent="0548", ptype="interface_module")
+            ),
+            ("24A806", "64A806"),
+        )
+
+    def test_store_operation_points_take_priority_over_derivation(self):
+        # #485 root cause: the latch re-derived addresses instead of
+        # reading the store's op points — so it could disagree with the
+        # A/B sensors, which always use the store. The store is now the
+        # primary source; derivation is only a fallback.
+        phys = {
+            **self._phys(1, parent="0548", ptype="interface_module"),
+            "operation_points": {
+                "1A": {"bus_address": "24A806"},
+                "1B": {"bus_address": "64A806"},
+            },
+        }
+        self.assertEqual(input_ab_addresses(phys), ("24A806", "64A806"))
+
+        # Even deliberately-divergent stored ops win over derivation —
+        # whatever the sensors listen on, the latch listens on.
+        phys["operation_points"] = {
+            "1A": {"bus_address": "AAAAAA"},
+            "1B": {"bus_address": "BBBBBB"},
+        }
+        self.assertEqual(input_ab_addresses(phys), ("AAAAAA", "BBBBBB"))
+
+    def test_malformed_operation_points_fall_back_to_derivation(self):
+        phys = {
+            **self._phys(1),
+            "operation_points": {"1A": {"bus_address": ""}, "1B": "junk"},
+        }
+        self.assertEqual(input_ab_addresses(phys), ("21814B", "61814B"))
 
     def test_missing_provenance_returns_none(self):
         self.assertIsNone(input_ab_addresses({}))


### PR DESCRIPTION
## Summary

v3.13.2 — #485 follow-up, based on the reporter's field test of 3.13.1.

**Their report:** after updating and re-running discovery, the corrected Interface-Module input entries were created and the **A/B press sensors now pulse** (the 0.34.0 address fix works) — but the **A/B latch switch still doesn't change**. And only Interface entries were recreated, not Logic-Module ones (correct: those were never wrong).

**Root cause:** `input_ab_addresses()` in `switch.py` didn't read the latch's A/B addresses from storage — it *re-derived* them from parent + slot **without passing the module type**, silently recomputing the old pc_logic-formula addresses for `interface_module` inputs. The latch subscribed to (and its `turn_on/off` transmitted on) addresses the 05-206 never uses, while the sensors — fed from the store's operation points — worked. A second copy of the same wrong assumption the library fix removed, this time HA-side.

**Fix:** the store's operation points are now the **primary source** — the latch listens on exactly what the sensors listen on, by construction, and can never drift from them again. Derivation remains only as a fallback for malformed entries, and now passes the module type through to the 0.34.0 library.

The test that enshrined *"interface_module derives identically"* is replaced with hardware-anchored expectations (including the #485 install's captured `24A806`/`64A806` pair), plus store-priority and fallback tests.

Logic-Module latches were unaffected throughout (the default derivation was always correct for them).

## Tests

Full suite: **537 passed**, ruff clean. No pin change (still `nikobus-connect >= 0.34.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_