### PR TITLE
chore: 3.16.4 — feedback read survives a quiet module (nikobus-connect 0.36.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.16.4
+
+- **Feedback module read completes when the module goes quiet mid-way** (`nikobus-connect 0.36.3`, required). On a real 05-207 the LED import read the output table, the plate table, the LED list and the LED modes, then the module stopped answering; the read now re-enters link mode and carries on, and the last two tables are optional.
+- A maintenance button whose run fails now logs the error instead of leaving an unretrieved task exception.
+
+
 ## 3.16.3
 
 - **Feedback module read validated on a real 05-207 and made resilient** (`nikobus-connect 0.36.2`, required). The module serves block reads only in link mode, needs a moment after entering and leaving it, and drops an occasional block while it pushes feedback frames; the read now goes straight to link mode, pauses, retries each block and treats an unreadable LED-mode table as unknown modes. Backup of the feedback module and the LED import work end to end. The LED import now follows the corrected decoder (group table placement per software build, key order A, B, C, D inside a plate).

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -728,7 +728,7 @@ class _NikobusMaintenanceButton(_NikobusBridgeButton):
         async def _run() -> None:
             try:
                 await coro
-            except Exception:  # noqa: BLE001 - a failed run is reported, not lost
+            except Exception:  # a failed run is reported, not lost
                 _LOGGER.exception("%s failed", name)
 
         self.hass.async_create_background_task(_run(), name=name)

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -724,7 +724,14 @@ class _NikobusMaintenanceButton(_NikobusBridgeButton):
             raise HomeAssistantError(
                 translation_domain=DOMAIN, translation_key="maintenance_running"
             )
-        self.hass.async_create_background_task(coro, name=name)
+
+        async def _run() -> None:
+            try:
+                await coro
+            except Exception:  # noqa: BLE001 - a failed run is reported, not lost
+                _LOGGER.exception("%s failed", name)
+
+        self.hass.async_create_background_task(_run(), name=name)
 
 
 class NikobusSyncClockButton(_NikobusMaintenanceButton):

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -20,7 +20,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.36.2"
+    "nikobus-connect>=0.36.3"
   ],
-  "version": "3.16.3"
+  "version": "3.16.4"
 }


### PR DESCRIPTION
## Summary

3.16.4 — requirement bump to **nikobus-connect 0.36.3** (fdebrus/nikobus-connect#139) plus one small integration change.

The 3.16.3 LED import on a real 05-207 read the output table, the plate table, the LED list and the LED-mode table, then the module stopped answering on the input-event records and the run aborted (and its background task exception went unretrieved). 0.36.3 re-enters link mode when the module goes quiet and treats the last two tables as optional; the maintenance buttons now log a failed run instead of leaving an unretrieved task exception.

CI test jobs stay red until 0.36.3 is on PyPI. Locally: 593 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_