### PR TITLE
feat: read_module_blocks diagnostic action (3.16.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.16.2
+
+- **New diagnostic action `nikobus.read_module_blocks`.** Sends raw 16-byte (0x10) or 8-byte (0x22) block reads to one module, optionally inside link mode, and returns each block as hex, with unanswered blocks reported as timeouts. Meant for working out the memory access of module types that are not settled yet, such as the feedback module, which so far accepts link mode and the status query but ignores 16-byte reads at blocks 0 and 0x600.
+
+
 ## 3.16.1
 
 - **Feedback module read works through link mode.** On a real 05-207 the status query is answered but block reads are ignored, so 3.16.0's Backup and LED import stopped at the first block. `nikobus-connect 0.36.1` (required) retries the read in link mode, the mode the module is programmed in, and leaves it again in every case. Link mode changes no programming.

--- a/custom_components/nikobus/__init__.py
+++ b/custom_components/nikobus/__init__.py
@@ -53,6 +53,7 @@ SERVICE_SYNC_PC_LINK_CLOCK: Final = "sync_pc_link_clock"
 SERVICE_VERIFY_MODULES: Final = "verify_modules"
 SERVICE_BACKUP_MODULES: Final = "backup_modules"
 SERVICE_IMPORT_FEEDBACK_LEDS: Final = "import_feedback_leds"
+SERVICE_READ_MODULE_BLOCKS: Final = "read_module_blocks"
 
 # Optional module-address list shared by the programming actions; empty
 # means every output module.
@@ -91,6 +92,25 @@ def _parse_register_byte(value: Any) -> int:
             raise vol.Invalid(f"Cannot parse '{value}' as a hex register byte") from None
     if not (0 <= n <= 0xFF):
         raise vol.Invalid(f"Register {n:#x} out of range 0x00..0xFF")
+    return n
+
+
+def _parse_block_index(value: Any) -> int:
+    """Accept an int 0..65535 or a hex string (``"600"``, ``"0x600"``)."""
+    if isinstance(value, bool):
+        raise vol.Invalid("Block index must be an integer or hex string, not a bool")
+    if isinstance(value, int):
+        n = value
+    else:
+        text = str(value).strip()
+        if text.lower().startswith("0x"):
+            text = text[2:]
+        try:
+            n = int(text, 16)
+        except ValueError as err:
+            raise vol.Invalid(f"Block index must be an integer or hex string, got: {value!r}") from err
+    if not 0 <= n <= 0xFFFF:
+        raise vol.Invalid(f"Block index out of range 0..0xFFFF: {n}")
     return n
 
 
@@ -390,6 +410,30 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         handle_import_feedback_leds,
         vol.Schema({vol.Optional("overwrite", default=False): cv.boolean}),
         supports_response=SupportsResponse.OPTIONAL,
+    )
+
+    async def handle_read_module_blocks(call: ServiceCall) -> dict[str, Any]:
+        """Diagnostic raw block read of one module; returns the hex per block."""
+        return await _programming(call).async_read_blocks(
+            call.data["address"],
+            call.data["blocks"],
+            block_size=call.data.get("block_size", 16),
+            link_mode=bool(call.data.get("link_mode", False)),
+        )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_READ_MODULE_BLOCKS,
+        handle_read_module_blocks,
+        vol.Schema(
+            {
+                vol.Required("address"): cv.string,
+                vol.Required("blocks"): vol.All(cv.ensure_list, [_parse_block_index]),
+                vol.Optional("block_size", default=16): vol.In([8, 16]),
+                vol.Optional("link_mode", default=False): cv.boolean,
+            }
+        ),
+        supports_response=SupportsResponse.ONLY,
     )
     return True
 

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -22,5 +22,5 @@
     "pyserial-asyncio-fast>=0.16",
     "nikobus-connect>=0.36.1"
   ],
-  "version": "3.16.1"
+  "version": "3.16.2"
 }

--- a/custom_components/nikobus/nkbprogramming.py
+++ b/custom_components/nikobus/nkbprogramming.py
@@ -29,6 +29,12 @@ from nikobus_connect.discovery.feedback_decoder import (
     decode_feedback_image,
 )
 from nikobus_connect.discovery.fileio import find_module
+from nikobus_connect.exceptions import NikobusError
+from nikobus_connect.protocol import (
+    FUNC_READ_BLOCK8,
+    FUNC_READ_BLOCK16,
+    make_block_index_args,
+)
 
 from .const import (
     DOMAIN,
@@ -430,6 +436,60 @@ class NikobusProgramming:
         return {"path": str(folder), "images": sorted(images), **summary}
 
 
+    # -- raw block reads (diagnostics) ---------------------------------------
+
+    async def async_read_blocks(
+        self,
+        address: str,
+        blocks: list[int],
+        *,
+        block_size: int = 16,
+        link_mode: bool = False,
+    ) -> dict[str, Any]:
+        """Read raw memory blocks from one module and return them as hex.
+
+        Diagnostic helper for module types whose memory access is not
+        settled yet: sends the 16-byte (0x10) or 8-byte (0x22) read for
+        each block index, optionally inside link mode (0x18 / 0x19,
+        left again in every case). A block that goes unanswered is
+        reported as ``"timeout"`` instead of aborting the run.
+        """
+        self._acquire()
+        api = self._api()
+        address = address.upper()
+        func = FUNC_READ_BLOCK8 if block_size == 8 else FUNC_READ_BLOCK16
+        results: dict[str, str] = {}
+        self._set_running(True)
+        try:
+            async with self._lock:
+                if link_mode:
+                    await api.set_link_mode(address, True)
+                try:
+                    for block in blocks:
+                        index = _block_index(block)
+                        key = f"0x{index:04X}"
+                        try:
+                            payload = await api._command_handler.query(  # noqa: SLF001 - diagnostic access
+                                func, address, make_block_index_args(index)
+                            )
+                        except NikobusError as err:
+                            results[key] = f"timeout: {err}" if "ACK" in str(err) else f"error: {err}"
+                            continue
+                        results[key] = payload[2:].hex().upper() if len(payload) > 2 else payload.hex().upper()
+                finally:
+                    if link_mode:
+                        await api.set_link_mode(address, False)
+        finally:
+            self._set_running(False)
+            self._coordinator.async_update_listeners()
+        _LOGGER.info("Block read of %s (%d-byte, link mode %s): %s", address, block_size, link_mode, results)
+        return {
+            "address": address,
+            "block_size": block_size,
+            "link_mode": link_mode,
+            "blocks": results,
+        }
+
     # -- feedback module LED links -------------------------------------------
 
     def feedback_modules(self) -> list[tuple[str, str]]:
@@ -547,6 +607,16 @@ class NikobusProgramming:
         entry["led_off"] = bus_address
         entry["led_source"] = LED_SOURCE_FEEDBACK
         return True
+
+
+def _block_index(value: Any) -> int:
+    """Block index from an int or a hex string (``"600"`` / ``"0x600"``)."""
+    if isinstance(value, int):
+        return value
+    text = str(value).strip().lower()
+    if text.startswith("0x"):
+        text = text[2:]
+    return int(text, 16)
 
 
 def resolve_feedback_led(

--- a/custom_components/nikobus/nkbprogramming.py
+++ b/custom_components/nikobus/nkbprogramming.py
@@ -469,7 +469,8 @@ class NikobusProgramming:
                         index = _block_index(block)
                         key = f"0x{index:04X}"
                         try:
-                            payload = await api._command_handler.query(  # noqa: SLF001 - diagnostic access
+                            # Diagnostic access to the command layer's generic query.
+                            payload = await api._command_handler.query(
                                 func, address, make_block_index_args(index)
                             )
                         except NikobusError as err:
@@ -613,9 +614,7 @@ def _block_index(value: Any) -> int:
     """Block index from an int or a hex string (``"600"`` / ``"0x600"``)."""
     if isinstance(value, int):
         return value
-    text = str(value).strip().lower()
-    if text.startswith("0x"):
-        text = text[2:]
+    text = str(value).strip().lower().removeprefix("0x")
     return int(text, 16)
 
 

--- a/custom_components/nikobus/services.yaml
+++ b/custom_components/nikobus/services.yaml
@@ -92,3 +92,29 @@ import_feedback_leds:
       default: false
       selector:
         boolean:
+
+read_module_blocks:
+  fields:
+    address:
+      example: "966C"
+      required: true
+      selector:
+        text:
+    blocks:
+      example: "['0x0', '0x600']"
+      required: true
+      selector:
+        object:
+    block_size:
+      required: false
+      default: 16
+      selector:
+        select:
+          options:
+            - "8"
+            - "16"
+    link_mode:
+      required: false
+      default: false
+      selector:
+        boolean:

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -438,6 +438,28 @@
           "description": "Also replace LED addresses that were set by hand."
         }
       }
+    },
+    "read_module_blocks": {
+      "name": "Read module memory blocks (diagnostic)",
+      "description": "Sends raw block reads to one module and returns the bytes of each block as hex, for module types whose memory access is still being worked out. A block that goes unanswered is reported as a timeout. With link mode on, the module is put in link mode first and taken out of it afterwards; link mode changes no programming.",
+      "fields": {
+        "address": {
+          "name": "Module address",
+          "description": "Four hex digits, for example 966C."
+        },
+        "blocks": {
+          "name": "Block indexes",
+          "description": "List of block indexes, decimal or hex (for example ['0x0', '0x600'])."
+        },
+        "block_size": {
+          "name": "Block size",
+          "description": "16 bytes (function 0x10, most modules) or 8 bytes (function 0x22, dimmers)."
+        },
+        "link_mode": {
+          "name": "Link mode",
+          "description": "Send the reads inside link mode (0x18 before, 0x19 after)."
+        }
+      }
     }
   },
   "selector": {

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -477,6 +477,28 @@
           "description": "Remplacer aussi les adresses LED saisies à la main."
         }
       }
+    },
+    "read_module_blocks": {
+      "name": "Lire des blocs mémoire d'un module (diagnostic)",
+      "description": "Envoie des lectures de blocs bruts à un module et renvoie les octets de chaque bloc en hexadécimal, pour les types de modules dont l'accès mémoire n'est pas encore établi. Un bloc sans réponse est signalé comme délai dépassé. Avec le mode liaison, le module est d'abord mis en mode liaison puis retiré de ce mode ; le mode liaison ne modifie aucune programmation.",
+      "fields": {
+        "address": {
+          "name": "Adresse du module",
+          "description": "Quatre chiffres hexadécimaux, par exemple 966C."
+        },
+        "blocks": {
+          "name": "Index de blocs",
+          "description": "Liste d'index de blocs, en décimal ou hexadécimal (par exemple ['0x0', '0x600'])."
+        },
+        "block_size": {
+          "name": "Taille de bloc",
+          "description": "16 octets (fonction 0x10, la plupart des modules) ou 8 octets (fonction 0x22, variateurs)."
+        },
+        "link_mode": {
+          "name": "Mode liaison",
+          "description": "Envoyer les lectures en mode liaison (0x18 avant, 0x19 après)."
+        }
+      }
     }
   }
 }

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -477,6 +477,28 @@
           "description": "Ook handmatig ingestelde LED-adressen vervangen."
         }
       }
+    },
+    "read_module_blocks": {
+      "name": "Geheugenblokken van een module lezen (diagnose)",
+      "description": "Stuurt ruwe blokleesopdrachten naar één module en geeft de bytes van elk blok als hex terug, voor moduletypes waarvan de geheugentoegang nog wordt uitgezocht. Een blok zonder antwoord wordt als time-out gemeld. Met koppelmodus wordt de module eerst in koppelmodus gezet en daarna weer eruit gehaald; koppelmodus wijzigt geen programmering.",
+      "fields": {
+        "address": {
+          "name": "Moduleadres",
+          "description": "Vier hexadecimale cijfers, bijvoorbeeld 966C."
+        },
+        "blocks": {
+          "name": "Blokindexen",
+          "description": "Lijst van blokindexen, decimaal of hexadecimaal (bijvoorbeeld ['0x0', '0x600'])."
+        },
+        "block_size": {
+          "name": "Blokgrootte",
+          "description": "16 bytes (functie 0x10, de meeste modules) of 8 bytes (functie 0x22, dimmers)."
+        },
+        "link_mode": {
+          "name": "Koppelmodus",
+          "description": "De leesopdrachten in koppelmodus sturen (0x18 ervoor, 0x19 erna)."
+        }
+      }
     }
   }
 }

--- a/tests/test_programming.py
+++ b/tests/test_programming.py
@@ -376,3 +376,46 @@ class TestImportFeedbackLeds(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestReadBlocks(unittest.TestCase):
+    def test_reads_and_reports_timeouts_with_link_mode(self):
+        from nikobus_connect.exceptions import NikobusTimeoutError
+
+        api = _api()
+        api.set_link_mode = AsyncMock()
+        calls: list[tuple[int, bytes]] = []
+
+        async def query(func, address, args=None):
+            calls.append((func, args))
+            if args == b"\x00\x06":
+                raise NikobusTimeoutError("Failed to receive ACK and state")
+            return bytes.fromhex("6C96") + bytes(range(16))
+
+        api._command_handler = SimpleNamespace(query=query)
+        coord = _import_coordinator(api)
+        prog = NikobusProgramming(_hass("/tmp"), coord)
+        result = _run(prog.async_read_blocks("966c", [0, 0x600], link_mode=True))
+        self.assertEqual(result["address"], "966C")
+        self.assertEqual(result["blocks"]["0x0000"], bytes(range(16)).hex().upper())
+        self.assertTrue(result["blocks"]["0x0600"].startswith("timeout"))
+        self.assertEqual([c[0] for c in calls], [0x10, 0x10])
+        self.assertEqual(
+            [c.args for c in api.set_link_mode.await_args_list],
+            [("966C", True), ("966C", False)],
+        )
+        self.assertFalse(prog.running)
+
+    def test_eight_byte_function(self):
+        api = _api()
+        seen = []
+
+        async def query(func, address, args=None):
+            seen.append(func)
+            return bytes.fromhex("6C96") + b"\x01" * 8
+
+        api._command_handler = SimpleNamespace(query=query)
+        prog = NikobusProgramming(_hass("/tmp"), _import_coordinator(api))
+        result = _run(prog.async_read_blocks("966C", ["0xC00"], block_size=8))
+        self.assertEqual(seen, [0x22])
+        self.assertEqual(result["blocks"]["0x0C00"], "01" * 8)


### PR DESCRIPTION
## Summary

3.16.2 — a diagnostic action to work out the feedback module's memory access without a release per experiment.

**`nikobus.read_module_blocks`** (`address`, `blocks` list of int/hex, `block_size` 16 → 0x10 or 8 → 0x22, `link_mode` bool). Sends the raw reads and returns every block as hex; an unanswered block is reported as `timeout` instead of aborting. With `link_mode` the module is put in link mode first (0x18) and taken out afterwards (0x19) in a `finally`. Runs under the same one-bus-action-at-a-time lock as the other maintenance actions.

**Hardware result so far (966C, 05-207):** status query answered; link mode on/off accepted (the module answers with its `$0EFF6C96` short ack); 16-byte reads at blocks 0 and 0x600 unanswered both outside and inside link mode. The PC-Link holds the `$0510` acks of the unanswered reads and flushes them on the next command, so this is the module ignoring the function, not a link-layer issue. Next experiments: block 0 inside link mode, and the 8-byte read function.

Tests: link-mode wrap + timeout reporting, 8-byte function selection, hex block indexes. Suite: 593 passed, ruff clean. No library change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_