### PR TITLE
3.17.3: withdraw the "no device answered" Repair issue as soon as the bus answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.17.3
+
+- **The "No Nikobus device answered" Repair issue withdraws itself as soon as the bus answers** (`nikobus-connect 0.37.3`, required). The verdict of the start-up probe was only re-evaluated at the next reload: a probe missed on a cold boot — host restart, USB re-enumeration, the PC-Link still resetting when the probe went out — left the warning up for days while every command worked. The library now overturns a silent verdict on the first well-formed frame it receives (a button press, the answer to a command) and tells the integration, which deletes the issue on the spot. The probe also waits a second after the handshake before its first attempt, so a cold boot passes it in the first place. The issue is re-evaluated after an automatic reconnect as well.
+
 ## 3.17.2
 
 - **Reprogrammed modules are noticed.** Every output module keeps a checksum of its own programming (function `0x13`, one read-only frame). Home Assistant now records it whenever it reads a module's programming — after *Scan all module links*, *Verify* or *Backup* — and re-reads it ten minutes after start-up and then once a day. A module whose checksum moved was reprogrammed with the Nikobus PC software since its links were last read: a Repair issue names it and asks for a link rescan, the *Programming health* sensor lists it under `programming_changed`, and the issue clears by itself once the module is read again. Nothing is written to any module.

--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ Activation sends one command per channel (HA-driven fan-out), touching only the 
 
 On a dropped connection the integration reconnects with exponential back-off (5 s → 10 s → 20 s → … capped at 60 s). Entities go unavailable until the link is restored, then resume without an HA restart.
 
-Every connection ends with a **presence probe**: after the handshake the integration sends a status query the PC-Link (or a Feedback Module used as gateway) acknowledges, and takes any Nikobus frame relayed meanwhile as proof that a device is on the line. When the port opens but nothing answers — wrong port, PC-Link unpowered, serial handle left dead by the Nikobus PC software — the integration still starts, but a Repair issue names the port and what to check instead of every command timing out silently. A PC-Logic used as gateway may not acknowledge the probe; if the warning appears there while everything works, ignore it, it clears on the next answered connection.
+Every connection ends with a **presence probe**: after the handshake the integration sends a status query the PC-Link (or a Feedback Module used as gateway) acknowledges, and takes any Nikobus frame relayed meanwhile as proof that a device is on the line. When the port opens but nothing answers — wrong port, PC-Link unpowered, serial handle left dead by the Nikobus PC software — the integration still starts, but a Repair issue names the port and what to check instead of every command timing out silently. The verdict is not final: the first Nikobus frame received afterwards — a button press, the answer to a command — withdraws the issue, so a probe missed while the PC-Link was still resetting on a cold boot corrects itself within seconds. A PC-Logic used as gateway may not acknowledge the probe; if the warning stays there while everything works, ignore it.
 
 Only one exchange is on the bus at a time: polls, user commands and discovery reads are serialised through one lock, so a scan started during a poll cannot garble either.
 
@@ -673,7 +673,7 @@ The module's checksum no longer matches the one recorded when its links were las
 
 ### Repair issue: "No Nikobus device answered on …"
 
-The port opened but nothing acknowledged the presence probe. Check the cable and the PC-Link power, make sure the Nikobus PC software is not holding the port, and if the PC-Link was used by another program, power-cycle it. On a PC-Logic gateway where everything works, ignore it. See [Connectivity](#connectivity).
+The port opened but nothing acknowledged the presence probe. Check the cable and the PC-Link power, make sure the Nikobus PC software is not holding the port, and if the PC-Link was used by another program, power-cycle it. The issue withdraws itself as soon as any Nikobus frame is received, so if the bus works the warning is gone within seconds; on a PC-Logic gateway where it stays while everything works, ignore it. See [Connectivity](#connectivity).
 
 ### State is slow to update
 

--- a/custom_components/nikobus/coordinator.py
+++ b/custom_components/nikobus/coordinator.py
@@ -137,6 +137,10 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
         )
 
         self.nikobus_connection = NikobusConnect(self.connection_string)
+        # A probe that found the port silent is overturned by the first
+        # frame the listener receives (nikobus-connect 0.37.3): withdraw
+        # the Repair issue as soon as that happens, not at the next reload.
+        self.nikobus_connection.on_device_answered = self._surface_device_probe
         self.nikobus_config = NikobusConfig(hass)
         self.button_storage = NikobusButtonStorage(hass)
         self.module_storage = NikobusModuleStorage(hass)
@@ -270,8 +274,10 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
         means a wrong port, an unpowered PC-Link, a bridge with nothing
         behind it or a serial handle left dead by the Nikobus PC software:
         the connection stays up, so say it here instead of letting every
-        command time out silently. Re-evaluated on every (re)connect;
-        older libraries without the attribute clear the issue.
+        command time out silently. Re-evaluated on every (re)connect and
+        again when the library overturns a silent verdict on the first
+        frame received (``on_device_answered``); older libraries without
+        the attribute clear the issue.
         """
         answered = getattr(self.nikobus_connection, "device_answered", None)
         issue_id = f"{ISSUE_NO_DEVICE_ANSWERED}_{self.config_entry.entry_id}"
@@ -1369,6 +1375,7 @@ class NikobusDataCoordinator(NikobusDiscoveryMixin, DataUpdateCoordinator[None])
                 await self.nikobus_listener.start()
                 self._last_connected = datetime.now(timezone.utc)
                 self._reconnect_attempts = 0
+                self._surface_device_probe()
                 await self._async_update_data()
                 self.async_update_listeners()
                 _LOGGER.info("Nikobus reconnected after %d attempt(s)", attempts)

--- a/custom_components/nikobus/manifest.json
+++ b/custom_components/nikobus/manifest.json
@@ -20,7 +20,7 @@
   "requirements": [
     "aiofiles>=25.1.0",
     "pyserial-asyncio-fast>=0.16",
-    "nikobus-connect>=0.37.2"
+    "nikobus-connect>=0.37.3"
   ],
-  "version": "3.17.2"
+  "version": "3.17.3"
 }

--- a/custom_components/nikobus/translations/en.json
+++ b/custom_components/nikobus/translations/en.json
@@ -164,7 +164,7 @@
     },
     "no_device_answered": {
       "title": "No Nikobus device answered on {port}",
-      "description": "The port opened and the handshake was sent, but nothing on the other end acknowledged Home Assistant's presence probe. Commands will time out until a device answers. Check the cable and the PC-Link power, make sure the Nikobus PC software is not holding the port, and if the PC-Link was used by another program, power-cycle it. If your installation uses a PC-Logic as gateway and everything works, you can ignore this warning; it clears by itself on the next successful connection."
+      "description": "The port opened and the handshake was sent, but nothing on the other end acknowledged Home Assistant's presence probe. Commands will time out until a device answers. Check the cable and the PC-Link power, make sure the Nikobus PC software is not holding the port, and if the PC-Link was used by another program, power-cycle it. The warning clears by itself as soon as any Nikobus frame is received — a button press, the answer to a command — or on the next connection that is answered. If it stays while everything works, your gateway (a PC-Logic, for instance) simply does not acknowledge the probe and the warning can be ignored."
     }
   },
   "exceptions": {

--- a/custom_components/nikobus/translations/fr.json
+++ b/custom_components/nikobus/translations/fr.json
@@ -297,7 +297,7 @@
     },
     "no_device_answered": {
       "title": "Aucun appareil Nikobus n'a répondu sur {port}",
-      "description": "Le port s'est ouvert et le handshake a été envoyé, mais rien n'a acquitté la sonde de présence de Home Assistant. Les commandes échoueront par dépassement de délai tant qu'aucun appareil ne répond. Vérifiez le câble et l'alimentation du PC-Link, assurez-vous que le logiciel PC Nikobus n'occupe pas le port et, si le PC-Link a été utilisé par un autre programme, redémarrez-le électriquement. Si votre installation utilise un PC-Logic comme passerelle et que tout fonctionne, vous pouvez ignorer cet avertissement ; il disparaît de lui-même à la prochaine connexion réussie."
+      "description": "Le port s'est ouvert et le handshake a été envoyé, mais rien n'a acquitté la sonde de présence de Home Assistant. Les commandes échoueront par dépassement de délai tant qu'aucun appareil ne répond. Vérifiez le câble et l'alimentation du PC-Link, assurez-vous que le logiciel PC Nikobus n'occupe pas le port et, si le PC-Link a été utilisé par un autre programme, redémarrez-le électriquement. L'avertissement disparaît de lui-même dès qu'une trame Nikobus est reçue — un appui sur un bouton, la réponse à une commande — ou à la prochaine connexion qui obtient une réponse. S'il persiste alors que tout fonctionne, votre passerelle (un PC-Logic, par exemple) n'acquitte simplement pas la sonde et l'avertissement peut être ignoré."
     }
   },
   "exceptions": {

--- a/custom_components/nikobus/translations/nl.json
+++ b/custom_components/nikobus/translations/nl.json
@@ -297,7 +297,7 @@
     },
     "no_device_answered": {
       "title": "Geen Nikobus-apparaat antwoordde op {port}",
-      "description": "De poort ging open en de handshake is verzonden, maar niets aan de andere kant bevestigde de aanwezigheidstest van Home Assistant. Opdrachten lopen op een time-out tot een apparaat antwoordt. Controleer de kabel en de voeding van de PC-Link, zorg dat de Nikobus-pc-software de poort niet bezet houdt en herstart de PC-Link als hij door een ander programma is gebruikt. Gebruikt uw installatie een PC-Logic als gateway en werkt alles, dan kunt u deze waarschuwing negeren; ze verdwijnt vanzelf bij de volgende geslaagde verbinding."
+      "description": "De poort ging open en de handshake is verzonden, maar niets aan de andere kant bevestigde de aanwezigheidstest van Home Assistant. Opdrachten lopen op een time-out tot een apparaat antwoordt. Controleer de kabel en de voeding van de PC-Link, zorg dat de Nikobus-pc-software de poort niet bezet houdt en herstart de PC-Link als hij door een ander programma is gebruikt. De waarschuwing verdwijnt vanzelf zodra een Nikobus-frame wordt ontvangen — een druk op een knop, het antwoord op een opdracht — of bij de volgende verbinding die beantwoord wordt. Blijft ze staan terwijl alles werkt, dan bevestigt uw gateway (bijvoorbeeld een PC-Logic) de test gewoon niet en kunt u de waarschuwing negeren."
     }
   },
   "exceptions": {

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2202,3 +2202,35 @@ class TestDevicePresenceIssue(unittest.TestCase):
         with patch("custom_components.nikobus.coordinator.ir") as ir:
             NikobusDataCoordinator._surface_device_probe(coord)
         ir.async_delete_issue.assert_called_once()
+
+    def test_library_overturning_a_silent_probe_withdraws_the_issue(self):
+        """The coordinator hands ``_surface_device_probe`` to the library
+        as ``on_device_answered``: the first frame received after a silent
+        probe deletes the issue on the spot, not at the next reload."""
+        hass = MagicMock()
+        entry = MagicMock()
+        entry.entry_id = "entry1"
+        entry.data = {"connection_string": "/dev/ttyUSB0"}
+        entry.options = {}
+        with (
+            patch("custom_components.nikobus.coordinator.NikobusConnect") as connect_cls,
+            patch("custom_components.nikobus.coordinator.NikobusConfig"),
+            patch("custom_components.nikobus.coordinator.NikobusButtonStorage"),
+            patch("custom_components.nikobus.coordinator.NikobusModuleStorage"),
+            patch("custom_components.nikobus.coordinator.NikobusProgramming", create=True),
+            patch("custom_components.nikobus.coordinator.DataUpdateCoordinator.__init__", return_value=None),
+        ):
+            connection = connect_cls.return_value
+            connection.device_answered = None
+            try:
+                coord = NikobusDataCoordinator(hass, entry)
+            except Exception as err:  # pragma: no cover - constructor drift
+                self.skipTest(f"coordinator constructor needs more scaffolding: {err}")
+        assert connection.on_device_answered == coord._surface_device_probe
+        coord.hass = hass
+        coord.config_entry = entry
+        coord.connection_string = "/dev/ttyUSB0"
+        connection.device_answered = True
+        with patch("custom_components.nikobus.coordinator.ir") as ir:
+            connection.on_device_answered()
+        ir.async_delete_issue.assert_called_once_with(hass, "nikobus", "no_device_answered_entry1")

--- a/tests/test_reconnect.py
+++ b/tests/test_reconnect.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import unittest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from custom_components.nikobus.const import RECONNECT_DELAY_INITIAL, RECONNECT_DELAY_MAX
 from custom_components.nikobus.coordinator import NikobusDataCoordinator
@@ -245,3 +245,17 @@ class TestReconnectConstants(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestReconnectReevaluatesProbe(unittest.IsolatedAsyncioTestCase):
+    """A successful reconnect re-runs the presence probe in the library;
+    the coordinator surfaces its fresh verdict before the first refresh."""
+
+    async def test_probe_surfaced_after_reconnect(self):
+        coord = _make_coordinator()
+        coord.nikobus_connection.device_answered = True
+        coord._async_update_data = AsyncMock()
+        coord.async_update_listeners = MagicMock()
+        with patch.object(NikobusDataCoordinator, "_surface_device_probe") as surface:
+            await coord._reconnect_loop()
+        surface.assert_called_once()


### PR DESCRIPTION
## Why

The start-up probe verdict was only re-evaluated at the next reload. A probe missed on a cold boot left the "No Nikobus device answered on /dev/ttyUSB0" Repair issue up for days while every command worked (hourly clock reads and the daily programming check both fine under the warning).

## What

- `nikobus-connect 0.37.3` (required) overturns a silent verdict on the first well-formed frame received and calls `on_device_answered`. The coordinator hands it `_surface_device_probe`, which deletes the issue on the spot instead of at the next reload.
- The verdict is also re-surfaced after an automatic reconnect, which it was not before.
- Repair text (en, fr, nl) now says the warning withdraws itself on the first frame received. README connectivity and troubleshooting sections updated, CHANGELOG entry, manifest at 3.17.3 with `nikobus-connect>=0.37.3`.

## Tests

Two new tests: the coordinator wires the callback and the callback deletes the issue; a successful reconnect re-surfaces the verdict before the first refresh. Suite: 595 passed, ruff clean, translation JSON validated.

Release after `nikobus-connect 0.37.3` is on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7yGDY8ttvZUVMVjfSNXj)_