### PR TITLE
fix: link scans no longer collide with polling (3.17.1, nikobus-connect 0.37.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.17.1
+
+- **Scan all module links no longer collides with polling** (`nikobus-connect 0.37.1`, required). On installations that poll (no Feedback Module), a poll already under way when the scan started — the initial sync after a reload, a running 120 s cycle, a button-triggered refresh — was sent on the bus in the middle of a register read. The two replies garbled each other, the scan saw the module's link table start one block late and discarded the whole module as corrupt, leaving every button on it without links (#502: a switch module with 33 records, all its buttons empty, and the modules probed as absent afterwards). The library now serialises every bus exchange, so a queued command goes out between two register reads, never on top of one. Run *Scan all module links* again after updating.
+
 ## 3.17.0
 
 - **Removed: Import LED links from feedback module, and the block-read diagnostic.** Reading a feedback module (05-207) required putting it into link mode — the mode that gates erasing and writing a module — and never became reliable on real hardware. The risk of using the write-enable mode for a read was not worth it, so the **Import LED links** bridge button, the `nikobus.import_feedback_leds` action and the `nikobus.read_module_blocks` diagnostic are gone, and the integration no longer puts any module into link mode. Fill the LED-on / LED-off trigger addresses by hand under *Customize a module* as before. Backup and Verify continue to cover switch, dimmer and roller modules. Requires `nikobus-connect >= 0.37.0`. The real-time state push from a Feedback Module is unaffected.

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -20,7 +20,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.37.0"
+    "nikobus-connect>=0.37.1"
   ],
-  "version": "3.17.0"
+  "version": "3.17.1"
 }


### PR DESCRIPTION
## Summary

Fixes #502.

On installations that poll (no Feedback Module), a poll already under way when *Scan all module links* started — the initial sync after a reload, a running 120 s cycle, a button-triggered refresh — was sent on the bus in the middle of a register read. In the reporter's log the reply to register 0x10 of switch module 035A arrived merged with a poll reply as one oversized frame that failed its CRC; the scan then saw the link table start at block 0x11, logged "link table looks corrupt" and discarded the module, leaving every button on it with empty `linked_modules`. The post-scan presence probe on the jammed bus then reported all five modules absent.

The `discovery_running` guard only stops the *next* poll cycle; it cannot stop a cycle in flight or commands already queued. The fix is in the library (fdebrus/nikobus-connect#141): every bus exchange now takes a shared lock, so a queued command goes out between two register reads, never on top of one.

## Changes

- `manifest.json`: version 3.17.1, `nikobus-connect>=0.37.1`.
- `CHANGELOG.md`.

## Test plan

- [x] `pytest tests` — 583 passed; `ruff check` clean
- [ ] Reporter: update, run *Scan all module links* once more; 035A should come back with its 33 link records and the Feedbackknop / inkom / buro buttons with their links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_