### PR TITLE
feat: import LED links from the feedback module; backup covers it (3.16.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.16.0
+
+- **New: Import LED links from feedback module.** A bridge button (and `nikobus.import_feedback_leds` action, with an *Overwrite* option) reads the programming of the feedback module (05-207) and fills the LED-on / LED-off trigger address of every output channel with the wall key whose feedback LED tracks it — the addresses you had to look up and type by hand under *Customize a module*. The key is identified from the plate the feedback module names and from the links discovery already knows; a report of the assignments is returned by the action. Typed addresses stay unless Overwrite is on; imported ones are refreshed on every run. Requires `nikobus-connect >= 0.36.0`.
+- **Backup and Verify include the feedback module.** Its image lands in the backup as `<address>_feedback_module.nkm`; the checksum comparison is skipped for it because its coverage is not known yet, and a missing status reply is tolerated.
+- **Fix: cover run times from the module links never matched the stored links.** The lookup expected a flat link shape while discovery stores links as per-module output lists, so every cover fell back to the configured or default time. Now read from the stored shape.
+- **Fix: the PC-Link clock reply appeared as a phantom module** (`F5FF`, carrying the date as its output state) on installs with a feedback module. Fixed in `nikobus-connect 0.36.0`.
+
+
 ## 3.15.6
 
 - **Fix: discovery scans failed on every module since 3.15.0.** The count-driven scan asks each module for its status first. The module's reply is a `$18` frame, and during the module stage the integration still treated any `$18` frame as "a module button was pressed, discover it" — using the byte-swapped wire address. Each real scan therefore spawned a phantom scan of a module that does not exist, whose status query held the command queue for 15 s while the real scan's register reads timed out one after another. Status replies are now ignored in the module stage; the engine already consumes them from its response queue.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Press **3. Import Names from .nkb** to apply the friendly names, rooms, and scen
 - **Description** → the entity name.
 - **Entity type** → how HA exposes it (switch modules: `switch`/`light`/`none`; dimmers: `light`/`none`; rollers: `cover`/`switch`/`light`/`none`).
 - **LED on / off addresses** → feedback-LED bus addresses (blank if unused).
+  With a feedback module (05-207) on the bus, press **Import LED links from feedback module** on the Nikobus Bridge (or call `nikobus.import_feedback_leds`) and these are filled in from the module's own programming; addresses you typed stay unless you choose Overwrite.
 - **Travel time up / down** (rollers) → seconds to open/close, used by the position calculator.
 - **End-stop margin** (rollers) → seconds after the estimated arrival at fully open/closed before a Home Assistant-started motion sends its stop frame (default 3). The motor runs into the end stop during the margin, which keeps the position model honest; the stop then releases the relay so a wall button acts on the first press. Set it higher to let the module's own run time release the relay instead.
 

--- a/custom_components/nikobus/__init__.py
+++ b/custom_components/nikobus/__init__.py
@@ -52,6 +52,7 @@ SERVICE_PURGE_STALE_INVENTORY: Final = "purge_stale_inventory"
 SERVICE_SYNC_PC_LINK_CLOCK: Final = "sync_pc_link_clock"
 SERVICE_VERIFY_MODULES: Final = "verify_modules"
 SERVICE_BACKUP_MODULES: Final = "backup_modules"
+SERVICE_IMPORT_FEEDBACK_LEDS: Final = "import_feedback_leds"
 
 # Optional module-address list shared by the programming actions; empty
 # means every output module.
@@ -374,6 +375,20 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         SERVICE_BACKUP_MODULES,
         handle_backup_modules,
         MODULE_LIST_SCHEMA,
+        supports_response=SupportsResponse.OPTIONAL,
+    )
+
+    async def handle_import_feedback_leds(call: ServiceCall) -> dict[str, Any]:
+        """Fill the channels' LED trigger addresses from the feedback module."""
+        return await _programming(call).async_import_feedback_leds(
+            overwrite=bool(call.data.get("overwrite", False))
+        )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_IMPORT_FEEDBACK_LEDS,
+        handle_import_feedback_leds,
+        vol.Schema({vol.Optional("overwrite", default=False): cv.boolean}),
         supports_response=SupportsResponse.OPTIONAL,
     )
     return True

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -57,6 +57,7 @@ async def async_setup_entry(
         NikobusSyncClockButton(coordinator),
         NikobusVerifyProgrammingButton(coordinator),
         NikobusBackupProgrammingButton(coordinator),
+        NikobusImportFeedbackLedsButton(coordinator),
     ]
 
     buttons = (coordinator.dict_button_data or {}).get("nikobus_button", {})
@@ -770,4 +771,27 @@ class NikobusBackupProgrammingButton(_NikobusMaintenanceButton):
         self._start(
             self._coordinator.programming.async_backup_modules(),
             "nikobus_backup_programming",
+        )
+
+
+class NikobusImportFeedbackLedsButton(_NikobusMaintenanceButton):
+    """Fill the channels' LED trigger addresses from the feedback module."""
+
+    _attr_translation_key = "import_feedback_leds"
+
+    def __init__(self, coordinator: NikobusDataCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{DOMAIN}_import_feedback_leds_button"
+
+    @property
+    def available(self) -> bool:
+        programming = getattr(self._coordinator, "programming", None)
+        has_module = bool(programming and programming.feedback_modules())
+        return has_module and super().available
+
+    async def async_press(self) -> None:
+        _LOGGER.info("Feedback LED import triggered via UI button")
+        self._start(
+            self._coordinator.programming.async_import_feedback_leds(),
+            "nikobus_import_feedback_leds",
         )

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -1461,6 +1461,7 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
         known.add(f"{DOMAIN}_sync_pc_link_clock_button")
         known.add(f"{DOMAIN}_verify_programming_button")
         known.add(f"{DOMAIN}_backup_programming_button")
+        known.add(f"{DOMAIN}_import_feedback_leds_button")
         return known
 
     def _rebuild_dict_module_data(self) -> None:

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -20,7 +20,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.35.1"
+    "nikobus-connect>=0.36.0"
   ],
-  "version": "3.15.6"
+  "version": "3.16.0"
 }

--- a/custom_components/nikobus/nkbprogramming.py
+++ b/custom_components/nikobus/nkbprogramming.py
@@ -22,7 +22,13 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.util import dt as dt_util
-from nikobus_connect.api import MODULE_IMAGE_SIZES
+from nikobus_connect.api import MODULE_CRC_UNKNOWN, MODULE_IMAGE_SIZES
+from nikobus_connect.discovery.feedback_decoder import (
+    FeedbackImage,
+    FeedbackLed,
+    decode_feedback_image,
+)
+from nikobus_connect.discovery.fileio import find_module
 
 from .const import (
     DOMAIN,
@@ -35,6 +41,17 @@ from .router import iter_operation_points
 _LOGGER = logging.getLogger(__name__)
 
 BACKUP_DIR = "nikobus_backup"
+LED_SOURCE_FEEDBACK = "feedback_module"
+
+# Row order of the LED slots inside one push-button module group, by
+# number of keys on the plate (the order the Nikobus application lists
+# them). Used only when the link table cannot single out the key.
+_LED_ROW_KEYS: dict[int, tuple[str, ...]] = {
+    1: ("1A",),
+    2: ("1B", "1A"),
+    4: ("1D", "1C", "1B", "1A"),
+    8: ("2D", "2C", "2B", "2A", "1D", "1C", "1B", "1A"),
+}
 
 HEALTH_OK = "ok"
 HEALTH_PROBLEM = "problem"
@@ -85,20 +102,44 @@ def link_run_time(
     best: float | None = None
     buttons = (button_data or {}).get("nikobus_button") or {}
     for _addr, _key, op_point, _ in iter_operation_points(buttons):
-        for link in op_point.get("linked_modules") or []:
-            if not isinstance(link, dict):
+        for module_address_, channel_, output in iter_link_outputs(op_point):
+            if module_address_ != target or channel_ != channel:
                 continue
-            if str(link.get("module_address") or "").upper() != target:
-                continue
-            if link.get("channel") != channel:
-                continue
-            mode = str(link.get("mode") or "")
+            mode = str(output.get("mode") or "")
             if not mode.startswith(modes):
                 continue
-            seconds = parse_run_time_label(link.get("t1"))
+            seconds = parse_run_time_label(output.get("t1"))
             if seconds is not None and (best is None or seconds > best):
                 best = seconds
     return best
+
+
+def iter_link_outputs(op_point: dict[str, Any]) -> list[tuple[str, int, dict[str, Any]]]:
+    """``(module_address, channel, output)`` for every link of an op-point.
+
+    Discovery stores ``linked_modules`` as ``[{module_address, outputs:
+    [{channel, mode, t1, t2}]}]``; a flat ``{module_address, channel,
+    mode, t1}`` entry is accepted as well.
+    """
+    found: list[tuple[str, int, dict[str, Any]]] = []
+    for link in op_point.get("linked_modules") or []:
+        if not isinstance(link, dict):
+            continue
+        module_address = str(link.get("module_address") or "").upper()
+        if not module_address:
+            continue
+        outputs = link.get("outputs")
+        if isinstance(outputs, list):
+            candidates = [out for out in outputs if isinstance(out, dict)]
+        else:
+            candidates = [link]
+        for out in candidates:
+            try:
+                channel = int(out.get("channel"))
+            except (TypeError, ValueError):
+                continue
+            found.append((module_address, channel, out))
+    return found
 
 
 @dataclass
@@ -266,20 +307,31 @@ class NikobusProgramming:
     ) -> tuple[ModuleCheck, bytes | None]:
         check = ModuleCheck(address, module_type, description)
         data: bytes | None = None
+        crc_unknown = module_type in MODULE_CRC_UNKNOWN
         try:
-            status = await api.get_module_status(address)
-            check.eeprom_error = status.eeprom_error
-            check.record_count_a = status.record_count_a
-            # 0xFF = "no second table" on switch / roller modules.
-            check.record_count_b = (
-                None if status.record_count_b == 0xFF else status.record_count_b
-            )
+            try:
+                status = await api.get_module_status(address)
+            except Exception:
+                # A module whose CRC coverage is unknown may not answer
+                # the status query either; its image is still worth
+                # reading. Every other module must answer.
+                if not crc_unknown:
+                    raise
+                _LOGGER.debug("Module %s did not answer the status query", address)
+            else:
+                check.eeprom_error = status.eeprom_error
+                check.record_count_a = status.record_count_a
+                # 0xFF = "no second table" on switch / roller modules.
+                check.record_count_b = (
+                    None if status.record_count_b == 0xFF else status.record_count_b
+                )
             if image:
                 data = await api.read_module_memory(address, module_type)
                 check.image_bytes = len(data)
-                check.crc_ok, check.module_crc, check.computed_crc = (
-                    await api.verify_module_memory(address, module_type, data)
-                )
+                if not crc_unknown:
+                    check.crc_ok, check.module_crc, check.computed_crc = (
+                        await api.verify_module_memory(address, module_type, data)
+                    )
         except Exception as err:  # noqa: BLE001 - one module's failure must not abort the run
             check.error = str(err) or err.__class__.__name__
             _LOGGER.warning("Programming check of module %s failed: %s", address, check.error)
@@ -376,6 +428,179 @@ class NikobusProgramming:
             self._coordinator.async_update_listeners()
         _LOGGER.info("Nikobus programming backup written to %s (%d image(s))", folder, len(images))
         return {"path": str(folder), "images": sorted(images), **summary}
+
+
+    # -- feedback module LED links -------------------------------------------
+
+    def feedback_modules(self) -> list[tuple[str, str]]:
+        """``(address, description)`` of every feedback module (05-207)."""
+        return [
+            (address, str(entry.get("description") or address))
+            for address, module_type, entry in self._modules()
+            if module_type == LED_SOURCE_FEEDBACK
+        ]
+
+    async def async_import_feedback_leds(self, *, overwrite: bool = False) -> dict[str, Any]:
+        """Fill the channels' LED trigger addresses from the feedback module.
+
+        Reads the feedback module's programming, resolves every LED slot
+        to the wall key that carries it and writes that key's bus
+        address as ``led_on`` / ``led_off`` of each output the LED
+        tracks. Values typed by the user stay unless ``overwrite`` is
+        set; values from an earlier import are always refreshed.
+        """
+        self._acquire()
+        api = self._api()
+        modules = self.feedback_modules()
+        if not modules:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="no_feedback_module"
+            )
+        self._set_running(True)
+        try:
+            async with self._lock:
+                report: dict[str, Any] = {
+                    "feedback_modules": [address for address, _ in modules],
+                    "leds": 0,
+                    "resolved": 0,
+                    "channels_updated": 0,
+                    "channels_kept": 0,
+                    "unresolved": [],
+                    "assignments": [],
+                }
+                for address, _description in modules:
+                    image = await api.read_module_memory(address, LED_SOURCE_FEEDBACK)
+                    decoded = decode_feedback_image(image)
+                    self._apply_feedback_leds(decoded, report, overwrite=overwrite)
+                if report["channels_updated"]:
+                    await self._coordinator.async_on_module_save()
+        finally:
+            self._set_running(False)
+            self._coordinator.async_update_listeners()
+        _LOGGER.info(
+            "Feedback LED import: %d LED(s), %d resolved, %d channel(s) updated, %d kept",
+            report["leds"], report["resolved"], report["channels_updated"], report["channels_kept"],
+        )
+        return report
+
+    def _apply_feedback_leds(
+        self, decoded: FeedbackImage, report: dict[str, Any], *, overwrite: bool
+    ) -> None:
+        buttons = (self._coordinator.dict_button_data or {}).get("nikobus_button") or {}
+        for led in decoded.leds:
+            tracked = [
+                (item.output.module_address.upper(), item.output.channel)
+                for item in led.outputs
+                if item.output is not None
+            ]
+            if not tracked:
+                continue
+            report["leds"] += 1
+            resolved = resolve_feedback_led(led, tracked, buttons)
+            if resolved is None:
+                report["unresolved"].append(
+                    {"slot": led.slot, "plates": list(led.plate_addresses), "outputs": tracked}
+                )
+                continue
+            plate, key_label, bus_address = resolved
+            report["resolved"] += 1
+            for module_address, channel in tracked:
+                outcome = self._set_channel_led(module_address, channel, bus_address, overwrite)
+                if outcome is None:
+                    continue
+                report["channels_updated" if outcome else "channels_kept"] += 1
+                report["assignments"].append(
+                    {
+                        "module_address": module_address,
+                        "channel": channel,
+                        "plate": plate,
+                        "key": key_label,
+                        "bus_address": bus_address,
+                        "updated": outcome,
+                    }
+                )
+
+    def _set_channel_led(
+        self, module_address: str, channel: int, bus_address: str, overwrite: bool
+    ) -> bool | None:
+        """Write ``led_on``/``led_off`` on one channel.
+
+        Returns ``True`` when written, ``False`` when an existing value was
+        kept, ``None`` when the module or channel is unknown.
+        """
+        hit = find_module(self._coordinator.module_storage.data, module_address)
+        if hit is None:
+            return None
+        channels = hit[1].get("channels")
+        if not isinstance(channels, list) or not 1 <= channel <= len(channels):
+            return None
+        entry = channels[channel - 1]
+        if not isinstance(entry, dict):
+            return None
+        existing = entry.get("led_on") or entry.get("led_off")
+        imported = entry.get("led_source") == LED_SOURCE_FEEDBACK
+        if existing and not (overwrite or imported):
+            return False
+        if existing == bus_address and entry.get("led_off") == bus_address and imported:
+            return False
+        entry["led_on"] = bus_address
+        entry["led_off"] = bus_address
+        entry["led_source"] = LED_SOURCE_FEEDBACK
+        return True
+
+
+def resolve_feedback_led(
+    led: FeedbackLed,
+    tracked: list[tuple[str, int]],
+    buttons: dict[str, Any],
+) -> tuple[str, str, str] | None:
+    """Find the wall key behind an LED slot: ``(plate, key_label, bus_address)``.
+
+    The plate is the group's module address (either bit-0 variant that
+    exists in the button store). Among its keys, the one whose links
+    drive an output the LED tracks is the LED's key — a feedback LED
+    normally sits on the key that switches the light. When the links
+    do not single one out, the slot's row inside the group decides.
+    """
+    plate_entry: dict[str, Any] | None = None
+    plate = ""
+    for candidate in led.plate_addresses:
+        entry = buttons.get(candidate) or buttons.get(candidate.lower())
+        if isinstance(entry, dict):
+            plate_entry, plate = entry, candidate
+            break
+    if plate_entry is None:
+        return None
+    op_points = plate_entry.get("operation_points")
+    if not isinstance(op_points, dict):
+        return None
+    keys: dict[str, str] = {}
+    matching: list[str] = []
+    for key_label, op_point in op_points.items():
+        if not isinstance(op_point, dict) or str(key_label).startswith("IR:"):
+            continue
+        bus_address = str(op_point.get("bus_address") or "").upper()
+        if not bus_address:
+            continue
+        keys[str(key_label)] = bus_address
+        links = {(addr, chan) for addr, chan, _ in iter_link_outputs(op_point)}
+        if any(target in links for target in tracked):
+            matching.append(str(key_label))
+    if not keys:
+        return None
+    guess: str | None = None
+    rows = _LED_ROW_KEYS.get(len(keys))
+    if rows is not None and led.row is not None and led.row < len(rows):
+        guess = rows[led.row]
+    if len(matching) == 1:
+        chosen = matching[0]
+    elif matching:
+        chosen = guess if guess in matching else matching[0]
+    elif guess in keys:
+        chosen = guess
+    else:
+        return None
+    return plate, chosen, keys[chosen]
 
 
 def _write_backup(folder: Path, images: dict[str, bytes], summary: dict[str, Any]) -> None:

--- a/custom_components/nikobus/services.yaml
+++ b/custom_components/nikobus/services.yaml
@@ -84,3 +84,11 @@ backup_modules:
       required: false
       selector:
         object:
+
+import_feedback_leds:
+  fields:
+    overwrite:
+      required: false
+      default: false
+      selector:
+        boolean:

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -79,6 +79,9 @@
       },
       "backup_module_programming": {
         "name": "Backup module programming"
+      },
+      "import_feedback_leds": {
+        "name": "Import LED links from feedback module"
       }
     },
     "sensor": {
@@ -207,6 +210,9 @@
     },
     "no_pc_link_known": {
       "message": "No PC-Link is known yet — run **1. Load Project Overview** first."
+    },
+    "no_feedback_module": {
+      "message": "No feedback module (05-207) is known — run **1. Load Project Overview** first, or enable the feedback module in the integration options."
     }
   },
   "options": {
@@ -420,6 +426,16 @@
         "addresses": {
           "name": "Module addresses",
           "description": "Optional list of module addresses to limit the run to (for example ['9105', '4707']). Empty means every switch, dimmer and roller module."
+        }
+      }
+    },
+    "import_feedback_leds": {
+      "name": "Import LED links from feedback module",
+      "description": "Reads the feedback module's programming and fills the LED-on / LED-off trigger address of every output channel with the wall key whose LED tracks it. Addresses you typed yourself are kept unless Overwrite is on; addresses from an earlier import are refreshed.",
+      "fields": {
+        "overwrite": {
+          "name": "Overwrite",
+          "description": "Also replace LED addresses that were set by hand."
         }
       }
     }

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -246,6 +246,9 @@
       },
       "backup_module_programming": {
         "name": "Sauvegarder la programmation des modules"
+      },
+      "import_feedback_leds": {
+        "name": "Importer les liens LED du module de feedback"
       }
     }
   },
@@ -340,6 +343,9 @@
     },
     "no_pc_link_known": {
       "message": "Aucun PC-Link n'est encore connu — lancez d'abord **1. Charger la vue d'ensemble du projet**."
+    },
+    "no_feedback_module": {
+      "message": "Aucun module de feedback (05-207) n'est connu — lancez d'abord **1. Charger la vue d'ensemble du projet**, ou activez le module de feedback dans les options de l'intégration."
     }
   },
   "selector": {
@@ -459,6 +465,16 @@
         "addresses": {
           "name": "Adresses des modules",
           "description": "Liste facultative d'adresses de modules pour limiter l'opération (par exemple ['9105', '4707']). Vide = tous les modules de commutation, variation et volets."
+        }
+      }
+    },
+    "import_feedback_leds": {
+      "name": "Importer les liens LED du module de feedback",
+      "description": "Lit la programmation du module de feedback et remplit l'adresse de déclenchement LED allumée / LED éteinte de chaque canal de sortie avec la touche murale dont la LED le suit. Les adresses saisies à la main sont conservées sauf si Écraser est activé ; celles d'un import précédent sont rafraîchies.",
+      "fields": {
+        "overwrite": {
+          "name": "Écraser",
+          "description": "Remplacer aussi les adresses LED saisies à la main."
         }
       }
     }

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -246,6 +246,9 @@
       },
       "backup_module_programming": {
         "name": "Moduleprogrammering back-uppen"
+      },
+      "import_feedback_leds": {
+        "name": "LED-koppelingen importeren uit feedbackmodule"
       }
     }
   },
@@ -340,6 +343,9 @@
     },
     "no_pc_link_known": {
       "message": "Er is nog geen PC-Link bekend — voer eerst **1. Projectoverzicht laden** uit."
+    },
+    "no_feedback_module": {
+      "message": "Er is geen feedbackmodule (05-207) bekend — voer eerst **1. Projectoverzicht laden** uit, of schakel de feedbackmodule in bij de integratie-opties."
     }
   },
   "selector": {
@@ -459,6 +465,16 @@
         "addresses": {
           "name": "Moduleadressen",
           "description": "Optionele lijst van moduleadressen om de actie te beperken (bijvoorbeeld ['9105', '4707']). Leeg betekent alle schakel-, dim- en rolluikmodules."
+        }
+      }
+    },
+    "import_feedback_leds": {
+      "name": "LED-koppelingen importeren uit feedbackmodule",
+      "description": "Leest de programmering van de feedbackmodule en vult het LED-aan / LED-uit triggeradres van elk uitgangskanaal in met de wandtoets waarvan de LED het volgt. Handmatig ingevulde adressen blijven staan tenzij Overschrijven aan staat; adressen van een eerdere import worden vernieuwd.",
+      "fields": {
+        "overwrite": {
+          "name": "Overschrijven",
+          "description": "Ook handmatig ingestelde LED-adressen vervangen."
         }
       }
     }

--- a/tests/test_programming.py
+++ b/tests/test_programming.py
@@ -13,13 +13,24 @@ from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.exceptions import HomeAssistantError
 
+from nikobus_connect.discovery.feedback_decoder import (
+    FEEDBACK_IMAGE_SIZE,
+    LED_MODE_TABLE_OFFSET,
+    REGION_GROUP_ADDRESSES,
+    REGION_LED_LISTS,
+    REGION_OUTPUT_MODULES,
+    decode_feedback_image,
+)
+
 from custom_components.nikobus.nkbprogramming import (
     HEALTH_OK,
     HEALTH_PROBLEM,
     HEALTH_UNKNOWN,
+    LED_SOURCE_FEEDBACK,
     NikobusProgramming,
     link_run_time,
     parse_run_time_label,
+    resolve_feedback_led,
 )
 
 
@@ -189,6 +200,179 @@ class TestVerifyAndBackup(unittest.TestCase):
         prog = NikobusProgramming(_hass("/tmp"), coord)
         with self.assertRaises(HomeAssistantError):
             _run(prog.async_verify_modules())
+
+
+class TestLinkRunTimeStoredShape(unittest.TestCase):
+    """Discovery stores links as ``{module_address, outputs: [...]}``."""
+
+    def test_reads_outputs_list(self):
+        buttons = {
+            "nikobus_button": {
+                "1A2B3C": {
+                    "operation_points": {
+                        "1A": {
+                            "bus_address": "081032",
+                            "linked_modules": [
+                                {
+                                    "module_address": "9105",
+                                    "outputs": [
+                                        {"channel": 2, "mode": "M02 (Open)", "t1": "20 s"},
+                                        {"channel": 2, "mode": "M03 (Close)", "t1": "35 s"},
+                                    ],
+                                }
+                            ],
+                        }
+                    }
+                }
+            }
+        }
+        self.assertEqual(link_run_time(buttons, "9105", 2, "up"), 20.0)
+        self.assertEqual(link_run_time(buttons, "9105", 2, "down"), 35.0)
+
+
+def _feedback_image() -> bytes:
+    """Plate 1843B4 (4 keys, group 0): slot 0 tracks 5B05 ch 1, slot 3
+    tracks 5B05 ch 6 and dimmer 0E6C ch 2; own LED 1 tracks 0E6C ch 2."""
+    img = bytearray(b"\xff" * FEEDBACK_IMAGE_SIZE)
+    base = REGION_OUTPUT_MODULES[0]
+    img[base : base + 8] = bytes([1, 0x5B, 0x05, 0, 0x00, 0x21, 0xFF, 0xFF])
+    img[base + 8 : base + 16] = bytes([3, 0x0E, 0x6C, 0, 0x00, 0x02, 0xFF, 0xFF])
+    grp = REGION_GROUP_ADDRESSES[0]
+    img[grp : grp + 3] = bytes([0x06, 0x10, 0xEC])  # 1843B4 with bit 0 cleared
+    lists = REGION_LED_LISTS[0]
+    stream = bytes(
+        [0x00, 0x00, 0x04, 0x00, 0x00, 0x01, 0x00, 0x02, 0x04, 0x03, 0x00, 0x02, 0x04, 0xC0]
+    )
+    img[lists : lists + len(stream)] = stream
+    img[LED_MODE_TABLE_OFFSET] = 0
+    img[LED_MODE_TABLE_OFFSET + 3] = 0
+    return bytes(img)
+
+
+def _plate(links: dict[str, list[tuple[str, int]]]) -> dict:
+    """Plate 1843B4 with its four real key addresses and the given links."""
+    addresses = {"1A": "8B7086", "1B": "CB7086", "1C": "0B7086", "1D": "4B7086"}
+    return {
+        "1843B4": {
+            "type": "Button",
+            "operation_points": {
+                key: {
+                    "bus_address": addr,
+                    "linked_modules": [
+                        {"module_address": m, "outputs": [{"channel": c, "mode": "M01 (On / off)"}]}
+                        for m, c in links.get(key, [])
+                    ],
+                }
+                for key, addr in addresses.items()
+            },
+        }
+    }
+
+
+class TestResolveFeedbackLed(unittest.TestCase):
+    def _led(self, slot):
+        decoded = decode_feedback_image(_feedback_image())
+        return next(led for led in decoded.leds if led.slot == slot)
+
+    def test_links_single_out_the_key(self):
+        buttons = _plate({"1A": [("5B05", 1)], "1B": [("5B05", 6)]})
+        self.assertEqual(
+            resolve_feedback_led(self._led(0), [("5B05", 1)], buttons),
+            ("1843B4", "1A", "8B7086"),
+        )
+        self.assertEqual(
+            resolve_feedback_led(self._led(3), [("5B05", 6), ("0E6C", 2)], buttons),
+            ("1843B4", "1B", "CB7086"),
+        )
+
+    def test_row_order_decides_without_links(self):
+        buttons = _plate({})
+        # slot 0 = row 0 = 1D on a 4-key plate, slot 3 = 1A
+        self.assertEqual(resolve_feedback_led(self._led(0), [("5B05", 1)], buttons)[1], "1D")
+        self.assertEqual(resolve_feedback_led(self._led(3), [("5B05", 6)], buttons)[1], "1A")
+
+    def test_unknown_plate_is_unresolved(self):
+        self.assertIsNone(resolve_feedback_led(self._led(0), [("5B05", 1)], {}))
+
+
+def _import_coordinator(api, channels_5b05=None, links=None):
+    coord = _coordinator(
+        modules={
+            "switch_module": {"5B05": {"module_type": "switch_module", "description": "S2"}},
+            "dimmer_module": {"0E6C": {"module_type": "dimmer_module", "description": "D1"}},
+            "feedback_module": {"966C": {"module_type": "feedback_module", "description": "FB"}},
+        },
+        api=api,
+    )
+    coord.dict_button_data = {"nikobus_button": _plate(links or {"1A": [("5B05", 1)], "1B": [("5B05", 6)]})}
+    coord.module_storage = SimpleNamespace(
+        data={
+            "nikobus_module": {
+                "5B05": {
+                    "module_type": "switch_module",
+                    "channels": channels_5b05
+                    or [{"description": f"out {i}"} for i in range(1, 13)],
+                },
+                "0E6C": {"module_type": "dimmer_module", "channels": [{"description": f"d {i}"} for i in range(1, 13)]},
+            }
+        }
+    )
+    coord.async_on_module_save = AsyncMock()
+    return coord
+
+
+class TestImportFeedbackLeds(unittest.TestCase):
+    def test_fills_led_addresses_and_saves(self):
+        api = _api()
+        api.read_module_memory = AsyncMock(return_value=_feedback_image())
+        coord = _import_coordinator(api)
+        prog = NikobusProgramming(_hass("/tmp"), coord)
+        report = _run(prog.async_import_feedback_leds())
+        api.read_module_memory.assert_awaited_once_with("966C", "feedback_module")
+        self.assertEqual((report["leds"], report["resolved"]), (3, 2))  # own LED has no plate
+        self.assertEqual(report["channels_updated"], 3)
+        ch = coord.module_storage.data["nikobus_module"]["5B05"]["channels"]
+        self.assertEqual((ch[0]["led_on"], ch[0]["led_off"], ch[0]["led_source"]), ("8B7086", "8B7086", LED_SOURCE_FEEDBACK))
+        self.assertEqual(ch[5]["led_on"], "CB7086")
+        dimmer = coord.module_storage.data["nikobus_module"]["0E6C"]["channels"]
+        self.assertEqual(dimmer[1]["led_on"], "CB7086")
+        coord.async_on_module_save.assert_awaited_once()
+        self.assertEqual(len(report["unresolved"]), 1)  # the module's own LED
+        self.assertFalse(prog.running)
+
+    def test_keeps_typed_addresses_unless_overwrite(self):
+        api = _api()
+        api.read_module_memory = AsyncMock(return_value=_feedback_image())
+        channels = [{"description": f"out {i}"} for i in range(1, 13)]
+        channels[0]["led_on"] = "AAAAAA"
+        coord = _import_coordinator(api, channels_5b05=channels)
+        prog = NikobusProgramming(_hass("/tmp"), coord)
+        report = _run(prog.async_import_feedback_leds())
+        self.assertEqual(channels[0]["led_on"], "AAAAAA")
+        self.assertEqual(report["channels_kept"], 1)
+        report = _run(prog.async_import_feedback_leds(overwrite=True))
+        self.assertEqual(channels[0]["led_on"], "8B7086")
+        # The two channels imported on the first run already hold the
+        # address: unchanged, so counted as kept.
+        self.assertEqual((report["channels_updated"], report["channels_kept"]), (1, 2))
+
+    def test_without_feedback_module_raises(self):
+        prog = NikobusProgramming(_hass("/tmp"), _coordinator(api=_api()))
+        with self.assertRaises(HomeAssistantError):
+            _run(prog.async_import_feedback_leds())
+
+    def test_backup_includes_feedback_module_without_crc(self):
+        api = _api()
+        api.get_module_status = AsyncMock(side_effect=RuntimeError("no answer"))
+        coord = _import_coordinator(api)
+        with TemporaryDirectory() as tmp:
+            prog = NikobusProgramming(_hass(tmp), coord)
+            result = _run(prog.async_backup_modules(["966C"]))
+            self.assertIn("966C_feedback_module.nkm", result["images"])
+            check = result["modules"]["966C"]
+            self.assertIsNone(check["crc_ok"])
+            self.assertIsNone(check["error"])
+            api.verify_module_memory.assert_not_awaited()
 
 
 if __name__ == "__main__":

--- a/tests/test_programming.py
+++ b/tests/test_programming.py
@@ -12,7 +12,6 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.exceptions import HomeAssistantError
-
 from nikobus_connect.discovery.feedback_decoder import (
     FEEDBACK_IMAGE_SIZE,
     LED_MODE_TABLE_OFFSET,

--- a/tests/test_programming_entities.py
+++ b/tests/test_programming_entities.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 from custom_components.nikobus.button import (
     NikobusBackupProgrammingButton,
+    NikobusImportFeedbackLedsButton,
     NikobusSyncClockButton,
     NikobusVerifyProgrammingButton,
 )
@@ -28,9 +29,11 @@ def _run(coro):
         loop.close()
 
 
-def _coordinator(pc_link="86F5", running=False, discovery_running=False):
+def _coordinator(pc_link="86F5", running=False, discovery_running=False, feedback=("966C",)):
     programming = SimpleNamespace(
         pc_link_address=lambda: pc_link,
+        feedback_modules=lambda: [(a, a) for a in feedback],
+        async_import_feedback_leds=AsyncMock(),
         clock=None,
         clock_read_at=None,
         clock_drift_seconds=None,
@@ -79,10 +82,19 @@ class TestMaintenanceButtons(unittest.TestCase):
     def test_availability_gating(self):
         # One bridge action at a time: every bridge button greys out
         # while discovery or a maintenance run is busy.
-        for cls in (NikobusVerifyProgrammingButton, NikobusSyncClockButton, NikobusBackupProgrammingButton):
+        for cls in (
+            NikobusVerifyProgrammingButton,
+            NikobusSyncClockButton,
+            NikobusBackupProgrammingButton,
+            NikobusImportFeedbackLedsButton,
+        ):
             self.assertTrue(cls(_coordinator()).available, cls.__name__)
             self.assertFalse(cls(_coordinator(running=True)).available, cls.__name__)
             self.assertFalse(cls(_coordinator(discovery_running=True)).available, cls.__name__)
+
+    def test_led_import_needs_a_feedback_module(self):
+        self.assertFalse(NikobusImportFeedbackLedsButton(_coordinator(feedback=())).available)
+        self.assertTrue(NikobusImportFeedbackLedsButton(_coordinator()).available)
 
     def test_sync_button_awaits_sync(self):
         coord = _coordinator()
@@ -94,6 +106,7 @@ class TestMaintenanceButtons(unittest.TestCase):
         for cls, method in (
             (NikobusVerifyProgrammingButton, "async_verify_modules"),
             (NikobusBackupProgrammingButton, "async_backup_modules"),
+            (NikobusImportFeedbackLedsButton, "async_import_feedback_leds"),
         ):
             button = cls(coord)
             button.hass = MagicMock()
@@ -138,6 +151,7 @@ class TestHubEntitiesSurviveOrphanCleanup(unittest.TestCase):
             NikobusSyncClockButton(fake),
             NikobusVerifyProgrammingButton(fake),
             NikobusBackupProgrammingButton(fake),
+            NikobusImportFeedbackLedsButton(fake),
         ]
         health = NikobusProgrammingHealthSensor.__new__(NikobusProgrammingHealthSensor)
         health._attr_unique_id = f"{DOMAIN}_programming_health"


### PR DESCRIPTION
## Summary

**3.16.0 — the LED feedback addresses come from the feedback module's own programming.**

- **New: Import LED links from feedback module.** Bridge button and `nikobus.import_feedback_leds` action (with an *Overwrite* option). Reads the 05-207's programming, resolves every LED slot to the wall key behind it and writes that key's bus address as `led_on` / `led_off` of every output the LED tracks — the values users had to look up and type under *Customize a module*. Resolution: the plate comes from the module's group table (both bit-0 variants are tried against the button store), the key from the discovered links (the key whose LED tracks an output normally drives it); the slot's row inside the group decides when links do not single one out. Typed addresses stay unless Overwrite; imported ones (`led_source: feedback_module`) are refreshed. The action returns a report with every assignment and the unresolved slots.
- **Backup and Verify include the feedback module** (`<address>_feedback_module.nkm`). Its CRC coverage is not known, so the checksum comparison is skipped and a missing status reply is tolerated — this is also the first read of a 05-207 over the bus, so the backup doubles as the hardware test.
- **Fix: cover run times from module links never matched.** `link_run_time` expected a flat `{module_address, channel, ...}` link while discovery stores `{module_address, outputs: [...]}`; every cover silently fell back to the configured/default time. Shared `iter_link_outputs()` now walks the stored shape (flat accepted too).
- **Fix: phantom module `F5FF`** (the PC-Link clock reply filed as an output state) — fixed in nikobus-connect 0.36.0.

Requires **nikobus-connect 0.36.0** (fdebrus/nikobus-connect#136) — release it first; CI installs the library from PyPI and is red until then.

Tests: resolution by links / by row order / unknown plate, end-to-end import (fill, keep typed, overwrite, save), backup of the feedback module without CRC, the stored link shape, button availability and known ids. Suite: 591 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_