### PR TITLE
feat!: remove feedback-module LED import and block-read diagnostic (3.17.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.17.0
+
+- **Removed: Import LED links from feedback module, and the block-read diagnostic.** Reading a feedback module (05-207) required putting it into link mode — the mode that gates erasing and writing a module — and never became reliable on real hardware. The risk of using the write-enable mode for a read was not worth it, so the **Import LED links** bridge button, the `nikobus.import_feedback_leds` action and the `nikobus.read_module_blocks` diagnostic are gone, and the integration no longer puts any module into link mode. Fill the LED-on / LED-off trigger addresses by hand under *Customize a module* as before. Backup and Verify continue to cover switch, dimmer and roller modules. Requires `nikobus-connect >= 0.37.0`. The real-time state push from a Feedback Module is unaffected.
+
+
 ## 3.16.4
 
 - **Feedback module read completes when the module goes quiet mid-way** (`nikobus-connect 0.36.3`, required). On a real 05-207 the LED import read the output table, the plate table, the LED list and the LED modes, then the module stopped answering; the read now re-enters link mode and carries on, and the last two tables are optional.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ Press **3. Import Names from .nkb** to apply the friendly names, rooms, and scen
 - **Description** → the entity name.
 - **Entity type** → how HA exposes it (switch modules: `switch`/`light`/`none`; dimmers: `light`/`none`; rollers: `cover`/`switch`/`light`/`none`).
 - **LED on / off addresses** → feedback-LED bus addresses (blank if unused).
-  With a feedback module (05-207) on the bus, press **Import LED links from feedback module** on the Nikobus Bridge (or call `nikobus.import_feedback_leds`) and these are filled in from the module's own programming; addresses you typed stay unless you choose Overwrite.
 - **Travel time up / down** (rollers) → seconds to open/close, used by the position calculator.
 - **End-stop margin** (rollers) → seconds after the estimated arrival at fully open/closed before a Home Assistant-started motion sends its stop frame (default 3). The motor runs into the end stop during the margin, which keeps the position model honest; the stop then releases the relay so a wall button acts on the first press. Set it higher to let the module's own run time release the relay instead.
 

--- a/custom_components/nikobus/__init__.py
+++ b/custom_components/nikobus/__init__.py
@@ -52,8 +52,6 @@ SERVICE_PURGE_STALE_INVENTORY: Final = "purge_stale_inventory"
 SERVICE_SYNC_PC_LINK_CLOCK: Final = "sync_pc_link_clock"
 SERVICE_VERIFY_MODULES: Final = "verify_modules"
 SERVICE_BACKUP_MODULES: Final = "backup_modules"
-SERVICE_IMPORT_FEEDBACK_LEDS: Final = "import_feedback_leds"
-SERVICE_READ_MODULE_BLOCKS: Final = "read_module_blocks"
 
 # Optional module-address list shared by the programming actions; empty
 # means every output module.
@@ -92,25 +90,6 @@ def _parse_register_byte(value: Any) -> int:
             raise vol.Invalid(f"Cannot parse '{value}' as a hex register byte") from None
     if not (0 <= n <= 0xFF):
         raise vol.Invalid(f"Register {n:#x} out of range 0x00..0xFF")
-    return n
-
-
-def _parse_block_index(value: Any) -> int:
-    """Accept an int 0..65535 or a hex string (``"600"``, ``"0x600"``)."""
-    if isinstance(value, bool):
-        raise vol.Invalid("Block index must be an integer or hex string, not a bool")
-    if isinstance(value, int):
-        n = value
-    else:
-        text = str(value).strip()
-        if text.lower().startswith("0x"):
-            text = text[2:]
-        try:
-            n = int(text, 16)
-        except ValueError as err:
-            raise vol.Invalid(f"Block index must be an integer or hex string, got: {value!r}") from err
-    if not 0 <= n <= 0xFFFF:
-        raise vol.Invalid(f"Block index out of range 0..0xFFFF: {n}")
     return n
 
 
@@ -398,43 +377,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         supports_response=SupportsResponse.OPTIONAL,
     )
 
-    async def handle_import_feedback_leds(call: ServiceCall) -> dict[str, Any]:
-        """Fill the channels' LED trigger addresses from the feedback module."""
-        return await _programming(call).async_import_feedback_leds(
-            overwrite=bool(call.data.get("overwrite", False))
-        )
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_IMPORT_FEEDBACK_LEDS,
-        handle_import_feedback_leds,
-        vol.Schema({vol.Optional("overwrite", default=False): cv.boolean}),
-        supports_response=SupportsResponse.OPTIONAL,
-    )
-
-    async def handle_read_module_blocks(call: ServiceCall) -> dict[str, Any]:
-        """Diagnostic raw block read of one module; returns the hex per block."""
-        return await _programming(call).async_read_blocks(
-            call.data["address"],
-            call.data["blocks"],
-            block_size=call.data.get("block_size", 16),
-            link_mode=bool(call.data.get("link_mode", False)),
-        )
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_READ_MODULE_BLOCKS,
-        handle_read_module_blocks,
-        vol.Schema(
-            {
-                vol.Required("address"): cv.string,
-                vol.Required("blocks"): vol.All(cv.ensure_list, [_parse_block_index]),
-                vol.Optional("block_size", default=16): vol.In([8, 16]),
-                vol.Optional("link_mode", default=False): cv.boolean,
-            }
-        ),
-        supports_response=SupportsResponse.ONLY,
-    )
     return True
 
 

--- a/custom_components/nikobus/button.py
+++ b/custom_components/nikobus/button.py
@@ -57,7 +57,6 @@ async def async_setup_entry(
         NikobusSyncClockButton(coordinator),
         NikobusVerifyProgrammingButton(coordinator),
         NikobusBackupProgrammingButton(coordinator),
-        NikobusImportFeedbackLedsButton(coordinator),
     ]
 
     buttons = (coordinator.dict_button_data or {}).get("nikobus_button", {})
@@ -780,25 +779,3 @@ class NikobusBackupProgrammingButton(_NikobusMaintenanceButton):
             "nikobus_backup_programming",
         )
 
-
-class NikobusImportFeedbackLedsButton(_NikobusMaintenanceButton):
-    """Fill the channels' LED trigger addresses from the feedback module."""
-
-    _attr_translation_key = "import_feedback_leds"
-
-    def __init__(self, coordinator: NikobusDataCoordinator) -> None:
-        super().__init__(coordinator)
-        self._attr_unique_id = f"{DOMAIN}_import_feedback_leds_button"
-
-    @property
-    def available(self) -> bool:
-        programming = getattr(self._coordinator, "programming", None)
-        has_module = bool(programming and programming.feedback_modules())
-        return has_module and super().available
-
-    async def async_press(self) -> None:
-        _LOGGER.info("Feedback LED import triggered via UI button")
-        self._start(
-            self._coordinator.programming.async_import_feedback_leds(),
-            "nikobus_import_feedback_leds",
-        )

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -1461,7 +1461,6 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
         known.add(f"{DOMAIN}_sync_pc_link_clock_button")
         known.add(f"{DOMAIN}_verify_programming_button")
         known.add(f"{DOMAIN}_backup_programming_button")
-        known.add(f"{DOMAIN}_import_feedback_leds_button")
         return known
 
     def _rebuild_dict_module_data(self) -> None:

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -20,7 +20,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.36.3"
+    "nikobus-connect>=0.37.0"
   ],
-  "version": "3.16.4"
+  "version": "3.17.0"
 }

--- a/custom_components/nikobus/nkbprogramming.py
+++ b/custom_components/nikobus/nkbprogramming.py
@@ -22,20 +22,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.util import dt as dt_util
-from nikobus_connect.api import MODULE_CRC_UNKNOWN, MODULE_IMAGE_SIZES
-from nikobus_connect.discovery.feedback_decoder import (
-    KEY_LABELS_BY_ROW,
-    FeedbackImage,
-    FeedbackLed,
-    decode_feedback_image,
-)
-from nikobus_connect.discovery.fileio import find_module
-from nikobus_connect.exceptions import NikobusError
-from nikobus_connect.protocol import (
-    FUNC_READ_BLOCK8,
-    FUNC_READ_BLOCK16,
-    make_block_index_args,
-)
+from nikobus_connect.api import MODULE_IMAGE_SIZES
 
 from .const import (
     DOMAIN,
@@ -48,13 +35,6 @@ from .router import iter_operation_points
 _LOGGER = logging.getLogger(__name__)
 
 BACKUP_DIR = "nikobus_backup"
-LED_SOURCE_FEEDBACK = "feedback_module"
-
-# Row order of the LED slots inside one push-button module group, by
-# number of keys on the plate: the key order A, B, C, D (validated on a
-# real module: slot 2 of a 4-key plate is key C). Used when the link
-# table cannot single out the key.
-_LED_ROW_KEYS: dict[int, tuple[str, ...]] = KEY_LABELS_BY_ROW
 
 HEALTH_OK = "ok"
 HEALTH_PROBLEM = "problem"
@@ -310,31 +290,20 @@ class NikobusProgramming:
     ) -> tuple[ModuleCheck, bytes | None]:
         check = ModuleCheck(address, module_type, description)
         data: bytes | None = None
-        crc_unknown = module_type in MODULE_CRC_UNKNOWN
         try:
-            try:
-                status = await api.get_module_status(address)
-            except Exception:
-                # A module whose CRC coverage is unknown may not answer
-                # the status query either; its image is still worth
-                # reading. Every other module must answer.
-                if not crc_unknown:
-                    raise
-                _LOGGER.debug("Module %s did not answer the status query", address)
-            else:
-                check.eeprom_error = status.eeprom_error
-                check.record_count_a = status.record_count_a
-                # 0xFF = "no second table" on switch / roller modules.
-                check.record_count_b = (
-                    None if status.record_count_b == 0xFF else status.record_count_b
-                )
+            status = await api.get_module_status(address)
+            check.eeprom_error = status.eeprom_error
+            check.record_count_a = status.record_count_a
+            # 0xFF = "no second table" on switch / roller modules.
+            check.record_count_b = (
+                None if status.record_count_b == 0xFF else status.record_count_b
+            )
             if image:
                 data = await api.read_module_memory(address, module_type)
                 check.image_bytes = len(data)
-                if not crc_unknown:
-                    check.crc_ok, check.module_crc, check.computed_crc = (
-                        await api.verify_module_memory(address, module_type, data)
-                    )
+                check.crc_ok, check.module_crc, check.computed_crc = (
+                    await api.verify_module_memory(address, module_type, data)
+                )
         except Exception as err:  # noqa: BLE001 - one module's failure must not abort the run
             check.error = str(err) or err.__class__.__name__
             _LOGGER.warning("Programming check of module %s failed: %s", address, check.error)
@@ -431,242 +400,6 @@ class NikobusProgramming:
             self._coordinator.async_update_listeners()
         _LOGGER.info("Nikobus programming backup written to %s (%d image(s))", folder, len(images))
         return {"path": str(folder), "images": sorted(images), **summary}
-
-
-    # -- raw block reads (diagnostics) ---------------------------------------
-
-    async def async_read_blocks(
-        self,
-        address: str,
-        blocks: list[int],
-        *,
-        block_size: int = 16,
-        link_mode: bool = False,
-    ) -> dict[str, Any]:
-        """Read raw memory blocks from one module and return them as hex.
-
-        Diagnostic helper for module types whose memory access is not
-        settled yet: sends the 16-byte (0x10) or 8-byte (0x22) read for
-        each block index, optionally inside link mode (0x18 / 0x19,
-        left again in every case). A block that goes unanswered is
-        reported as ``"timeout"`` instead of aborting the run.
-        """
-        self._acquire()
-        api = self._api()
-        address = address.upper()
-        func = FUNC_READ_BLOCK8 if block_size == 8 else FUNC_READ_BLOCK16
-        results: dict[str, str] = {}
-        self._set_running(True)
-        try:
-            async with self._lock:
-                if link_mode:
-                    await api.set_link_mode(address, True)
-                try:
-                    for block in blocks:
-                        index = _block_index(block)
-                        key = f"0x{index:04X}"
-                        try:
-                            # Diagnostic access to the command layer's generic query.
-                            payload = await api._command_handler.query(
-                                func, address, make_block_index_args(index)
-                            )
-                        except NikobusError as err:
-                            results[key] = f"timeout: {err}" if "ACK" in str(err) else f"error: {err}"
-                            continue
-                        results[key] = payload[2:].hex().upper() if len(payload) > 2 else payload.hex().upper()
-                finally:
-                    if link_mode:
-                        await api.set_link_mode(address, False)
-        finally:
-            self._set_running(False)
-            self._coordinator.async_update_listeners()
-        _LOGGER.info("Block read of %s (%d-byte, link mode %s): %s", address, block_size, link_mode, results)
-        return {
-            "address": address,
-            "block_size": block_size,
-            "link_mode": link_mode,
-            "blocks": results,
-        }
-
-    # -- feedback module LED links -------------------------------------------
-
-    def feedback_modules(self) -> list[tuple[str, str]]:
-        """``(address, description)`` of every feedback module (05-207)."""
-        return [
-            (address, str(entry.get("description") or address))
-            for address, module_type, entry in self._modules()
-            if module_type == LED_SOURCE_FEEDBACK
-        ]
-
-    async def async_import_feedback_leds(self, *, overwrite: bool = False) -> dict[str, Any]:
-        """Fill the channels' LED trigger addresses from the feedback module.
-
-        Reads the feedback module's programming, resolves every LED slot
-        to the wall key that carries it and writes that key's bus
-        address as ``led_on`` / ``led_off`` of each output the LED
-        tracks. Values typed by the user stay unless ``overwrite`` is
-        set; values from an earlier import are always refreshed.
-        """
-        self._acquire()
-        api = self._api()
-        modules = self.feedback_modules()
-        if not modules:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN, translation_key="no_feedback_module"
-            )
-        self._set_running(True)
-        try:
-            async with self._lock:
-                report: dict[str, Any] = {
-                    "feedback_modules": [address for address, _ in modules],
-                    "leds": 0,
-                    "resolved": 0,
-                    "channels_updated": 0,
-                    "channels_kept": 0,
-                    "unresolved": [],
-                    "assignments": [],
-                }
-                for address, _description in modules:
-                    image = await api.read_module_memory(address, LED_SOURCE_FEEDBACK)
-                    decoded = decode_feedback_image(image)
-                    self._apply_feedback_leds(decoded, report, overwrite=overwrite)
-                if report["channels_updated"]:
-                    await self._coordinator.async_on_module_save()
-        finally:
-            self._set_running(False)
-            self._coordinator.async_update_listeners()
-        _LOGGER.info(
-            "Feedback LED import: %d LED(s), %d resolved, %d channel(s) updated, %d kept",
-            report["leds"], report["resolved"], report["channels_updated"], report["channels_kept"],
-        )
-        return report
-
-    def _apply_feedback_leds(
-        self, decoded: FeedbackImage, report: dict[str, Any], *, overwrite: bool
-    ) -> None:
-        buttons = (self._coordinator.dict_button_data or {}).get("nikobus_button") or {}
-        for led in decoded.leds:
-            tracked = [
-                (item.output.module_address.upper(), item.output.channel)
-                for item in led.outputs
-                if item.output is not None
-            ]
-            if not tracked:
-                continue
-            report["leds"] += 1
-            resolved = resolve_feedback_led(led, tracked, buttons)
-            if resolved is None:
-                report["unresolved"].append(
-                    {"slot": led.slot, "plates": list(led.plate_addresses), "outputs": tracked}
-                )
-                continue
-            plate, key_label, bus_address = resolved
-            report["resolved"] += 1
-            for module_address, channel in tracked:
-                outcome = self._set_channel_led(module_address, channel, bus_address, overwrite)
-                if outcome is None:
-                    continue
-                report["channels_updated" if outcome else "channels_kept"] += 1
-                report["assignments"].append(
-                    {
-                        "module_address": module_address,
-                        "channel": channel,
-                        "plate": plate,
-                        "key": key_label,
-                        "bus_address": bus_address,
-                        "updated": outcome,
-                    }
-                )
-
-    def _set_channel_led(
-        self, module_address: str, channel: int, bus_address: str, overwrite: bool
-    ) -> bool | None:
-        """Write ``led_on``/``led_off`` on one channel.
-
-        Returns ``True`` when written, ``False`` when an existing value was
-        kept, ``None`` when the module or channel is unknown.
-        """
-        hit = find_module(self._coordinator.module_storage.data, module_address)
-        if hit is None:
-            return None
-        channels = hit[1].get("channels")
-        if not isinstance(channels, list) or not 1 <= channel <= len(channels):
-            return None
-        entry = channels[channel - 1]
-        if not isinstance(entry, dict):
-            return None
-        existing = entry.get("led_on") or entry.get("led_off")
-        imported = entry.get("led_source") == LED_SOURCE_FEEDBACK
-        if existing and not (overwrite or imported):
-            return False
-        if existing == bus_address and entry.get("led_off") == bus_address and imported:
-            return False
-        entry["led_on"] = bus_address
-        entry["led_off"] = bus_address
-        entry["led_source"] = LED_SOURCE_FEEDBACK
-        return True
-
-
-def _block_index(value: Any) -> int:
-    """Block index from an int or a hex string (``"600"`` / ``"0x600"``)."""
-    if isinstance(value, int):
-        return value
-    text = str(value).strip().lower().removeprefix("0x")
-    return int(text, 16)
-
-
-def resolve_feedback_led(
-    led: FeedbackLed,
-    tracked: list[tuple[str, int]],
-    buttons: dict[str, Any],
-) -> tuple[str, str, str] | None:
-    """Find the wall key behind an LED slot: ``(plate, key_label, bus_address)``.
-
-    The plate is the group's module address (either bit-0 variant that
-    exists in the button store). Among its keys, the one whose links
-    drive an output the LED tracks is the LED's key — a feedback LED
-    normally sits on the key that switches the light. When the links
-    do not single one out, the slot's row inside the group decides.
-    """
-    plate_entry: dict[str, Any] | None = None
-    plate = ""
-    for candidate in led.plate_addresses:
-        entry = buttons.get(candidate) or buttons.get(candidate.lower())
-        if isinstance(entry, dict):
-            plate_entry, plate = entry, candidate
-            break
-    if plate_entry is None:
-        return None
-    op_points = plate_entry.get("operation_points")
-    if not isinstance(op_points, dict):
-        return None
-    keys: dict[str, str] = {}
-    matching: list[str] = []
-    for key_label, op_point in op_points.items():
-        if not isinstance(op_point, dict) or str(key_label).startswith("IR:"):
-            continue
-        bus_address = str(op_point.get("bus_address") or "").upper()
-        if not bus_address:
-            continue
-        keys[str(key_label)] = bus_address
-        links = {(addr, chan) for addr, chan, _ in iter_link_outputs(op_point)}
-        if any(target in links for target in tracked):
-            matching.append(str(key_label))
-    if not keys:
-        return None
-    guess: str | None = None
-    rows = _LED_ROW_KEYS.get(len(keys))
-    if rows is not None and led.row is not None and led.row < len(rows):
-        guess = rows[led.row]
-    if len(matching) == 1:
-        chosen = matching[0]
-    elif matching:
-        chosen = guess if guess in matching else matching[0]
-    elif guess in keys:
-        chosen = guess
-    else:
-        return None
-    return plate, chosen, keys[chosen]
 
 
 def _write_backup(folder: Path, images: dict[str, bytes], summary: dict[str, Any]) -> None:

--- a/custom_components/nikobus/services.yaml
+++ b/custom_components/nikobus/services.yaml
@@ -84,37 +84,3 @@ backup_modules:
       required: false
       selector:
         object:
-
-import_feedback_leds:
-  fields:
-    overwrite:
-      required: false
-      default: false
-      selector:
-        boolean:
-
-read_module_blocks:
-  fields:
-    address:
-      example: "966C"
-      required: true
-      selector:
-        text:
-    blocks:
-      example: "['0x0', '0x600']"
-      required: true
-      selector:
-        object:
-    block_size:
-      required: false
-      default: 16
-      selector:
-        select:
-          options:
-            - "8"
-            - "16"
-    link_mode:
-      required: false
-      default: false
-      selector:
-        boolean:

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -79,9 +79,6 @@
       },
       "backup_module_programming": {
         "name": "Backup module programming"
-      },
-      "import_feedback_leds": {
-        "name": "Import LED links from feedback module"
       }
     },
     "sensor": {
@@ -210,9 +207,6 @@
     },
     "no_pc_link_known": {
       "message": "No PC-Link is known yet — run **1. Load Project Overview** first."
-    },
-    "no_feedback_module": {
-      "message": "No feedback module (05-207) is known — run **1. Load Project Overview** first, or enable the feedback module in the integration options."
     }
   },
   "options": {
@@ -426,38 +420,6 @@
         "addresses": {
           "name": "Module addresses",
           "description": "Optional list of module addresses to limit the run to (for example ['9105', '4707']). Empty means every switch, dimmer and roller module."
-        }
-      }
-    },
-    "import_feedback_leds": {
-      "name": "Import LED links from feedback module",
-      "description": "Reads the feedback module's programming and fills the LED-on / LED-off trigger address of every output channel with the wall key whose LED tracks it. Addresses you typed yourself are kept unless Overwrite is on; addresses from an earlier import are refreshed.",
-      "fields": {
-        "overwrite": {
-          "name": "Overwrite",
-          "description": "Also replace LED addresses that were set by hand."
-        }
-      }
-    },
-    "read_module_blocks": {
-      "name": "Read module memory blocks (diagnostic)",
-      "description": "Sends raw block reads to one module and returns the bytes of each block as hex, for module types whose memory access is still being worked out. A block that goes unanswered is reported as a timeout. With link mode on, the module is put in link mode first and taken out of it afterwards; link mode changes no programming.",
-      "fields": {
-        "address": {
-          "name": "Module address",
-          "description": "Four hex digits, for example 966C."
-        },
-        "blocks": {
-          "name": "Block indexes",
-          "description": "List of block indexes, decimal or hex (for example ['0x0', '0x600'])."
-        },
-        "block_size": {
-          "name": "Block size",
-          "description": "16 bytes (function 0x10, most modules) or 8 bytes (function 0x22, dimmers)."
-        },
-        "link_mode": {
-          "name": "Link mode",
-          "description": "Send the reads inside link mode (0x18 before, 0x19 after)."
         }
       }
     }

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -246,9 +246,6 @@
       },
       "backup_module_programming": {
         "name": "Sauvegarder la programmation des modules"
-      },
-      "import_feedback_leds": {
-        "name": "Importer les liens LED du module de feedback"
       }
     }
   },
@@ -343,9 +340,6 @@
     },
     "no_pc_link_known": {
       "message": "Aucun PC-Link n'est encore connu — lancez d'abord **1. Charger la vue d'ensemble du projet**."
-    },
-    "no_feedback_module": {
-      "message": "Aucun module de feedback (05-207) n'est connu — lancez d'abord **1. Charger la vue d'ensemble du projet**, ou activez le module de feedback dans les options de l'intégration."
     }
   },
   "selector": {
@@ -465,38 +459,6 @@
         "addresses": {
           "name": "Adresses des modules",
           "description": "Liste facultative d'adresses de modules pour limiter l'opération (par exemple ['9105', '4707']). Vide = tous les modules de commutation, variation et volets."
-        }
-      }
-    },
-    "import_feedback_leds": {
-      "name": "Importer les liens LED du module de feedback",
-      "description": "Lit la programmation du module de feedback et remplit l'adresse de déclenchement LED allumée / LED éteinte de chaque canal de sortie avec la touche murale dont la LED le suit. Les adresses saisies à la main sont conservées sauf si Écraser est activé ; celles d'un import précédent sont rafraîchies.",
-      "fields": {
-        "overwrite": {
-          "name": "Écraser",
-          "description": "Remplacer aussi les adresses LED saisies à la main."
-        }
-      }
-    },
-    "read_module_blocks": {
-      "name": "Lire des blocs mémoire d'un module (diagnostic)",
-      "description": "Envoie des lectures de blocs bruts à un module et renvoie les octets de chaque bloc en hexadécimal, pour les types de modules dont l'accès mémoire n'est pas encore établi. Un bloc sans réponse est signalé comme délai dépassé. Avec le mode liaison, le module est d'abord mis en mode liaison puis retiré de ce mode ; le mode liaison ne modifie aucune programmation.",
-      "fields": {
-        "address": {
-          "name": "Adresse du module",
-          "description": "Quatre chiffres hexadécimaux, par exemple 966C."
-        },
-        "blocks": {
-          "name": "Index de blocs",
-          "description": "Liste d'index de blocs, en décimal ou hexadécimal (par exemple ['0x0', '0x600'])."
-        },
-        "block_size": {
-          "name": "Taille de bloc",
-          "description": "16 octets (fonction 0x10, la plupart des modules) ou 8 octets (fonction 0x22, variateurs)."
-        },
-        "link_mode": {
-          "name": "Mode liaison",
-          "description": "Envoyer les lectures en mode liaison (0x18 avant, 0x19 après)."
         }
       }
     }

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -246,9 +246,6 @@
       },
       "backup_module_programming": {
         "name": "Moduleprogrammering back-uppen"
-      },
-      "import_feedback_leds": {
-        "name": "LED-koppelingen importeren uit feedbackmodule"
       }
     }
   },
@@ -343,9 +340,6 @@
     },
     "no_pc_link_known": {
       "message": "Er is nog geen PC-Link bekend — voer eerst **1. Projectoverzicht laden** uit."
-    },
-    "no_feedback_module": {
-      "message": "Er is geen feedbackmodule (05-207) bekend — voer eerst **1. Projectoverzicht laden** uit, of schakel de feedbackmodule in bij de integratie-opties."
     }
   },
   "selector": {
@@ -465,38 +459,6 @@
         "addresses": {
           "name": "Moduleadressen",
           "description": "Optionele lijst van moduleadressen om de actie te beperken (bijvoorbeeld ['9105', '4707']). Leeg betekent alle schakel-, dim- en rolluikmodules."
-        }
-      }
-    },
-    "import_feedback_leds": {
-      "name": "LED-koppelingen importeren uit feedbackmodule",
-      "description": "Leest de programmering van de feedbackmodule en vult het LED-aan / LED-uit triggeradres van elk uitgangskanaal in met de wandtoets waarvan de LED het volgt. Handmatig ingevulde adressen blijven staan tenzij Overschrijven aan staat; adressen van een eerdere import worden vernieuwd.",
-      "fields": {
-        "overwrite": {
-          "name": "Overschrijven",
-          "description": "Ook handmatig ingestelde LED-adressen vervangen."
-        }
-      }
-    },
-    "read_module_blocks": {
-      "name": "Geheugenblokken van een module lezen (diagnose)",
-      "description": "Stuurt ruwe blokleesopdrachten naar één module en geeft de bytes van elk blok als hex terug, voor moduletypes waarvan de geheugentoegang nog wordt uitgezocht. Een blok zonder antwoord wordt als time-out gemeld. Met koppelmodus wordt de module eerst in koppelmodus gezet en daarna weer eruit gehaald; koppelmodus wijzigt geen programmering.",
-      "fields": {
-        "address": {
-          "name": "Moduleadres",
-          "description": "Vier hexadecimale cijfers, bijvoorbeeld 966C."
-        },
-        "blocks": {
-          "name": "Blokindexen",
-          "description": "Lijst van blokindexen, decimaal of hexadecimaal (bijvoorbeeld ['0x0', '0x600'])."
-        },
-        "block_size": {
-          "name": "Blokgrootte",
-          "description": "16 bytes (functie 0x10, de meeste modules) of 8 bytes (functie 0x22, dimmers)."
-        },
-        "link_mode": {
-          "name": "Koppelmodus",
-          "description": "De leesopdrachten in koppelmodus sturen (0x18 ervoor, 0x19 erna)."
         }
       }
     }

--- a/tests/test_programming.py
+++ b/tests/test_programming.py
@@ -12,24 +12,14 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.exceptions import HomeAssistantError
-from nikobus_connect.discovery.feedback_decoder import (
-    FEEDBACK_IMAGE_SIZE,
-    LED_MODE_TABLE_OFFSET,
-    REGION_GROUP_ADDRESSES,
-    REGION_LED_LISTS,
-    REGION_OUTPUT_MODULES,
-    decode_feedback_image,
-)
 
 from custom_components.nikobus.nkbprogramming import (
     HEALTH_OK,
     HEALTH_PROBLEM,
     HEALTH_UNKNOWN,
-    LED_SOURCE_FEEDBACK,
     NikobusProgramming,
     link_run_time,
     parse_run_time_label,
-    resolve_feedback_led,
 )
 
 
@@ -229,193 +219,6 @@ class TestLinkRunTimeStoredShape(unittest.TestCase):
         self.assertEqual(link_run_time(buttons, "9105", 2, "down"), 35.0)
 
 
-def _feedback_image() -> bytes:
-    """Plate 1843B4 (4 keys, group 0): slot 0 tracks 5B05 ch 1, slot 3
-    tracks 5B05 ch 6 and dimmer 0E6C ch 2; own LED 1 tracks 0E6C ch 2."""
-    img = bytearray(b"\xff" * FEEDBACK_IMAGE_SIZE)
-    base = REGION_OUTPUT_MODULES[0]
-    img[base : base + 8] = bytes([1, 0x5B, 0x05, 0, 0x00, 0x21, 0xFF, 0xFF])
-    img[base + 8 : base + 16] = bytes([3, 0x0E, 0x6C, 0, 0x00, 0x02, 0xFF, 0xFF])
-    grp = REGION_GROUP_ADDRESSES[0]
-    img[grp : grp + 3] = bytes([0x06, 0x10, 0xEC])  # 1843B4 with bit 0 cleared
-    lists = REGION_LED_LISTS[0]
-    stream = bytes(
-        [0x00, 0x00, 0x04, 0x00, 0x00, 0x01, 0x00, 0x02, 0x04, 0x03, 0x00, 0x02, 0x04, 0xC0]
-    )
-    img[lists : lists + len(stream)] = stream
-    img[LED_MODE_TABLE_OFFSET] = 0
-    img[LED_MODE_TABLE_OFFSET + 3] = 0
-    return bytes(img)
-
-
-def _plate(links: dict[str, list[tuple[str, int]]]) -> dict:
-    """Plate 1843B4 with its four real key addresses and the given links."""
-    addresses = {"1A": "8B7086", "1B": "CB7086", "1C": "0B7086", "1D": "4B7086"}
-    return {
-        "1843B4": {
-            "type": "Button",
-            "operation_points": {
-                key: {
-                    "bus_address": addr,
-                    "linked_modules": [
-                        {"module_address": m, "outputs": [{"channel": c, "mode": "M01 (On / off)"}]}
-                        for m, c in links.get(key, [])
-                    ],
-                }
-                for key, addr in addresses.items()
-            },
-        }
-    }
-
-
-class TestResolveFeedbackLed(unittest.TestCase):
-    def _led(self, slot):
-        decoded = decode_feedback_image(_feedback_image())
-        return next(led for led in decoded.leds if led.slot == slot)
-
-    def test_links_single_out_the_key(self):
-        buttons = _plate({"1A": [("5B05", 1)], "1B": [("5B05", 6)]})
-        self.assertEqual(
-            resolve_feedback_led(self._led(0), [("5B05", 1)], buttons),
-            ("1843B4", "1A", "8B7086"),
-        )
-        self.assertEqual(
-            resolve_feedback_led(self._led(3), [("5B05", 6), ("0E6C", 2)], buttons),
-            ("1843B4", "1B", "CB7086"),
-        )
-
-    def test_row_order_decides_without_links(self):
-        buttons = _plate({})
-        # rows follow the key order: slot 0 = 1A, slot 3 = 1D on a 4-key plate
-        self.assertEqual(resolve_feedback_led(self._led(0), [("5B05", 1)], buttons)[1], "1A")
-        self.assertEqual(resolve_feedback_led(self._led(3), [("5B05", 6)], buttons)[1], "1D")
-
-    def test_unknown_plate_is_unresolved(self):
-        self.assertIsNone(resolve_feedback_led(self._led(0), [("5B05", 1)], {}))
-
-
-def _import_coordinator(api, channels_5b05=None, links=None):
-    coord = _coordinator(
-        modules={
-            "switch_module": {"5B05": {"module_type": "switch_module", "description": "S2"}},
-            "dimmer_module": {"0E6C": {"module_type": "dimmer_module", "description": "D1"}},
-            "feedback_module": {"966C": {"module_type": "feedback_module", "description": "FB"}},
-        },
-        api=api,
-    )
-    coord.dict_button_data = {"nikobus_button": _plate(links or {"1A": [("5B05", 1)], "1B": [("5B05", 6)]})}
-    coord.module_storage = SimpleNamespace(
-        data={
-            "nikobus_module": {
-                "5B05": {
-                    "module_type": "switch_module",
-                    "channels": channels_5b05
-                    or [{"description": f"out {i}"} for i in range(1, 13)],
-                },
-                "0E6C": {"module_type": "dimmer_module", "channels": [{"description": f"d {i}"} for i in range(1, 13)]},
-            }
-        }
-    )
-    coord.async_on_module_save = AsyncMock()
-    return coord
-
-
-class TestImportFeedbackLeds(unittest.TestCase):
-    def test_fills_led_addresses_and_saves(self):
-        api = _api()
-        api.read_module_memory = AsyncMock(return_value=_feedback_image())
-        coord = _import_coordinator(api)
-        prog = NikobusProgramming(_hass("/tmp"), coord)
-        report = _run(prog.async_import_feedback_leds())
-        api.read_module_memory.assert_awaited_once_with("966C", "feedback_module")
-        self.assertEqual((report["leds"], report["resolved"]), (3, 2))  # own LED has no plate
-        self.assertEqual(report["channels_updated"], 3)
-        ch = coord.module_storage.data["nikobus_module"]["5B05"]["channels"]
-        self.assertEqual((ch[0]["led_on"], ch[0]["led_off"], ch[0]["led_source"]), ("8B7086", "8B7086", LED_SOURCE_FEEDBACK))
-        self.assertEqual(ch[5]["led_on"], "CB7086")
-        dimmer = coord.module_storage.data["nikobus_module"]["0E6C"]["channels"]
-        self.assertEqual(dimmer[1]["led_on"], "CB7086")
-        coord.async_on_module_save.assert_awaited_once()
-        self.assertEqual(len(report["unresolved"]), 1)  # the module's own LED
-        self.assertFalse(prog.running)
-
-    def test_keeps_typed_addresses_unless_overwrite(self):
-        api = _api()
-        api.read_module_memory = AsyncMock(return_value=_feedback_image())
-        channels = [{"description": f"out {i}"} for i in range(1, 13)]
-        channels[0]["led_on"] = "AAAAAA"
-        coord = _import_coordinator(api, channels_5b05=channels)
-        prog = NikobusProgramming(_hass("/tmp"), coord)
-        report = _run(prog.async_import_feedback_leds())
-        self.assertEqual(channels[0]["led_on"], "AAAAAA")
-        self.assertEqual(report["channels_kept"], 1)
-        report = _run(prog.async_import_feedback_leds(overwrite=True))
-        self.assertEqual(channels[0]["led_on"], "8B7086")
-        # The two channels imported on the first run already hold the
-        # address: unchanged, so counted as kept.
-        self.assertEqual((report["channels_updated"], report["channels_kept"]), (1, 2))
-
-    def test_without_feedback_module_raises(self):
-        prog = NikobusProgramming(_hass("/tmp"), _coordinator(api=_api()))
-        with self.assertRaises(HomeAssistantError):
-            _run(prog.async_import_feedback_leds())
-
-    def test_backup_includes_feedback_module_without_crc(self):
-        api = _api()
-        api.get_module_status = AsyncMock(side_effect=RuntimeError("no answer"))
-        coord = _import_coordinator(api)
-        with TemporaryDirectory() as tmp:
-            prog = NikobusProgramming(_hass(tmp), coord)
-            result = _run(prog.async_backup_modules(["966C"]))
-            self.assertIn("966C_feedback_module.nkm", result["images"])
-            check = result["modules"]["966C"]
-            self.assertIsNone(check["crc_ok"])
-            self.assertIsNone(check["error"])
-            api.verify_module_memory.assert_not_awaited()
-
 
 if __name__ == "__main__":
     unittest.main()
-
-
-class TestReadBlocks(unittest.TestCase):
-    def test_reads_and_reports_timeouts_with_link_mode(self):
-        from nikobus_connect.exceptions import NikobusTimeoutError
-
-        api = _api()
-        api.set_link_mode = AsyncMock()
-        calls: list[tuple[int, bytes]] = []
-
-        async def query(func, address, args=None):
-            calls.append((func, args))
-            if args == b"\x00\x06":
-                raise NikobusTimeoutError("Failed to receive ACK and state")
-            return bytes.fromhex("6C96") + bytes(range(16))
-
-        api._command_handler = SimpleNamespace(query=query)
-        coord = _import_coordinator(api)
-        prog = NikobusProgramming(_hass("/tmp"), coord)
-        result = _run(prog.async_read_blocks("966c", [0, 0x600], link_mode=True))
-        self.assertEqual(result["address"], "966C")
-        self.assertEqual(result["blocks"]["0x0000"], bytes(range(16)).hex().upper())
-        self.assertTrue(result["blocks"]["0x0600"].startswith("timeout"))
-        self.assertEqual([c[0] for c in calls], [0x10, 0x10])
-        self.assertEqual(
-            [c.args for c in api.set_link_mode.await_args_list],
-            [("966C", True), ("966C", False)],
-        )
-        self.assertFalse(prog.running)
-
-    def test_eight_byte_function(self):
-        api = _api()
-        seen = []
-
-        async def query(func, address, args=None):
-            seen.append(func)
-            return bytes.fromhex("6C96") + b"\x01" * 8
-
-        api._command_handler = SimpleNamespace(query=query)
-        prog = NikobusProgramming(_hass("/tmp"), _import_coordinator(api))
-        result = _run(prog.async_read_blocks("966C", ["0xC00"], block_size=8))
-        self.assertEqual(seen, [0x22])
-        self.assertEqual(result["blocks"]["0x0C00"], "01" * 8)

--- a/tests/test_programming_entities.py
+++ b/tests/test_programming_entities.py
@@ -9,7 +9,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 from custom_components.nikobus.button import (
     NikobusBackupProgrammingButton,
-    NikobusImportFeedbackLedsButton,
     NikobusSyncClockButton,
     NikobusVerifyProgrammingButton,
 )
@@ -29,11 +28,9 @@ def _run(coro):
         loop.close()
 
 
-def _coordinator(pc_link="86F5", running=False, discovery_running=False, feedback=("966C",)):
+def _coordinator(pc_link="86F5", running=False, discovery_running=False):
     programming = SimpleNamespace(
         pc_link_address=lambda: pc_link,
-        feedback_modules=lambda: [(a, a) for a in feedback],
-        async_import_feedback_leds=AsyncMock(),
         clock=None,
         clock_read_at=None,
         clock_drift_seconds=None,
@@ -86,15 +83,10 @@ class TestMaintenanceButtons(unittest.TestCase):
             NikobusVerifyProgrammingButton,
             NikobusSyncClockButton,
             NikobusBackupProgrammingButton,
-            NikobusImportFeedbackLedsButton,
-        ):
+                ):
             self.assertTrue(cls(_coordinator()).available, cls.__name__)
             self.assertFalse(cls(_coordinator(running=True)).available, cls.__name__)
             self.assertFalse(cls(_coordinator(discovery_running=True)).available, cls.__name__)
-
-    def test_led_import_needs_a_feedback_module(self):
-        self.assertFalse(NikobusImportFeedbackLedsButton(_coordinator(feedback=())).available)
-        self.assertTrue(NikobusImportFeedbackLedsButton(_coordinator()).available)
 
     def test_sync_button_awaits_sync(self):
         coord = _coordinator()
@@ -106,7 +98,6 @@ class TestMaintenanceButtons(unittest.TestCase):
         for cls, method in (
             (NikobusVerifyProgrammingButton, "async_verify_modules"),
             (NikobusBackupProgrammingButton, "async_backup_modules"),
-            (NikobusImportFeedbackLedsButton, "async_import_feedback_leds"),
         ):
             button = cls(coord)
             button.hass = MagicMock()
@@ -151,7 +142,6 @@ class TestHubEntitiesSurviveOrphanCleanup(unittest.TestCase):
             NikobusSyncClockButton(fake),
             NikobusVerifyProgrammingButton(fake),
             NikobusBackupProgrammingButton(fake),
-            NikobusImportFeedbackLedsButton(fake),
         ]
         health = NikobusProgrammingHealthSensor.__new__(NikobusProgrammingHealthSensor)
         health._attr_unique_id = f"{DOMAIN}_programming_health"


### PR DESCRIPTION
## Summary

Reading a feedback module (05-207) needed link mode (the write-enable mode) and never stabilised on hardware, so the feedback data path is removed:

- The **Import LED links from feedback module** bridge button and the `nikobus.import_feedback_leds` action.
- The `nikobus.read_module_blocks` diagnostic action (it existed to probe the feedback module and carried the link-mode option).
- The CRC-unknown special-casing; the integration no longer puts any module into link mode.

Set the LED-on / LED-off trigger addresses by hand under *Customize a module* as before. **Backup** and **Verify** continue to cover switch, dimmer and roller modules. The real-time state push from a Feedback Module is unaffected.

Kept the unrelated cover run-time fix (`iter_link_outputs`, the stored-link-shape reader). Requires **nikobus-connect 0.37.0** (fdebrus/nikobus-connect#140); CI's test jobs are red until it is on PyPI. Suite: 583 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_