### PR TITLE
fix(discovery): module status replies no longer start phantom scans (3.15.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.15.6
+
+- **Fix: discovery scans failed on every module since 3.15.0.** The count-driven scan asks each module for its status first. The module's reply is a `$18` frame, and during the module stage the integration still treated any `$18` frame as "a module button was pressed, discover it" — using the byte-swapped wire address. Each real scan therefore spawned a phantom scan of a module that does not exist, whose status query held the command queue for 15 s while the real scan's register reads timed out one after another. Status replies are now ignored in the module stage; the engine already consumes them from its response queue.
+- Ruff findings in the 3.15.5 tests (import order, unused variable).
+
+
 ## 3.15.5
 
 - **Covers: the stop frame at fully open/closed is back, sent after an end-stop margin.** Since 3.14.0 a motion started from Home Assistant that ended at 0 or 100 sent no stop at all and left the relay to the module's own run time. Where that run time is longer than the real travel (a common installer setting) the relay stayed engaged well after the shutter had arrived, and a wall button pressed in that window only stopped the relay — a second press was needed to move the shutter. The stop frame is now sent **End-stop margin** seconds after the estimated arrival (new per-channel setting under *Customize a module*, default 3 s, same as before 3.14.0): the motor still runs into the end stop during the margin, which keeps erasing the position drift, and the relay is released right after, so the wall button acts on the first press. A large margin restores the 3.14.0 behaviour for installs that prefer it.

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -468,8 +468,14 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
             return
         if self.inventory_query_type == InventoryQueryType.PC_LINK:
             self.nikobus_discovery.handle_device_address_inventory(message)
-        else:
-            await self.nikobus_discovery.query_module_inventory(message[3:7])
+            return
+        # Module stage. The only $18 frames here are replies to the
+        # engine's own module-status queries (already consumed from the
+        # response queue) and all-FF trailers. Starting a module
+        # discovery from one — as the legacy "module button pressed"
+        # path did — re-scanned the module under its byte-swapped wire
+        # address and blocked the command queue for the real scan.
+        _LOGGER.debug("Status frame during module scan ignored: %s", message)
 
     async def _discovery_frame_callback(self, message: str) -> None:
         """Route $2E/$1E discovery response frames."""

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -22,5 +22,5 @@
     "pyserial-asyncio-fast>=0.16",
     "nikobus-connect>=0.35.1"
   ],
-  "version": "3.15.5"
+  "version": "3.15.6"
 }

--- a/tests/test_config_flow_helpers.py
+++ b/tests/test_config_flow_helpers.py
@@ -17,8 +17,8 @@ from custom_components.nikobus.config_flow import (
     _module_label,
     _module_type_order,
     _needs_polling,
-    _set_or_drop,
     _set_margin_or_drop,
+    _set_or_drop,
     _set_time_or_drop,
     _validate_optional_hex6,
 )

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -313,7 +313,7 @@ class TestDeferredEndStop(unittest.TestCase):
         coord.api.stop_cover.assert_awaited_once_with("9105", 1, "opening")
 
     def test_new_ha_command_cancels_pending_stop(self):
-        ent, coord = _make_cover(margin=10.0)
+        ent, _ = _make_cover(margin=10.0)
         pending = MagicMock()
         ent._end_stop_task = pending
         _run(ent._request_move("opening"))

--- a/tests/test_programming_entities.py
+++ b/tests/test_programming_entities.py
@@ -157,3 +157,35 @@ class TestStatusFrameOutsideDiscovery(unittest.TestCase):
         coord = NikobusDataCoordinator.__new__(NikobusDataCoordinator)
         coord.nikobus_discovery = MagicMock(spec=[])  # no discovery methods at all
         _run(coord._inventory_callback("$18F58600500F3FFFAC61FE", False))
+
+
+class TestStatusFrameDuringModuleScan(unittest.TestCase):
+    """During the module stage a $18 frame is the module's reply to the
+    engine's own status query. It must not start a discovery for the
+    byte-swapped wire address it carries (phantom module, blocked queue)."""
+
+    def test_module_stage_frame_does_not_start_a_scan(self):
+        from custom_components.nikobus.coordinator import (
+            InventoryQueryType,
+            NikobusDataCoordinator,
+        )
+
+        coord = NikobusDataCoordinator.__new__(NikobusDataCoordinator)
+        coord.nikobus_discovery = MagicMock()
+        coord.nikobus_discovery.query_module_inventory = AsyncMock()
+        coord.inventory_query_type = InventoryQueryType.MODULE
+        _run(coord._inventory_callback("$18F58600500C3FFFF531D1", True))
+        coord.nikobus_discovery.query_module_inventory.assert_not_awaited()
+        coord.nikobus_discovery.handle_device_address_inventory.assert_not_called()
+
+    def test_pc_link_stage_frame_still_feeds_the_inventory(self):
+        from custom_components.nikobus.coordinator import (
+            InventoryQueryType,
+            NikobusDataCoordinator,
+        )
+
+        coord = NikobusDataCoordinator.__new__(NikobusDataCoordinator)
+        coord.nikobus_discovery = MagicMock()
+        coord.inventory_query_type = InventoryQueryType.PC_LINK
+        _run(coord._inventory_callback("$18F58600500F3FFFAC61FE", True))
+        coord.nikobus_discovery.handle_device_address_inventory.assert_called_once()


### PR DESCRIPTION
## Summary

**3.15.6 — discovery scans failed on every module since 3.15.0.**

The count-driven scan asks each module for its status first. The module's reply is a `$18` frame. During the module stage `_inventory_callback` still treated any `$18` frame as the legacy "module button pressed, discover it" trigger, using the byte-swapped wire address (`F586` for module `86F5`). Each real scan therefore spawned a phantom scan of a module that does not exist. The phantom's status query held the command queue for 15 s, so the real scan's register reads timed out one after another, and the phantom's own register scan then interleaved with the real one.

Seen in the log: `$18F58600500C3FFFF531D1` answered by 86F5, immediately followed by `Queueing command $101186F5B64B14` (to `F586`), then `Register scan ACK timeout for module 86F5` on every register.

Fix: `$18` frames in the module stage are ignored (debug log only). The command layer already consumes them from its response queue; the PC-Link inventory stage is unchanged.

Also included: the two Ruff findings left by #494 (test import order, unused unpack).

Tests: new `TestStatusFrameDuringModuleScan` (module-stage frame never starts a scan, PC-Link stage still feeds the inventory). Suite: 582 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj