### PR TITLE
fix: ignore status frames outside discovery; keep clock sync available during maintenance (3.15.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **Fix: "Listener loop failed: 'NikobusDiscovery' object has no attribute 'process_mode_button_press'"** logged on every module-status reply. Status frames arriving outside a discovery run were routed to a discovery method that no longer exists; they are now ignored there (the query layer already consumes them). The backup / verify results were unaffected, only the log was.
 - **Sync PC-Link clock stays available during a backup or check.** It only needs two queued commands, so it no longer greys out (and no longer triggers "referenced entity not available" when pressed) while a longer maintenance run is in progress. Discovery still blocks it.
+- The PC-Link clock sensor reads the clock as soon as it is added instead of waiting for the first hourly poll (it stayed "unknown" for an hour after every restart).
 - Bus frames are logged as "Bus event frame" instead of "Press frame" at debug level.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.15.2
+
+- **Fix: "Listener loop failed: 'NikobusDiscovery' object has no attribute 'process_mode_button_press'"** logged on every module-status reply. Status frames arriving outside a discovery run were routed to a discovery method that no longer exists; they are now ignored there (the query layer already consumes them). The backup / verify results were unaffected, only the log was.
+- **Sync PC-Link clock stays available during a backup or check.** It only needs two queued commands, so it no longer greys out (and no longer triggers "referenced entity not available" when pressed) while a longer maintenance run is in progress. Discovery still blocks it.
+- Bus frames are logged as "Bus event frame" instead of "Press frame" at debug level.
+
+
 ## 3.15.1
 
 - **Fix: the 3.15.0 buttons and sensors never appeared.** The new hub entities (Sync PC-Link clock, Verify / Backup module programming, PC-Link clock, Programming health) were created at startup and immediately deleted by the integration's orphan cleanup, which only keeps entities whose ids it knows. They are now registered as known; after updating they show up on the Nikobus Bridge device without any further action.

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -723,13 +723,21 @@ class _NikobusMaintenanceButton(_NikobusBridgeButton):
 
 
 class NikobusSyncClockButton(_NikobusMaintenanceButton):
-    """Set the PC-Link clock from Home Assistant's time."""
+    """Set the PC-Link clock from Home Assistant's time.
+
+    Two queued commands, so it stays available while a backup or check
+    runs (the command queue serialises them); only discovery blocks it.
+    """
 
     _attr_translation_key = "sync_pc_link_clock"
 
     def __init__(self, coordinator: NikobusDataCoordinator) -> None:
         super().__init__(coordinator)
         self._attr_unique_id = f"{DOMAIN}_sync_pc_link_clock_button"
+
+    @property
+    def available(self) -> bool:
+        return not self._coordinator.discovery_running
 
     async def async_press(self) -> None:
         await self._coordinator.programming.async_sync_clock()

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -404,11 +404,7 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
 
     async def _event_callback(self, message: str) -> None:
         """Route non-feedback bus events (buttons, ACKs, discovery frames)."""
-        _LOGGER.debug(
-            "Press frame %s (raw hex %s)",
-            message,
-            message.encode().hex(),
-        )
+        _LOGGER.debug("Bus event frame %s", message)
         if message.startswith("#N"):
             # Extract the 6-char address after the "#N" prefix
             if self.nikobus_actuator and len(message) >= 8:
@@ -460,16 +456,20 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
             _LOGGER.error("Feedback callback failed: %s", err)
 
     async def _inventory_callback(self, message: str, discovery_active: bool) -> None:
-        """Route $18 inventory frames."""
-        if not self.nikobus_discovery:
+        """Route $18 frames.
+
+        During discovery they are inventory answers for the engine.
+        Outside discovery a $18 frame is a query reply (module status,
+        EEPROM CRC) that the command layer already consumed from the
+        response queue — nothing to route, so it is only logged.
+        """
+        if not self.nikobus_discovery or not discovery_active:
+            _LOGGER.debug("Status frame outside discovery: %s", message)
             return
-        if discovery_active:
-            if self.inventory_query_type == InventoryQueryType.PC_LINK:
-                self.nikobus_discovery.handle_device_address_inventory(message)
-            else:
-                await self.nikobus_discovery.query_module_inventory(message[3:7])
+        if self.inventory_query_type == InventoryQueryType.PC_LINK:
+            self.nikobus_discovery.handle_device_address_inventory(message)
         else:
-            await self.nikobus_discovery.process_mode_button_press(message)
+            await self.nikobus_discovery.query_module_inventory(message[3:7])
 
     async def _discovery_frame_callback(self, message: str) -> None:
         """Route $2E/$1E discovery response frames."""

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -22,5 +22,5 @@
     "pyserial-asyncio-fast>=0.16",
     "nikobus-connect>=0.35.0"
   ],
-  "version": "3.15.1"
+  "version": "3.15.2"
 }

--- a/custom_components/nikobus/sensor.py
+++ b/custom_components/nikobus/sensor.py
@@ -201,6 +201,11 @@ class NikobusPcLinkClockSensor(SensorEntity):
         self._attr_unique_id = f"{DOMAIN}_pc_link_clock"
         self._attr_device_info = hub_device_info()
 
+    async def async_added_to_hass(self) -> None:
+        """Read the clock right away instead of waiting a full poll interval."""
+        await super().async_added_to_hass()
+        self.async_schedule_update_ha_state(force_refresh=True)
+
     @property
     def available(self) -> bool:
         return self._coordinator.programming.pc_link_address() is not None

--- a/tests/test_programming_entities.py
+++ b/tests/test_programming_entities.py
@@ -77,8 +77,14 @@ class TestHealthSensor(unittest.TestCase):
 
 class TestMaintenanceButtons(unittest.TestCase):
     def test_availability_gating(self):
+        # Verify/backup grey out while either discovery or a maintenance
+        # run is busy; the clock sync only needs the bus queue, so it
+        # stays available during a backup and only yields to discovery.
+        self.assertTrue(NikobusVerifyProgrammingButton(_coordinator()).available)
+        self.assertFalse(NikobusVerifyProgrammingButton(_coordinator(running=True)).available)
+        self.assertFalse(NikobusVerifyProgrammingButton(_coordinator(discovery_running=True)).available)
         self.assertTrue(NikobusSyncClockButton(_coordinator()).available)
-        self.assertFalse(NikobusSyncClockButton(_coordinator(running=True)).available)
+        self.assertTrue(NikobusSyncClockButton(_coordinator(running=True)).available)
         self.assertFalse(NikobusSyncClockButton(_coordinator(discovery_running=True)).available)
 
     def test_sync_button_awaits_sync(self):
@@ -141,3 +147,16 @@ class TestHubEntitiesSurviveOrphanCleanup(unittest.TestCase):
         entities.append(health)
         for entity in entities:
             self.assertIn(entity._attr_unique_id, known, entity.__class__.__name__)
+
+
+class TestStatusFrameOutsideDiscovery(unittest.TestCase):
+    """A $18 reply outside discovery (module status / CRC query) must not
+    reach a discovery method — it used to call a method that no longer
+    exists and error the listener loop on every status reply."""
+
+    def test_inventory_callback_ignores_frame_when_idle(self):
+        from custom_components.nikobus.coordinator import NikobusDataCoordinator
+
+        coord = NikobusDataCoordinator.__new__(NikobusDataCoordinator)
+        coord.nikobus_discovery = MagicMock(spec=[])  # no discovery methods at all
+        _run(coord._inventory_callback("$18F58600500F3FFFAC61FE", False))


### PR DESCRIPTION
## Summary

v3.15.2 — two issues seen on a live install during the first backup run.

**1. `Listener loop failed: 'NikobusDiscovery' object has no attribute 'process_mode_button_press'`** (ERROR, once per module-status reply). `_inventory_callback` routed any `$18` frame received *outside* a discovery run to a discovery method that no longer exists in the library. That branch was dead until 3.15.0, because `$18` answers only ever arrived during discovery; the new module-status query (0x11) answers with `$18` frames outside it. The command layer consumes those replies from the response queue, so the callback now just logs them at debug level. The backup/verify results were never affected — only the log and a dropped (already consumed) frame.

**2. "Referenced entities button.nikobus_bridge_sync_pc_link_clock are missing or not currently available"** when pressing the clock button during a backup. The sync button was gated on the maintenance flag like the long-running buttons; it only needs two queued commands, so it now stays available while a backup/check runs (the command queue serialises them). Discovery still blocks it.

Also: the debug log line for every bus frame now says "Bus event frame" instead of "Press frame" (it logged block-read replies as presses).

## Tests

New test: a `$18` frame with discovery idle must not touch the discovery object; button availability test updated. Full suite: **564 passed**, ruff-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_