### PR TITLE
feat(cover): end-stop margin — stop frame at 0/100 returns after a per-channel delay (3.15.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.15.5
+
+- **Covers: the stop frame at fully open/closed is back, sent after an end-stop margin.** Since 3.14.0 a motion started from Home Assistant that ended at 0 or 100 sent no stop at all and left the relay to the module's own run time. Where that run time is longer than the real travel (a common installer setting) the relay stayed engaged well after the shutter had arrived, and a wall button pressed in that window only stopped the relay — a second press was needed to move the shutter. The stop frame is now sent **End-stop margin** seconds after the estimated arrival (new per-channel setting under *Customize a module*, default 3 s, same as before 3.14.0): the motor still runs into the end stop during the margin, which keeps erasing the position drift, and the relay is released right after, so the wall button acts on the first press. A large margin restores the 3.14.0 behaviour for installs that prefer it.
+- The cover's `end_stop_margin` is exposed as a state attribute next to the travel times.
+
+
 ## 3.15.4
 
 - **All bridge buttons grey out while any bridge action runs** — discovery, a programming check or a backup — one bus action at a time, and no more "referenced entity not available" surprises from pressing a second one.

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Press **3. Import Names from .nkb** to apply the friendly names, rooms, and scen
 - **Entity type** → how HA exposes it (switch modules: `switch`/`light`/`none`; dimmers: `light`/`none`; rollers: `cover`/`switch`/`light`/`none`).
 - **LED on / off addresses** → feedback-LED bus addresses (blank if unused).
 - **Travel time up / down** (rollers) → seconds to open/close, used by the position calculator.
+- **End-stop margin** (rollers) → seconds after the estimated arrival at fully open/closed before a Home Assistant-started motion sends its stop frame (default 3). The motor runs into the end stop during the margin, which keeps the position model honest; the stop then releases the relay so a wall button acts on the first press. Set it higher to let the module's own run time release the relay instead.
 
 Changes persist in `.storage/nikobus.modules` and survive re-discovery.
 

--- a/custom_components/nikobus/config_flow.py
+++ b/custom_components/nikobus/config_flow.py
@@ -36,6 +36,7 @@ from .const import (
     CONF_PRIOR_GEN3,
     CONF_REFRESH_INTERVAL,
     CONFIG_ENTRY_VERSION,
+    DEFAULT_COVER_END_STOP_MARGIN,
     DEFAULT_PRESS_REPEAT,
     DOMAIN,
     NKB_IMPORT_CATEGORIES,
@@ -186,6 +187,22 @@ def _set_time_or_drop(mapping: dict[str, Any], key: str, value: Any) -> None:
         mapping.pop(key, None)
         return
     if as_int <= 0:
+        mapping.pop(key, None)
+        return
+    mapping[key] = str(as_int)
+
+
+def _set_margin_or_drop(mapping: dict[str, Any], key: str, value: Any) -> None:
+    """Store a non-negative seconds value (as a string); drop it otherwise."""
+    if value in (None, ""):
+        mapping.pop(key, None)
+        return
+    try:
+        as_int = int(float(value))
+    except (TypeError, ValueError):
+        mapping.pop(key, None)
+        return
+    if as_int < 0:
         mapping.pop(key, None)
         return
     mapping[key] = str(as_int)
@@ -859,6 +876,9 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
                     down = user_input.get("operation_time_down")
                     _set_time_or_drop(channel, "operation_time_up", up)
                     _set_time_or_drop(channel, "operation_time_down", down)
+                    _set_margin_or_drop(
+                        channel, "end_stop_margin", user_input.get("end_stop_margin")
+                    )
 
                 await coordinator.async_on_module_save()
                 # Return to the module step so the user can edit another
@@ -920,6 +940,16 @@ class NikobusOptionsFlow(config_entries.OptionsFlow):
             )] = NumberSelector(
                 NumberSelectorConfig(
                     min=1, max=600, step=1, mode=NumberSelectorMode.BOX, unit_of_measurement="s"
+                )
+            )
+            schema_dict[vol.Optional(
+                "end_stop_margin",
+                default=_coerce_int(
+                    channel.get("end_stop_margin"), int(DEFAULT_COVER_END_STOP_MARGIN)
+                ),
+            )] = NumberSelector(
+                NumberSelectorConfig(
+                    min=0, max=120, step=1, mode=NumberSelectorMode.BOX, unit_of_measurement="s"
                 )
             )
 

--- a/custom_components/nikobus/const.py
+++ b/custom_components/nikobus/const.py
@@ -269,6 +269,9 @@ MAX_EXTENDED_RELEASE_MS: Final[int] = 5000
 # Covers
 # =============================================================================
 DEFAULT_COVER_MOVEMENT_BUFFER: Final[float] = 3.0
+# Seconds after the estimated arrival at 0/100 before HA releases the
+# relay of a motion it started (per-channel ``end_stop_margin`` override).
+DEFAULT_COVER_END_STOP_MARGIN: Final[float] = 3.0
 DEFAULT_COVER_DEBOUNCE_DELAY: Final[float] = 0.3
 DEFAULT_COVER_OPERATION_TIME: Final[float] = 30.0
 

--- a/custom_components/nikobus/cover.py
+++ b/custom_components/nikobus/cover.py
@@ -23,6 +23,7 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from .const import (
     CATEGORY_CENTRAL_FUNCTIONS,
     DEFAULT_COVER_DEBOUNCE_DELAY,
+    DEFAULT_COVER_END_STOP_MARGIN,
     DEFAULT_COVER_MOVEMENT_BUFFER,
     DEFAULT_COVER_OPERATION_TIME,
     DOMAIN,
@@ -57,6 +58,26 @@ def _parse_operation_time(value: Any, fallback: float, label: str, address: str)
         "Cover %s: invalid %s %r — must be a positive number. Using default %.1fs.",
         address,
         label,
+        value,
+        fallback,
+    )
+    return fallback
+
+
+def _parse_end_stop_margin(value: Any, fallback: float, address: str) -> float:
+    """Parse the per-channel end-stop margin (seconds, zero allowed)."""
+    if value is None:
+        return fallback
+    try:
+        margin = float(value)
+        if margin >= 0:
+            return margin
+    except (TypeError, ValueError):
+        pass
+    _LOGGER.warning(
+        "Cover %s: invalid end_stop_margin %r — must be zero or a positive number. "
+        "Using default %.1fs.",
+        address,
         value,
         fallback,
     )
@@ -118,6 +139,10 @@ async def async_setup_entry(
             spec.address,
         )
 
+        end_stop_margin = _parse_end_stop_margin(
+            spec.end_stop_margin, DEFAULT_COVER_END_STOP_MARGIN, spec.address
+        )
+
         entities.append(
             NikobusCoverEntity(
                 coordinator,
@@ -128,6 +153,7 @@ async def async_setup_entry(
                 spec.module_model,
                 op_time_up,
                 op_time_down,
+                end_stop_margin,
             )
         )
 
@@ -175,6 +201,7 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
         model: str,
         op_time_up: float,
         op_time_down: float,
+        end_stop_margin: float = DEFAULT_COVER_END_STOP_MARGIN,
     ) -> None:
         """Initialize the cover entity."""
         super().__init__(coordinator, address, module_desc, model)
@@ -186,6 +213,9 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
         self._attr_unique_id = build_unique_id("cover", "cover", address, channel)
 
         self._calculator = NikobusTravelCalculator(op_time_up, op_time_down)
+        # Seconds after the estimated arrival at 0/100 before the stop
+        # frame of an HA-started motion goes out (see _motion_loop).
+        self._end_stop_margin = end_stop_margin
 
         self._position: float = 100.0
         self._state = STATE_STOPPED
@@ -193,6 +223,8 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
         self._motion_task: asyncio.Task[None] | None = None
         self._coalesce_task: asyncio.Task[None] | None = None
         self._error_recovery_task: asyncio.Task[None] | None = None
+        # Pending deferred stop frame of a motion that ended at 0/100.
+        self._end_stop_task: asyncio.Task[None] | None = None
 
         self._movement_source = "ha"
         self._current_run_limit: float = 0.0
@@ -249,6 +281,7 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
             **parent_attrs,
             "operation_time_up": self._calculator.time_up,
             "operation_time_down": self._calculator.time_down,
+            "end_stop_margin": self._end_stop_margin,
             "movement_source": self._movement_source,
             "controlled_by": self.coordinator.get_controlled_by(self._address, self._channel),
         }
@@ -273,7 +306,12 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
         )
 
         def _cancel_cover_tasks() -> None:
-            for task_attr in ("_motion_task", "_coalesce_task", "_error_recovery_task"):
+            for task_attr in (
+                "_motion_task",
+                "_coalesce_task",
+                "_error_recovery_task",
+                "_end_stop_task",
+            ):
                 task = getattr(self, task_attr, None)
                 if task:
                     task.cancel()
@@ -434,6 +472,9 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
                 await self._stop(send_stop=True)
                 await asyncio.sleep(0.5)
 
+        # A new HA command supersedes any stop frame still pending from
+        # the previous full travel.
+        self._cancel_end_stop()
         self._movement_source = "ha"
         self._target_position = target
 
@@ -497,17 +538,26 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
                         # Snap to exact target to eliminate 0.5 s tick overshoot.
                         self._position = float(self._target_position)
                         self._calculator.set_position(self._position)
-                    # A motion ending at 0/100 gets no bus stop: the position
-                    # model dead-reckons and drifts, so the estimate saying
-                    # "arrived" doesn't mean the shutter is physically at the
-                    # end. Left running, the motor reaches the limit switch —
-                    # erasing the accumulated drift — and the roller module's
-                    # own per-channel run time releases the relay, exactly as
-                    # after a physical wall-button full travel.
-                    send_stop = (
-                        movement_source == "ha" and not self._ends_at_end_stop()
-                    )
+                    # A motion ending at 0/100 gets its stop frame only
+                    # after the end-stop margin: the position model
+                    # dead-reckons and drifts, so the estimate saying
+                    # "arrived" doesn't mean the shutter is physically at
+                    # the end. Left running for the margin, the motor
+                    # reaches the limit switch (erasing the drift); the
+                    # stop then releases the relay so a wall button acts
+                    # on the first press again. The margin counts from
+                    # the estimated arrival, i.e. the run limit minus the
+                    # safety buffer.
+                    send_stop = movement_source == "ha"
+                    deferred = 0.0
+                    if send_stop and self._ends_at_end_stop():
+                        arrival = self._current_run_limit - DEFAULT_COVER_MOVEMENT_BUFFER
+                        deferred = arrival + self._end_stop_margin - elapsed
+                        if deferred > 0:
+                            send_stop = False
                     await self._stop(send_stop=send_stop)
+                    if deferred > 0:
+                        self._schedule_end_stop(deferred)
                     break
 
                 self.async_write_ha_state()
@@ -527,10 +577,29 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
 
         Full open/close (no target — the loop only terminates on the run
         limit) and an explicit target of 0/100 both end at a mechanical
-        end stop; only an intermediate target requires an actual bus stop
-        frame to halt the motor mid-travel.
+        end stop; only an intermediate target needs its stop frame the
+        moment the estimate reaches the target.
         """
         return self._target_position is None or self._target_position in (0, 100)
+
+    def _schedule_end_stop(self, delay: float) -> None:
+        """Send the stop frame of a finished full travel after ``delay`` s."""
+        self._cancel_end_stop()
+
+        async def _deferred_stop() -> None:
+            await asyncio.sleep(delay)
+            # force_api: the state was committed to STOPPED when the loop
+            # ended; the relay is still engaged until this frame goes out.
+            await self._stop(send_stop=True, force_api=True)
+
+        self._end_stop_task = self.hass.async_create_task(_deferred_stop())
+
+    def _cancel_end_stop(self) -> None:
+        """Drop a pending deferred stop frame (never the task running us)."""
+        task = self._end_stop_task
+        self._end_stop_task = None
+        if task is not None and task is not asyncio.current_task():
+            task.cancel()
 
     def _should_stop(self) -> bool:
         """Check if cover reached the target position."""
@@ -567,6 +636,8 @@ class NikobusCoverEntity(NikobusEntity, CoverEntity, RestoreEntity):
         self.coordinator.set_bytearray_state(self._address, self._channel, STATE_STOPPED)
 
         if send_stop and (stopped_state != STATE_STOPPED or force_api):
+            # A frame going out now makes any deferred end-stop redundant.
+            self._cancel_end_stop()
             if stopped_state == STATE_OPENING:
                 dir_cmd = "opening"
             elif stopped_state == STATE_CLOSING:

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -22,5 +22,5 @@
     "pyserial-asyncio-fast>=0.16",
     "nikobus-connect>=0.35.1"
   ],
-  "version": "3.15.4"
+  "version": "3.15.5"
 }

--- a/custom_components/nikobus/nkbmanual.py
+++ b/custom_components/nikobus/nkbmanual.py
@@ -250,6 +250,8 @@ def _convert_channel(
             out["operation_time_up"] = channel["operation_time_up"]
         if "operation_time_down" in channel:
             out["operation_time_down"] = channel["operation_time_down"]
+        if "end_stop_margin" in channel:
+            out["end_stop_margin"] = channel["end_stop_margin"]
         # Legacy single ``operation_time`` → split into both directions.
         if "operation_time" in channel and "operation_time_up" not in out:
             legacy_time = channel["operation_time"]

--- a/custom_components/nikobus/nkbstorage.py
+++ b/custom_components/nikobus/nkbstorage.py
@@ -17,7 +17,8 @@ Two parallel Stores back the integration:
               "channels": [
                   {"description", "entity_type",
                    "led_on", "led_off",
-                   "operation_time_up", "operation_time_down"}, ...
+                   "operation_time_up", "operation_time_down",
+                   "end_stop_margin"}, ...
               ],
               "discovered_info": {"name", "device_type", "channels_count"},
           },

--- a/custom_components/nikobus/router.py
+++ b/custom_components/nikobus/router.py
@@ -194,6 +194,7 @@ class EntitySpec:
     module_model: str
     operation_time_up: str | None = None
     operation_time_down: str | None = None
+    end_stop_margin: str | None = None
 
 
 def build_unique_id(domain: str, kind: str, address: str, channel: int) -> str:
@@ -314,6 +315,7 @@ def build_routing(
                         module_model=module_model,
                         operation_time_up=channel_info.get("operation_time_up"),
                         operation_time_down=channel_info.get("operation_time_down"),
+                        end_stop_margin=channel_info.get("end_stop_margin"),
                     )
                 )
 

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -287,7 +287,8 @@
           "led_on": "LED-on trigger (6-hex bus address, optional)",
           "led_off": "LED-off trigger (6-hex bus address, optional)",
           "operation_time_up": "Travel time up (seconds)",
-          "operation_time_down": "Travel time down (seconds)"
+          "operation_time_down": "Travel time down (seconds)",
+          "end_stop_margin": "End-stop margin (seconds)"
         }
       },
       "upload_nkb": {

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -122,7 +122,8 @@
           "led_on": "Déclencheur LED allumée (adresse bus 6-hex, optionnel)",
           "led_off": "Déclencheur LED éteinte (adresse bus 6-hex, optionnel)",
           "operation_time_up": "Temps de course à l'ouverture (secondes)",
-          "operation_time_down": "Temps de course à la fermeture (secondes)"
+          "operation_time_down": "Temps de course à la fermeture (secondes)",
+          "end_stop_margin": "Marge de fin de course (secondes)"
         }
       },
       "upload_nkb": {

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -122,7 +122,8 @@
           "led_on": "LED-aan trigger (6-hex busadres, optioneel)",
           "led_off": "LED-uit trigger (6-hex busadres, optioneel)",
           "operation_time_up": "Looptijd omhoog (seconden)",
-          "operation_time_down": "Looptijd omlaag (seconden)"
+          "operation_time_down": "Looptijd omlaag (seconden)",
+          "end_stop_margin": "Eindaanslagmarge (seconden)"
         }
       },
       "upload_nkb": {

--- a/tests/test_config_flow_helpers.py
+++ b/tests/test_config_flow_helpers.py
@@ -18,6 +18,7 @@ from custom_components.nikobus.config_flow import (
     _module_type_order,
     _needs_polling,
     _set_or_drop,
+    _set_margin_or_drop,
     _set_time_or_drop,
     _validate_optional_hex6,
 )
@@ -122,3 +123,21 @@ class TestNeedsPolling(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestSetMarginOrDrop(unittest.TestCase):
+    def test_zero_is_stored(self):
+        m = {}
+        _set_margin_or_drop(m, "end_stop_margin", 0)
+        self.assertEqual(m["end_stop_margin"], "0")
+
+    def test_float_truncates_to_int_string(self):
+        m = {}
+        _set_margin_or_drop(m, "end_stop_margin", 7.9)
+        self.assertEqual(m["end_stop_margin"], "7")
+
+    def test_negative_empty_and_junk_drop(self):
+        for bad in (-1, "", None, "abc"):
+            m = {"end_stop_margin": "3"}
+            _set_margin_or_drop(m, "end_stop_margin", bad)
+            self.assertNotIn("end_stop_margin", m, bad)

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -24,6 +24,7 @@ from custom_components.nikobus.cover import (
     NikobusCFCoverEntity,
     NikobusCoverEntity,
     _parse_cf_time,
+    _parse_end_stop_margin,
     _parse_operation_time,
 )
 from custom_components.nikobus.nkbtravelcalculator import NikobusTravelCalculator
@@ -138,14 +139,14 @@ class TestParseOperationTime(unittest.TestCase):
 # ---------------------------------------------------------------------------
 # NikobusCoverEntity — state machine
 # ---------------------------------------------------------------------------
-def _make_cover(op_up=10.0, op_down=10.0):
+def _make_cover(op_up=10.0, op_down=10.0, margin=3.0):
     coord = MagicMock()
     coord.api.open_cover = AsyncMock()
     coord.api.close_cover = AsyncMock()
     coord.api.stop_cover = AsyncMock()
     coord.set_bytearray_state = MagicMock()
     ent = NikobusCoverEntity(
-        coord, "9105", 1, "Shutter 1", "Roller module", "05-001", op_up, op_down
+        coord, "9105", 1, "Shutter 1", "Roller module", "05-001", op_up, op_down, margin
     )
     ent.hass = MagicMock()
 
@@ -208,13 +209,15 @@ class TestShouldStop(unittest.TestCase):
 
 
 class TestEndsAtEndStop(unittest.TestCase):
-    """A motion ending at 0/100 must NOT send a bus stop frame.
+    """A motion ending at 0/100 sends its stop frame after the end-stop margin.
 
     The position model dead-reckons, so "estimate says 100" doesn't mean
-    the shutter physically arrived. Suppressing the stop lets the motor
-    run into the mechanical limit switch — which erases accumulated
-    drift on every full travel — while the roller module's own run time
-    releases the relay. Only an intermediate target needs a stop frame.
+    the shutter physically arrived. Holding the stop for the margin lets
+    the motor run into the mechanical limit switch — erasing accumulated
+    drift on every full travel — and then releases the relay, so a wall
+    button acts on the first press again. With the default margin equal
+    to the safety buffer the stop goes out the moment the loop ends;
+    a larger margin defers it. Intermediate targets stop immediately.
     """
 
     def test_decision_per_target(self):
@@ -223,29 +226,45 @@ class TestEndsAtEndStop(unittest.TestCase):
             ent._target_position = target
             self.assertEqual(ent._ends_at_end_stop(), expected, target)
 
-    def _finish_motion(self, target):
+    def _finish_motion(self, target, margin=3.0, run_limit=0.0):
         """Run the motion loop with an already-expired run limit / reached
         target and capture the send_stop decision."""
-        ent, _ = _make_cover()
+        ent, _ = _make_cover(margin=margin)
         ent._state = STATE_OPENING
         ent._movement_source = "ha"
         ent._target_position = target
         ent._position = 100.0
         ent._calculator.set_position(100.0)
-        ent._current_run_limit = 0.0
+        ent._current_run_limit = run_limit
         ent._stop = AsyncMock()
         _run(ent._motion_loop())
         ent._stop.assert_awaited_once()
-        return ent._stop.await_args.kwargs["send_stop"]
+        return ent, ent._stop.await_args.kwargs["send_stop"]
 
-    def test_full_open_suppresses_bus_stop(self):
-        self.assertFalse(self._finish_motion(None))
+    def test_full_open_sends_stop_with_default_margin(self):
+        ent, send_stop = self._finish_motion(None)
+        self.assertTrue(send_stop)
+        ent.hass.async_create_task.assert_not_called()
 
-    def test_target_100_suppresses_bus_stop(self):
-        self.assertFalse(self._finish_motion(100))
+    def test_target_100_sends_stop_with_default_margin(self):
+        ent, send_stop = self._finish_motion(100)
+        self.assertTrue(send_stop)
+        ent.hass.async_create_task.assert_not_called()
+
+    def test_larger_margin_defers_the_stop(self):
+        # Run limit 3 s = arrival at 0 s (+ buffer); margin 10 s → the
+        # loop commits STOPPED without a frame and schedules it for later.
+        ent, send_stop = self._finish_motion(None, margin=10.0, run_limit=3.0)
+        self.assertFalse(send_stop)
+        ent.hass.async_create_task.assert_called_once()
+
+    def test_zero_margin_sends_stop_immediately(self):
+        ent, send_stop = self._finish_motion(None, margin=0.0, run_limit=3.0)
+        self.assertTrue(send_stop)
+        ent.hass.async_create_task.assert_not_called()
 
     def test_intermediate_target_still_sends_stop(self):
-        ent, _ = _make_cover()
+        ent, _ = _make_cover(margin=30.0)
         ent._state = STATE_OPENING
         ent._movement_source = "ha"
         ent._target_position = 50
@@ -256,6 +275,7 @@ class TestEndsAtEndStop(unittest.TestCase):
         _run(ent._motion_loop())
         ent._stop.assert_awaited_once()
         self.assertTrue(ent._stop.await_args.kwargs["send_stop"])
+        ent.hass.async_create_task.assert_not_called()
 
     def test_nikobus_sourced_motion_never_sends_stop(self):
         ent, _ = _make_cover()
@@ -268,6 +288,75 @@ class TestEndsAtEndStop(unittest.TestCase):
         ent._stop = AsyncMock()
         _run(ent._motion_loop())
         self.assertFalse(ent._stop.await_args.kwargs["send_stop"])
+        ent.hass.async_create_task.assert_not_called()
+
+
+class TestDeferredEndStop(unittest.TestCase):
+    """The deferred stop frame releases the relay after the margin."""
+
+    def test_deferred_stop_forces_the_frame_after_sleep(self):
+        ent, coord = _make_cover(margin=10.0)
+        ent._state = STATE_STOPPED
+        ent._last_motion_direction = "opening"
+        captured = {}
+
+        def _capture(coro):
+            captured["coro"] = coro
+            return MagicMock()
+
+        ent.hass.async_create_task = MagicMock(side_effect=_capture)
+        ent._schedule_end_stop(7.0)
+        sleep = AsyncMock()
+        with patch("custom_components.nikobus.cover.asyncio.sleep", new=sleep):
+            _run(captured["coro"])
+        sleep.assert_awaited_once_with(7.0)
+        coord.api.stop_cover.assert_awaited_once_with("9105", 1, "opening")
+
+    def test_new_ha_command_cancels_pending_stop(self):
+        ent, coord = _make_cover(margin=10.0)
+        pending = MagicMock()
+        ent._end_stop_task = pending
+        _run(ent._request_move("opening"))
+        pending.cancel.assert_called_once()
+        self.assertIsNone(ent._end_stop_task)
+
+    def test_sent_stop_frame_cancels_pending_stop(self):
+        ent, coord = _make_cover(margin=10.0)
+        pending = MagicMock()
+        ent._end_stop_task = pending
+        ent._state = STATE_OPENING
+        _run(ent._stop(send_stop=True))
+        pending.cancel.assert_called_once()
+        coord.api.stop_cover.assert_awaited_once()
+
+    def test_silent_stop_keeps_pending_stop(self):
+        # A bus poll reporting STOPPED must not drop the frame that
+        # actually releases the relay.
+        ent, _ = _make_cover(margin=10.0)
+        pending = MagicMock()
+        ent._end_stop_task = pending
+        ent._state = STATE_OPENING
+        _run(ent._stop(send_stop=False))
+        pending.cancel.assert_not_called()
+
+    def test_margin_is_a_state_attribute(self):
+        ent, _ = _make_cover(margin=7.0)
+        self.assertEqual(ent.extra_state_attributes["end_stop_margin"], 7.0)
+
+
+class TestParseEndStopMargin(unittest.TestCase):
+    def test_none_uses_fallback(self):
+        self.assertEqual(_parse_end_stop_margin(None, 3.0, "9105"), 3.0)
+
+    def test_zero_is_valid(self):
+        self.assertEqual(_parse_end_stop_margin("0", 3.0, "9105"), 0.0)
+
+    def test_positive_string(self):
+        self.assertEqual(_parse_end_stop_margin("12", 3.0, "9105"), 12.0)
+
+    def test_negative_and_junk_fall_back(self):
+        for bad in ("-1", "abc", object()):
+            self.assertEqual(_parse_end_stop_margin(bad, 3.0, "9105"), 3.0)
 
 
 class TestStop(unittest.TestCase):


### PR DESCRIPTION
## Summary

Answers the community feedback on the 3.14.0 cover behaviour: with no stop frame at fully open/closed, the relay stays engaged until the roller module's own run time expires. Where that run time is longer than the real travel (a common installer setting), a wall button pressed after arrival only stops the relay and a **second press** is needed to move the shutter.

**3.15.5 sends the stop frame again, after an end-stop margin.**

- New per-channel roller setting **End-stop margin (seconds)** under *Customize a module*, default 3 s — the same delay as before 3.14.0 (travel time + safety buffer).
- The stop of an HA-started motion ending at 0/100 goes out `margin` seconds after the estimated arrival. During the margin the motor runs into the limit switch, which keeps erasing the position drift (the 3.14.0 benefit); the relay is then released so the wall button acts on the first press.
- A large margin restores the pure 3.14.0 behaviour for installs that prefer it.
- Intermediate targets, explicit Stop, reversal and wall-button presses during an HA move are unchanged.

## Implementation

- `cover.py`: `_schedule_end_stop()` / `_cancel_end_stop()`; when the margin exceeds the loop's buffer the loop commits STOPPED silently and a deferred task sends the frame (`_stop(send_stop=True, force_api=True)`). A new HA command or an outgoing stop frame drops a pending deferred stop; a silent bus STOPPED does not (that frame is what releases the relay). Margin exposed as the `end_stop_margin` state attribute.
- `config_flow.py`: `end_stop_margin` number field (0–120 s) on roller channels, stored like the travel times; `router.py` / `nkbmanual.py` / `nkbstorage.py` carry the key.
- Translations en/fr/nl, README, changelog, version 3.15.5.

## Tests

New coverage for the loop decision (default margin sends, larger defers, zero sends, intermediate unaffected, Nikobus-sourced never), the deferred frame, the three cancellation rules, the parser and the config-flow helper. Full suite: **580 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_