### PR TITLE
chore: 3.16.1 — feedback module read via link mode (nikobus-connect 0.36.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.16.1
+
+- **Feedback module read works through link mode.** On a real 05-207 the status query is answered but block reads are ignored, so 3.16.0's Backup and LED import stopped at the first block. `nikobus-connect 0.36.1` (required) retries the read in link mode, the mode the module is programmed in, and leaves it again in every case. Link mode changes no programming.
+
+
 ## 3.16.0
 
 - **New: Import LED links from feedback module.** A bridge button (and `nikobus.import_feedback_leds` action, with an *Overwrite* option) reads the programming of the feedback module (05-207) and fills the LED-on / LED-off trigger address of every output channel with the wall key whose feedback LED tracks it — the addresses you had to look up and type by hand under *Customize a module*. The key is identified from the plate the feedback module names and from the links discovery already knows; a report of the assignments is returned by the action. Typed addresses stay unless Overwrite is on; imported ones are refreshed on every run. Requires `nikobus-connect >= 0.36.0`.

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -20,7 +20,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.36.0"
+    "nikobus-connect>=0.36.1"
   ],
-  "version": "3.16.0"
+  "version": "3.16.1"
 }


### PR DESCRIPTION
## Summary

3.16.1 — requirement bump to **nikobus-connect 0.36.1** (fdebrus/nikobus-connect#137) plus changelog. No integration code changes.

On a real 05-207 the status query is answered but block reads are ignored, so 3.16.0's Backup and LED import stopped at the first block. 0.36.1 retries the read in link mode (0x18), the mode the module is programmed in, and leaves it again (0x19) in every case. Link mode changes no programming.

CI's test jobs stay red until 0.36.1 is on PyPI (the workflow installs the library from there); locally against the 0.36.1 branch the suite passes (591 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_