### PR TITLE
fix: dimmer programming check false alarm; show absent second table as empty (3.15.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.15.3
+
+- **Fix: dimmer modules no longer fail the programming check.** A dimmer's own checksum skips the six bytes between its two link banks; the check computed it over the whole image, so every healthy dimmer was flagged with a false "checksum mismatch" Repair issue. Fixed in `nikobus-connect 0.35.1` (required). Re-run **Verify module programming** once to clear the issue.
+- The programming report shows *no second table* as empty instead of 255 on switch and roller modules.
+
+
 ## 3.15.2
 
 - **Fix: "Listener loop failed: 'NikobusDiscovery' object has no attribute 'process_mode_button_press'"** logged on every module-status reply. Status frames arriving outside a discovery run were routed to a discovery method that no longer exists; they are now ignored there (the query layer already consumes them). The backup / verify results were unaffected, only the log was.

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -20,7 +20,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.35.0"
+    "nikobus-connect>=0.35.1"
   ],
-  "version": "3.15.2"
+  "version": "3.15.3"
 }

--- a/custom_components/nikobus/nkbprogramming.py
+++ b/custom_components/nikobus/nkbprogramming.py
@@ -259,7 +259,10 @@ class NikobusProgramming:
             status = await api.get_module_status(address)
             check.eeprom_error = status.eeprom_error
             check.record_count_a = status.record_count_a
-            check.record_count_b = status.record_count_b
+            # 0xFF = "no second table" on switch / roller modules.
+            check.record_count_b = (
+                None if status.record_count_b == 0xFF else status.record_count_b
+            )
             if image:
                 data = await api.read_module_memory(address, module_type)
                 check.image_bytes = len(data)


### PR DESCRIPTION
## Summary

v3.15.3 — follow-up to the first real backup run (6 modules): all five switch/roller modules verified bit-exact; the one dimmer was flagged with a false "checksum mismatch".

**Cause:** a dimmer's self-reported CRC16 covers both link banks but skips the six bytes between them (`0x7FA..0x7FF`); the check computed the CRC over the whole image. Searching the real image for the range that reproduces the module's value gave exactly that coverage. Fixed in **nikobus-connect 0.35.1** (`verify_module_memory()` now uses per-module CRC ranges); this PR pins `>= 0.35.1` — **release the library first**.

**Also:** `record_count_b` of `0xFF` means "no second link table" (switch/roller); the programming report now shows it as empty instead of `255`.

After updating, press **Verify module programming** once: the dimmer's Repair issue clears on a clean check.

Tests: 564 passed, ruff-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_