### PR TITLE
fix: one bridge action at a time; resolve HA device-registry deprecations (3.15.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
 
+## 3.15.4
+
+- **All bridge buttons grey out while any bridge action runs** — discovery, a programming check or a backup — one bus action at a time, and no more "referenced entity not available" surprises from pressing a second one.
+- **Home Assistant 2027.8 / 2027.9 deprecations resolved.** Device parents are now registered with `via_device_id`, device lookups use `async_get_device_by_identifier`, and the orphan cleanup enumerates the config entry's devices instead of the registry mapping — the "deprecated `via_device` parameter" / "uses `device_registry.devices` as a mapping" warnings (24 per start-up) are gone.
+
+
 ## 3.15.3
 
 - **Fix: dimmer modules no longer fail the programming check.** A dimmer's own checksum skips the six bytes between its two link banks; the check computed it over the whole image, so every healthy dimmer was flagged with a false "checksum mismatch" Repair issue. Fixed in `nikobus-connect 0.35.1` (required). Re-run **Verify module programming** once to clear the issue.
 - The programming report shows *no second table* as empty instead of 255 on switch and roller modules.
-- **All bridge buttons grey out while any bridge action runs** — discovery, a programming check or a backup — one bus action at a time, and no more "referenced entity not available" surprises from pressing a second one.
-- **Home Assistant 2027.8 / 2027.9 deprecations resolved.** Device parents are now registered with `via_device_id`, device lookups use `async_get_device_by_identifier`, and the orphan cleanup enumerates the config entry's devices instead of the registry mapping — the "deprecated `via_device` parameter" / "uses `device_registry.devices` as a mapping" warnings (24 per start-up) are gone.
 
 
 ## 3.15.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - **Fix: dimmer modules no longer fail the programming check.** A dimmer's own checksum skips the six bytes between its two link banks; the check computed it over the whole image, so every healthy dimmer was flagged with a false "checksum mismatch" Repair issue. Fixed in `nikobus-connect 0.35.1` (required). Re-run **Verify module programming** once to clear the issue.
 - The programming report shows *no second table* as empty instead of 255 on switch and roller modules.
+- **All bridge buttons grey out while any bridge action runs** — discovery, a programming check or a backup — one bus action at a time, and no more "referenced entity not available" surprises from pressing a second one.
+- **Home Assistant 2027.8 / 2027.9 deprecations resolved.** Device parents are now registered with `via_device_id`, device lookups use `async_get_device_by_identifier`, and the orphan cleanup enumerates the config entry's devices instead of the registry mapping — the "deprecated `via_device` parameter" / "uses `device_registry.devices` as a mapping" warnings (24 per start-up) are gone.
 
 
 ## 3.15.2

--- a/custom_components/nikobus/__init__.py
+++ b/custom_components/nikobus/__init__.py
@@ -31,6 +31,7 @@ from .const import CONFIG_ENTRY_VERSION, DOMAIN, HUB_IDENTIFIER
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import hub_device_info
 from .exceptions import NikobusConnectionError, NikobusDataError, NikobusError
+from .nkbdevices import parent_device_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -522,7 +523,7 @@ def _register_category_devices(
             manufacturer="Niko",
             name=display_name,
             model=model,
-            via_device=(DOMAIN, HUB_IDENTIFIER),
+            via_device_id=parent_device_id(device_registry, entry.entry_id, (DOMAIN, HUB_IDENTIFIER)),
             entry_type=dr.DeviceEntryType.SERVICE,
         )
 
@@ -554,13 +555,13 @@ async def _async_cleanup_orphan_entities(
         entity.device_id for entity in ent_reg.entities.values()
         if entity.config_entry_id == entry.entry_id and entity.device_id
     }
+    entry_devices = list(dr.async_entries_for_config_entry(dev_reg, entry.entry_id))
     via_parent_ids = {
-        device.via_device_id for device in dev_reg.devices.values()
-        if device.via_device_id and entry.entry_id in device.config_entries
+        device.via_device_id for device in entry_devices if device.via_device_id
     }
 
-    for device in list(dev_reg.devices.values()):
-        if entry.entry_id in device.config_entries and hub_identifier not in device.identifiers:
+    for device in entry_devices:
+        if hub_identifier not in device.identifiers:
             if device.id in devices_with_entities or device.id in via_parent_ids:
                 continue
             dev_reg.async_remove_device(device.id)

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -28,6 +28,7 @@ from .const import (
 )
 from .coordinator import NikobusConfigEntry, NikobusDataCoordinator
 from .entity import NikobusEntity, hub_device_info
+from .nkbdevices import parent_device_id
 from .router import (
     INPUT_MODULE_TYPES,
     OPAQUE_MODULE_TYPES,
@@ -185,7 +186,7 @@ def register_wall_button_devices(
                 manufacturer=BRAND,
                 name=name,
                 model=str(phys.get("model") or "PC-Logic Logical Input"),
-                via_device=via_device,
+                via_device_id=parent_device_id(device_registry, entry.entry_id, via_device),
             )
             continue
 
@@ -204,7 +205,7 @@ def register_wall_button_devices(
                 manufacturer=BRAND,
                 name=name,
                 model=str(phys.get("model") or "Remote Code"),
-                via_device=via_device,
+                via_device_id=parent_device_id(device_registry, entry.entry_id, via_device),
             )
             continue
 
@@ -231,7 +232,7 @@ def register_wall_button_devices(
             manufacturer=BRAND,
             name=str(phys.get("nkb_name") or default_name),
             model=model,
-            via_device=(DOMAIN, category),
+            via_device_id=parent_device_id(device_registry, entry.entry_id, (DOMAIN, category)),
         )
 
 
@@ -260,7 +261,7 @@ def _ensure_remote_transmitter_parent_device(
         manufacturer=BRAND,
         name=f"Remote Transmitter ({suffix})",
         model="RF Remote (synthesized)",
-        via_device=(DOMAIN, CATEGORY_REMOTES),
+        via_device_id=parent_device_id(device_registry, entry.entry_id, (DOMAIN, CATEGORY_REMOTES)),
     )
 
 
@@ -312,7 +313,7 @@ def _ensure_pc_logic_parent_device(
         manufacturer=BRAND,
         name=name,
         model=model,
-        via_device=(DOMAIN, CATEGORY_SYSTEM_MODULES),
+        via_device_id=parent_device_id(device_registry, entry.entry_id, (DOMAIN, CATEGORY_SYSTEM_MODULES)),
     )
 
 
@@ -354,7 +355,7 @@ def register_input_module_devices(
             manufacturer=BRAND,
             name=description,
             model=model,
-            via_device=(DOMAIN, CATEGORY_SYSTEM_MODULES),
+            via_device_id=parent_device_id(device_registry, entry.entry_id, (DOMAIN, CATEGORY_SYSTEM_MODULES)),
         )
 
 
@@ -383,7 +384,7 @@ def register_opaque_module_devices(
             manufacturer=BRAND,
             name=description,
             model=model,
-            via_device=(DOMAIN, CATEGORY_SYSTEM_MODULES),
+            via_device_id=parent_device_id(device_registry, entry.entry_id, (DOMAIN, CATEGORY_SYSTEM_MODULES)),
         )
 
 
@@ -453,7 +454,15 @@ class _NikobusBridgeButton(ButtonEntity):
 
     @property
     def available(self) -> bool:
-        return not self._coordinator.discovery_running
+        # One bridge action at a time: discovery and the programming
+        # maintenance runs share the bus, so every bridge button greys
+        # out while any of them is busy.
+        return not (self._coordinator.discovery_running or self._maintenance_running)
+
+    @property
+    def _maintenance_running(self) -> bool:
+        programming = getattr(self._coordinator, "programming", None)
+        return getattr(programming, "running", False) is True
 
     async def async_added_to_hass(self) -> None:
         """Re-render availability whenever discovery state changes."""
@@ -700,14 +709,9 @@ class NikobusButtonEntity(NikobusEntity, ButtonEntity):
 class _NikobusMaintenanceButton(_NikobusBridgeButton):
     """Bridge buttons that read the modules' programming.
 
-    Greyed out while discovery or another maintenance run is busy —
-    both share the bus and must not interleave.
+    Availability follows the bridge rule (one action at a time); the
+    press handlers re-check it so a race can't start two bus runs.
     """
-
-    @property
-    def available(self) -> bool:
-        programming = self._coordinator.programming
-        return not (self._coordinator.discovery_running or programming.running)
 
     def _start(self, coro: Any, name: str) -> None:
         programming = self._coordinator.programming
@@ -723,21 +727,13 @@ class _NikobusMaintenanceButton(_NikobusBridgeButton):
 
 
 class NikobusSyncClockButton(_NikobusMaintenanceButton):
-    """Set the PC-Link clock from Home Assistant's time.
-
-    Two queued commands, so it stays available while a backup or check
-    runs (the command queue serialises them); only discovery blocks it.
-    """
+    """Set the PC-Link clock from Home Assistant's time."""
 
     _attr_translation_key = "sync_pc_link_clock"
 
     def __init__(self, coordinator: NikobusDataCoordinator) -> None:
         super().__init__(coordinator)
         self._attr_unique_id = f"{DOMAIN}_sync_pc_link_clock_button"
-
-    @property
-    def available(self) -> bool:
-        return not self._coordinator.discovery_running
 
     async def async_press(self) -> None:
         await self._coordinator.programming.async_sync_clock()

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -1039,8 +1039,9 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
             return ""
         addr = str(address).upper()
         if self.hass is not None:
-            device = dr.async_get(self.hass).async_get_device(
-                identifiers={(DOMAIN, addr)}
+            entry = getattr(self, "config_entry", None)
+            device = dr.async_get(self.hass).async_get_device_by_identifier(
+                (DOMAIN, addr), str(getattr(entry, "entry_id", "") or "")
             )
             if device is not None:
                 name = device.name_by_user or device.name

--- a/custom_components/nikobus/discovery_mixin.py
+++ b/custom_components/nikobus/discovery_mixin.py
@@ -1390,10 +1390,9 @@ class NikobusDiscoveryMixin:
                         # live in ``name_by_user``), so updating it when
                         # it equals the previous import is safe.
                         if prev and not overwrite:
-                            dev = dev_reg.async_get_device(
-                                identifiers={
-                                    (DOMAIN, str(op.get("bus_address") or "").upper())
-                                }
+                            dev = dev_reg.async_get_device_by_identifier(
+                                (DOMAIN, str(op.get("bus_address") or "").upper()),
+                                self.config_entry.entry_id,
                             )
                             if dev is not None and dev.name == prev:
                                 dev_reg.async_update_device(

--- a/custom_components/nikobus/entity.py
+++ b/custom_components/nikobus/entity.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import BRAND, DOMAIN, HUB_IDENTIFIER
 from .coordinator import NikobusDataCoordinator
+from .nkbdevices import parent_device_id
 
 # Sentinel return for ``_render_state``: this entity opts out of
 # write-diffing and writes on every coordinator update (the default).
@@ -87,8 +88,18 @@ class NikobusEntity(CoordinatorEntity[NikobusDataCoordinator]):
             manufacturer=BRAND,
             model=self._device_model,
         )
+        #: Identifier of the parent device (category / plate), if any.
+        self._via_device = via_device
         if via_device is not None:
-            device_info["via_device"] = via_device
+            hass = getattr(coordinator, "hass", None)
+            entry = getattr(coordinator, "config_entry", None)
+            parent_id = parent_device_id(
+                dr.async_get(hass) if hass is not None else None,
+                str(getattr(entry, "entry_id", "") or ""),
+                via_device,
+            )
+            if parent_id is not None:
+                device_info["via_device_id"] = parent_id
         self._attr_device_info = device_info
 
         #: Last ``(available, render_state)`` actually written, for diffing.

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -22,5 +22,5 @@
     "pyserial-asyncio-fast>=0.16",
     "nikobus-connect>=0.35.1"
   ],
-  "version": "3.15.3"
+  "version": "3.15.4"
 }

--- a/custom_components/nikobus/nkbdevices.py
+++ b/custom_components/nikobus/nkbdevices.py
@@ -1,0 +1,26 @@
+"""Device-registry helpers shared by every platform (no integration imports)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def parent_device_id(
+    device_registry: Any, entry_id: str, identifier: tuple[str, str]
+) -> str | None:
+    """Registry id of the device carrying ``identifier``, or ``None``.
+
+    Device parents are expressed as ``via_device_id`` (the registry id
+    of the parent), so the parent must already be registered — which
+    the setup order guarantees (hub → categories → modules / plates →
+    their children). ``None`` when the registry is unavailable or the
+    parent doesn't exist yet; the child is then created without a
+    parent link rather than failing.
+    """
+    if device_registry is None:
+        return None
+    lookup = getattr(device_registry, "async_get_device_by_identifier", None)
+    if lookup is None:
+        return None
+    device = lookup(identifier, entry_id)
+    return device.id if device is not None else None

--- a/custom_components/nikobus/nkbprogramming.py
+++ b/custom_components/nikobus/nkbprogramming.py
@@ -20,10 +20,16 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.util import dt as dt_util
 from nikobus_connect.api import MODULE_IMAGE_SIZES
 
-from .const import DOMAIN, ISSUE_MODULE_CRC_MISMATCH, ISSUE_MODULE_EEPROM_ERROR
+from .const import (
+    DOMAIN,
+    ISSUE_MODULE_CRC_MISMATCH,
+    ISSUE_MODULE_EEPROM_ERROR,
+    SIGNAL_DISCOVERY_STATE,
+)
 from .router import iter_operation_points
 
 _LOGGER = logging.getLogger(__name__)
@@ -189,6 +195,11 @@ class NikobusProgramming:
             return HEALTH_UNKNOWN
         return HEALTH_OK
 
+    def _set_running(self, running: bool) -> None:
+        """Flip the busy flag and repaint the bridge buttons' availability."""
+        self.running = running
+        async_dispatcher_send(self._hass, SIGNAL_DISCOVERY_STATE)
+
     # -- guards --------------------------------------------------------------
 
     def _api(self) -> Any:
@@ -303,7 +314,7 @@ class NikobusProgramming:
         self._acquire()
         api = self._api()
         wanted = {a.upper() for a in addresses} if addresses else None
-        self.running = True
+        self._set_running(True)
         try:
             async with self._lock:
                 for address, module_type, description in self.output_modules():
@@ -316,7 +327,7 @@ class NikobusProgramming:
                     self._apply_issues(check)
                 self.last_check_at = dt_util.now()
         finally:
-            self.running = False
+            self._set_running(False)
             self._coordinator.async_update_listeners()
         return self.check_report()
 
@@ -341,7 +352,7 @@ class NikobusProgramming:
         wanted = {a.upper() for a in addresses} if addresses else None
         stamp = dt_util.now().strftime("%Y%m%d-%H%M%S")
         folder = Path(self._hass.config.path(BACKUP_DIR, stamp))
-        self.running = True
+        self._set_running(True)
         try:
             async with self._lock:
                 images: dict[str, bytes] = {}
@@ -361,7 +372,7 @@ class NikobusProgramming:
                 self.last_backup_path = str(folder)
                 self.last_backup_at = self.last_check_at
         finally:
-            self.running = False
+            self._set_running(False)
             self._coordinator.async_update_listeners()
         _LOGGER.info("Nikobus programming backup written to %s (%d image(s))", folder, len(images))
         return {"path": str(folder), "images": sorted(images), **summary}

--- a/custom_components/nikobus/router.py
+++ b/custom_components/nikobus/router.py
@@ -12,6 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from .const import BRAND, CATEGORY_OUTPUT_MODULES, DOMAIN
+from .nkbdevices import parent_device_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,7 +43,7 @@ def register_output_module_devices(
             manufacturer=BRAND,
             name=spec.module_desc,
             model=spec.module_model,
-            via_device=(DOMAIN, CATEGORY_OUTPUT_MODULES),
+            via_device_id=parent_device_id(device_registry, entry.entry_id, (DOMAIN, CATEGORY_OUTPUT_MODULES)),
         )
         registered.add(spec.address)
 

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -414,7 +414,7 @@
     },
     "backup_modules": {
       "name": "Backup module programming",
-      "description": "Reads the full programming image of every output module (or the listed ones) into config/nikobus_backup/<timestamp>/ as .nkm files, together with a summary of the status checks.",
+      "description": "Reads the full programming image of every output module (or the listed ones) into config/nikobus_backup/ in a folder named after the run time, as .nkm files, together with a summary of the status checks.",
       "fields": {
         "addresses": {
           "name": "Module addresses",

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -453,7 +453,7 @@
     },
     "backup_modules": {
       "name": "Sauvegarder la programmation des modules",
-      "description": "Lit l'image de programmation complète de chaque module de sortie (ou de ceux listés) dans config/nikobus_backup/<horodatage>/ sous forme de fichiers .nkm, avec un résumé des vérifications.",
+      "description": "Lit l'image de programmation complète de chaque module de sortie (ou de ceux listés) dans config/nikobus_backup/ dans un dossier nommé d'après l'heure d'exécution, sous forme de fichiers .nkm, avec un résumé des vérifications.",
       "fields": {
         "addresses": {
           "name": "Adresses des modules",

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -453,7 +453,7 @@
     },
     "backup_modules": {
       "name": "Moduleprogrammering back-uppen",
-      "description": "Leest het volledige programmeergeheugen van elke uitgangsmodule (of de opgegeven modules) naar config/nikobus_backup/<tijdstempel>/ als .nkm-bestanden, samen met een samenvatting van de controles.",
+      "description": "Leest het volledige programmeergeheugen van elke uitgangsmodule (of de opgegeven modules) naar config/nikobus_backup/ in een map genoemd naar het tijdstip van uitvoering, als .nkm-bestanden, samen met een samenvatting van de controles.",
       "fields": {
         "addresses": {
           "name": "Moduleadressen",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,6 +193,9 @@ _mod(
     DeviceInfo=_DeviceInfo,
     DeviceEntry=type("DeviceEntry", (), {}),
     async_get=lambda hass: None,
+    # Real HA: list of DeviceEntry for a config entry. Tests that need
+    # devices patch this (see test_nkbnames) or hand in a fake registry.
+    async_entries_for_config_entry=lambda registry, entry_id: [],
 )
 
 # homeassistant.helpers.entity_registry

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -650,7 +650,7 @@ class TestCFCoverConstruction(unittest.TestCase):
             cf_config={"pattern": "roller", "name": "Gordijnen keuken", "outputs": []}
         )
         self.assertEqual(
-            ent._attr_device_info["via_device"],
+            ent._via_device,
             (DOMAIN, CATEGORY_CENTRAL_FUNCTIONS),
         )
         self.assertEqual(

--- a/tests/test_nkbdevices.py
+++ b/tests/test_nkbdevices.py
@@ -1,0 +1,26 @@
+"""Device-parent resolution (``via_device_id``)."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from custom_components.nikobus.nkbdevices import parent_device_id
+
+
+class TestParentDeviceId(unittest.TestCase):
+    def test_resolves_registered_parent(self):
+        registry = MagicMock()
+        registry.async_get_device_by_identifier.return_value = SimpleNamespace(id="dev42")
+        self.assertEqual(parent_device_id(registry, "entry1", ("nikobus", "hub")), "dev42")
+        registry.async_get_device_by_identifier.assert_called_once_with(("nikobus", "hub"), "entry1")
+
+    def test_missing_parent_or_registry_gives_none(self):
+        registry = MagicMock()
+        registry.async_get_device_by_identifier.return_value = None
+        self.assertIsNone(parent_device_id(registry, "entry1", ("nikobus", "x")))
+        self.assertIsNone(parent_device_id(None, "entry1", ("nikobus", "x")))
+        self.assertIsNone(parent_device_id(object(), "entry1", ("nikobus", "x")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nkbnames.py
+++ b/tests/test_nkbnames.py
@@ -787,7 +787,7 @@ def test_reimport_with_changed_plate_name_refreshes_key_devices():
     coord = _coord(button_data=store)
     key_dev = _device("d2", "9A43A2", name="Ancien nom Key 1A")
     dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
-    dev_reg.async_get_device.return_value = key_dev
+    dev_reg.async_get_device_by_identifier.return_value = key_dev
     with _patches(data, [], [], dev_reg, ent_reg, area_reg):
         _run(coord.async_import_nkb_names(categories={"device_names"}))
 
@@ -807,7 +807,7 @@ def test_reimport_key_heal_leaves_foreign_registry_names_alone():
     coord = _coord(button_data=store)
     key_dev = _device("d2", "9A43A2", name="Something else entirely")
     dev_reg, ent_reg, area_reg = MagicMock(), MagicMock(), MagicMock()
-    dev_reg.async_get_device.return_value = key_dev
+    dev_reg.async_get_device_by_identifier.return_value = key_dev
     with _patches(data, [], [], dev_reg, ent_reg, area_reg):
         _run(coord.async_import_nkb_names(categories={"device_names"}))
 

--- a/tests/test_programming_entities.py
+++ b/tests/test_programming_entities.py
@@ -77,15 +77,12 @@ class TestHealthSensor(unittest.TestCase):
 
 class TestMaintenanceButtons(unittest.TestCase):
     def test_availability_gating(self):
-        # Verify/backup grey out while either discovery or a maintenance
-        # run is busy; the clock sync only needs the bus queue, so it
-        # stays available during a backup and only yields to discovery.
-        self.assertTrue(NikobusVerifyProgrammingButton(_coordinator()).available)
-        self.assertFalse(NikobusVerifyProgrammingButton(_coordinator(running=True)).available)
-        self.assertFalse(NikobusVerifyProgrammingButton(_coordinator(discovery_running=True)).available)
-        self.assertTrue(NikobusSyncClockButton(_coordinator()).available)
-        self.assertTrue(NikobusSyncClockButton(_coordinator(running=True)).available)
-        self.assertFalse(NikobusSyncClockButton(_coordinator(discovery_running=True)).available)
+        # One bridge action at a time: every bridge button greys out
+        # while discovery or a maintenance run is busy.
+        for cls in (NikobusVerifyProgrammingButton, NikobusSyncClockButton, NikobusBackupProgrammingButton):
+            self.assertTrue(cls(_coordinator()).available, cls.__name__)
+            self.assertFalse(cls(_coordinator(running=True)).available, cls.__name__)
+            self.assertFalse(cls(_coordinator(discovery_running=True)).available, cls.__name__)
 
     def test_sync_button_awaits_sync(self):
         coord = _coordinator()

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -331,7 +331,7 @@ class TestCoordinatorSceneHelpers(unittest.TestCase):
         dev.name_by_user = None
         dev.name = "dimmer_module_d1"
         reg = MagicMock()
-        reg.async_get_device.return_value = dev
+        reg.async_get_device_by_identifier.return_value = dev
         with patch("custom_components.nikobus.coordinator.dr.async_get",
                    return_value=reg):
             self.assertEqual(c.address_label("0E6C"), "dimmer_module_d1 (0E6C)")


### PR DESCRIPTION
## Summary

v3.15.4 — two requests from the field.

### 1. All bridge buttons grey out while any bridge action runs

Discovery, a programming check and a backup all share the bus, so now **every** bridge button (the three discovery/import buttons and the three maintenance buttons) is unavailable while any of them is running — the same rule the discovery buttons already followed, extended to maintenance runs. The maintenance layer now repaints button availability through the existing discovery-state signal when a run starts or ends. (3.15.2's exception for the clock button is dropped: one action at a time, no surprises.)

### 2. Home Assistant 2027.8 / 2027.9 deprecation warnings (24 per start-up)

- `device_registry.async_get_or_create(via_device=…)` → **`via_device_id`**. Parents are resolved to their registry id with a new import-free helper `nkbdevices.parent_device_id(registry, entry_id, identifier)`; `NikobusEntity` does it for entity-level parents, and the direct registry calls in `router.py`, `button.py`, `__init__.py` use it. The setup order (hub → categories → modules/plates → children) already guarantees the parent exists.
- `dev_reg.async_get_device(identifiers=…)` → **`async_get_device_by_identifier(identifier, entry_id)`** in the coordinator's `address_label` and the `.nkb` key-rename path.
- Orphan cleanup: `dev_reg.devices.values()` → **`dr.async_entries_for_config_entry(dev_reg, entry_id)`**.

No behavioural change to device structure — same parents, same names.

## Tests

`test_nkbdevices.py` (parent resolution), availability tests updated to the one-action rule, registry mocks updated to the new API; test stub gains `async_entries_for_config_entry`. Full suite: **566 passed**, ruff-clean on the whole component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_